### PR TITLE
<feature>[ansible]: add SshFilesMd5Checker

### DIFF
--- a/core/src/main/java/org/zstack/core/ansible/SshFilesMd5Checker.java
+++ b/core/src/main/java/org/zstack/core/ansible/SshFilesMd5Checker.java
@@ -1,0 +1,113 @@
+package org.zstack.core.ansible;
+
+import org.zstack.utils.Utils;
+import org.zstack.utils.logging.CLogger;
+import org.zstack.utils.ssh.Ssh;
+import org.zstack.utils.ssh.SshResult;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class SshFilesMd5Checker implements AnsibleChecker {
+    private static final CLogger logger = Utils.getLogger(SshFilesMd5Checker.class);
+
+    private String username;
+    private String password;
+    private String privateKey;
+    private String ip;
+    private int sshPort = 22;
+
+    private List<String> fileMd5sums = new ArrayList<>();
+    String filePath;
+
+    @Override
+    public boolean needDeploy() {
+        Ssh ssh = new Ssh();
+        ssh.setUsername(username).setPrivateKey(privateKey)
+                .setPassword(password).setPort(sshPort)
+                .setHostname(ip)
+                .setTimeout(5);
+        try {
+            ssh.command(String.format("echo %s | sudo -S md5sum %s 2>/dev/null", password, filePath));
+            SshResult ret = ssh.run();
+            if (ret.getReturnCode() != 0) {
+                return true;
+            }
+            ssh.reset();
+            String md5 = ret.getStdout().split(" ")[0];
+            if (!fileMd5sums.contains(md5)) {
+                logger.debug(String.format("file MD5 changed, dest[%s, md5, %s]", filePath, md5));
+                return true;
+            }
+        } finally {
+            ssh.close();
+        }
+
+        return false;
+    }
+
+    @Override
+    public void deleteDestFile() {
+        Ssh ssh = new Ssh();
+        ssh.setUsername(username).setPrivateKey(privateKey)
+                .setPassword(password).setPort(sshPort)
+                .setHostname(ip).command(String.format("rm -f %s", filePath)).runAndClose();
+        logger.debug(String.format("delete dest file[%s]", filePath));
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    public String getPrivateKey() {
+        return privateKey;
+    }
+
+    public void setPrivateKey(String privateKey) {
+        this.privateKey = privateKey;
+    }
+
+    public int getSshPort() {
+        return sshPort;
+    }
+
+    public void setSshPort(int sshPort) {
+        this.sshPort = sshPort;
+    }
+
+    public String getIp() {
+        return ip;
+    }
+
+    public void setIp(String ip) {
+        this.ip = ip;
+    }
+
+    public List<String> getFileMd5sums() {
+        return fileMd5sums;
+    }
+
+    public void setFileMd5sums(List<String> fileMd5sums) {
+        this.fileMd5sums = fileMd5sums;
+    }
+
+    public String getFilePath() {
+        return filePath;
+    }
+
+    public void setFilePath(String filePath) {
+        this.filePath = filePath;
+    }
+}

--- a/utils/src/main/java/org/zstack/utils/SHAUtils.java
+++ b/utils/src/main/java/org/zstack/utils/SHAUtils.java
@@ -1,7 +1,13 @@
 package org.zstack.utils;
 
+import org.apache.commons.codec.digest.DigestUtils;
+
+import java.io.FileInputStream;
+import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.math.BigInteger;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 
@@ -17,6 +23,15 @@ public class SHAUtils {
             BigInteger bigInteger = new BigInteger(1, md.digest());
             return String.format("%0128x", bigInteger);
         } catch (NoSuchAlgorithmException | UnsupportedEncodingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static String getFileMd5sum(String filePath) {
+        try {
+            FileInputStream srcIn = new FileInputStream(filePath);
+            return DigestUtils.md5Hex(srcIn);
+        } catch (Exception e) {
             throw new RuntimeException(e);
         }
     }

--- a/utils/src/main/java/org/zstack/utils/path/PathUtil.java
+++ b/utils/src/main/java/org/zstack/utils/path/PathUtil.java
@@ -429,4 +429,13 @@ public class PathUtil {
             return false;
         }
     }
+
+    public static Long getFileInode(String filePath) {
+        Path path = Paths.get(filePath);
+        try {
+            return (Long) Files.getAttribute(path, "unix:ino");
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
 }


### PR DESCRIPTION
1 Cache inodes and hashes of all architectur bin packages in mn memory
2 If the bin package hash value of the target physical machine is
not in the in-memory hash list, redeploy the bin package.

Resolves: ZSTAC-59604

Change-Id: I75676474797078746d757a7564716d736f6b7267

sync from gitlab !5410

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 新增了应用中的搜索功能。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->