### PR TITLE
<fix>[conf]: Fix CA cert to work with Go 1.15+

### DIFF
--- a/conf/scripts/generate-keys.sh
+++ b/conf/scripts/generate-keys.sh
@@ -27,6 +27,7 @@ echo "country = CN"                     >> $TMP
 echo "state = Shanghai"                 >> $TMP
 echo "locality = Shanghai"              >> $TMP
 echo "cn = store.zstack.org"            >> $TMP
+echo "dns_name = store.zstack.org"      >> $TMP
 echo "expiration_days = 3652"           >> $TMP
 echo "activation_date = \"$activation_date\"" >> $TMP
 certtool --template "$TMP" \


### PR DESCRIPTION
In Go 1.15, the X.509 CommonName is deprecated.
c.f. https://go.dev/doc/go1.15#commonname

Resolves: ZSTAC-52744

Change-Id: I756466787561797266736b786e757a6b63626569

sync from gitlab !5425

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 更新了系统配置，将 `dns_name` 设置为 `store.zstack.org`。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->