### PR TITLE
<feature>[network]: improve zsv bond

### DIFF
--- a/conf/db/upgrade/V4.8.0.1__schema.sql
+++ b/conf/db/upgrade/V4.8.0.1__schema.sql
@@ -1,0 +1,2 @@
+UPDATE `zstack`.`L2NetworkHostRefVO` set `attachStatus` = 'Attached' WHERE `attachStatus` = '3';
+UPDATE `zstack`.`L2NetworkHostRefVO` set `attachStatus` = 'Detached' WHERE `attachStatus` != '3';

--- a/conf/serviceConfig/l2Network.xml
+++ b/conf/serviceConfig/l2Network.xml
@@ -16,7 +16,15 @@
     </message>
 
     <message>
+        <name>org.zstack.header.network.l2.APIAttachL2NetworkToHostMsg</name>
+    </message>
+
+    <message>
         <name>org.zstack.header.network.l2.APIDetachL2NetworkFromClusterMsg</name>
+    </message>
+
+    <message>
+        <name>org.zstack.header.network.l2.APIDetachL2NetworkFromHostMsg</name>
     </message>
 
     <message>

--- a/conf/springConfigXml/NetworkManager.xml
+++ b/conf/springConfigXml/NetworkManager.xml
@@ -110,6 +110,8 @@
             <zstack:extension interface="org.zstack.header.vm.PostVmInstantiateResourceExtensionPoint"/>
             <zstack:extension interface="org.zstack.header.vm.ReleaseNetworkServiceOnDetachingNicExtensionPoint"/>
             <zstack:extension interface="org.zstack.header.vm.InstantiateResourceOnAttachingNicExtensionPoint" order="-1"/>
+            <zstack:extension interface="org.zstack.header.host.HostAfterConnectedExtensionPoint" />
+            <zstack:extension interface="org.zstack.header.host.HostDeleteExtensionPoint" />
         </zstack:plugin>
     </bean>
 

--- a/header/src/main/java/org/zstack/header/network/l2/APIAttachL2NetworkToClusterMsg.java
+++ b/header/src/main/java/org/zstack/header/network/l2/APIAttachL2NetworkToClusterMsg.java
@@ -53,7 +53,7 @@ public class APIAttachL2NetworkToClusterMsg extends APIMessage implements L2Netw
     @APIParam(resourceType = ClusterVO.class)
     private String clusterUuid;
 
-    @APIParam(required = false, validValues = {"LinuxBridge"})
+    @APIParam(required = false, validValues = {L2NetworkConstant.VSWITCH_TYPE_LINUX_BRIDGE})
     private String l2ProviderType;
 
     @Override

--- a/header/src/main/java/org/zstack/header/network/l2/APIAttachL2NetworkToHostEvent.java
+++ b/header/src/main/java/org/zstack/header/network/l2/APIAttachL2NetworkToHostEvent.java
@@ -1,0 +1,44 @@
+package org.zstack.header.network.l2;
+
+import org.zstack.header.message.APIEvent;
+import org.zstack.header.rest.RestResponse;
+
+@RestResponse(allTo = "inventory")
+public class APIAttachL2NetworkToHostEvent extends APIEvent {
+    /**
+     * @desc see :ref:`L2NetworkInventory`
+     */
+    private L2NetworkInventory inventory;
+
+    public APIAttachL2NetworkToHostEvent(String apiId) {
+        super(apiId);
+    }
+
+    public APIAttachL2NetworkToHostEvent() {
+        super(null);
+    }
+
+    public L2NetworkInventory getInventory() {
+        return inventory;
+    }
+
+    public void setInventory(L2NetworkInventory inventory) {
+        this.inventory = inventory;
+    }
+
+    public static APIAttachL2NetworkToHostEvent __example__() {
+        APIAttachL2NetworkToHostEvent event = new APIAttachL2NetworkToHostEvent();
+        L2VlanNetworkInventory net = new L2VlanNetworkInventory();
+
+        net.setName("Test-Net");
+        net.setVlan(10);
+        net.setDescription("Test");
+        net.setZoneUuid(uuid());
+        net.setPhysicalInterface("eth0");
+        net.setType("L2VlanNetwork");
+
+        event.setInventory(net);
+        return event;
+    }
+
+}

--- a/header/src/main/java/org/zstack/header/network/l2/APIAttachL2NetworkToHostEventDoc_zh_cn.groovy
+++ b/header/src/main/java/org/zstack/header/network/l2/APIAttachL2NetworkToHostEventDoc_zh_cn.groovy
@@ -1,0 +1,32 @@
+package org.zstack.header.network.l2
+
+import org.zstack.header.network.l2.L2NetworkInventory
+import org.zstack.header.errorcode.ErrorCode
+
+doc {
+
+	title "二层网络清单"
+
+	ref {
+		name "inventory"
+		path "org.zstack.header.network.l2.APIAttachL2NetworkToHostEvent.inventory"
+		desc "null"
+		type "L2NetworkInventory"
+		since "4.8.0"
+		clz L2NetworkInventory.class
+	}
+	field {
+		name "success"
+		desc ""
+		type "boolean"
+		since "4.8.0"
+	}
+	ref {
+		name "error"
+		path "org.zstack.header.network.l2.APIAttachL2NetworkToHostEvent.error"
+		desc "错误码，若不为null，则表示操作失败, 操作成功时该字段为null",false
+		type "ErrorCode"
+		since "4.8.0"
+		clz ErrorCode.class
+	}
+}

--- a/header/src/main/java/org/zstack/header/network/l2/APIAttachL2NetworkToHostMsg.java
+++ b/header/src/main/java/org/zstack/header/network/l2/APIAttachL2NetworkToHostMsg.java
@@ -1,0 +1,64 @@
+package org.zstack.header.network.l2;
+
+import org.springframework.http.HttpMethod;
+import org.zstack.header.host.HostVO;
+import org.zstack.header.message.APIMessage;
+import org.zstack.header.message.APIParam;
+import org.zstack.header.rest.RestRequest;
+
+@RestRequest(
+        path = "/l2-networks/{l2NetworkUuid}/hosts/{hostUuid}",
+        method = HttpMethod.POST,
+        responseClass = APIAttachL2NetworkToHostEvent.class,
+        parameterName = "params"
+)
+public class APIAttachL2NetworkToHostMsg extends APIMessage implements L2NetworkMessage {
+    /**
+     * @desc l2Network uuid
+     */
+    @APIParam(resourceType = L2NetworkVO.class, checkAccount = true, operationTarget = true)
+    private String l2NetworkUuid;
+    /**
+     * @desc host uuid. See :ref:`HostInventory`
+     */
+    @APIParam(resourceType = HostVO.class)
+    private String hostUuid;
+
+    @APIParam(required = false, validValues = {L2NetworkConstant.VSWITCH_TYPE_LINUX_BRIDGE})
+    private String l2ProviderType;
+
+    @Override
+    public String getL2NetworkUuid() {
+        return l2NetworkUuid;
+    }
+
+    public void setL2NetworkUuid(String l2NetworkUuid) {
+        this.l2NetworkUuid = l2NetworkUuid;
+    }
+
+    public String getHostUuid() {
+        return hostUuid;
+    }
+
+    public void setHostUuid(String hostUuid) {
+        this.hostUuid = hostUuid;
+    }
+
+    public String getL2ProviderType() {
+        return l2ProviderType;
+    }
+
+    public void setL2ProviderType(String l2ProviderType) {
+        this.l2ProviderType = l2ProviderType;
+    }
+
+    public static APIAttachL2NetworkToHostMsg __example__() {
+        APIAttachL2NetworkToHostMsg msg = new APIAttachL2NetworkToHostMsg();
+
+        msg.setL2NetworkUuid(uuid());
+        msg.setHostUuid(uuid());
+        msg.setL2ProviderType(L2NetworkConstant.VSWITCH_TYPE_LINUX_BRIDGE);
+
+        return msg;
+    }
+}

--- a/header/src/main/java/org/zstack/header/network/l2/APIAttachL2NetworkToHostMsgDoc_zh_cn.groovy
+++ b/header/src/main/java/org/zstack/header/network/l2/APIAttachL2NetworkToHostMsgDoc_zh_cn.groovy
@@ -1,0 +1,77 @@
+package org.zstack.header.network.l2
+
+import org.zstack.header.network.l2.APIAttachL2NetworkToHostEvent
+
+doc {
+    title "挂载二层网络到物理机(AttachL2NetworkToHost)"
+
+    category "二层网络"
+
+    desc """挂载二层网络到物理机"""
+
+    rest {
+        request {
+			url "POST /v1/l2-networks/{l2NetworkUuid}/hosts/{hostUuid}"
+
+			header (Authorization: 'OAuth the-session-uuid')
+
+            clz APIAttachL2NetworkToHostMsg.class
+
+            desc """"""
+            
+			params {
+
+				column {
+					name "l2NetworkUuid"
+					enclosedIn "params"
+					desc "二层网络UUID"
+					location "url"
+					type "String"
+					optional false
+					since "4.8.0"
+				}
+				column {
+					name "hostUuid"
+					enclosedIn "params"
+					desc "物理机UUID"
+					location "url"
+					type "String"
+					optional false
+					since "4.8.0"
+				}
+				column {
+					name "l2ProviderType"
+					enclosedIn "params"
+					desc "二层网络实现类型"
+					location "body"
+					type "String"
+					optional true
+					since "4.8.0"
+					values ("LinuxBridge")
+				}
+				column {
+					name "systemTags"
+					enclosedIn ""
+					desc "系统标签"
+					location "body"
+					type "List"
+					optional true
+					since "4.8.0"
+				}
+				column {
+					name "userTags"
+					enclosedIn ""
+					desc "用户标签"
+					location "body"
+					type "List"
+					optional true
+					since "4.8.0"
+				}
+			}
+        }
+
+        response {
+            clz APIAttachL2NetworkToHostEvent.class
+        }
+    }
+}

--- a/header/src/main/java/org/zstack/header/network/l2/APICreateL2NetworkMsg.java
+++ b/header/src/main/java/org/zstack/header/network/l2/APICreateL2NetworkMsg.java
@@ -71,8 +71,8 @@ public abstract class APICreateL2NetworkMsg extends APICreateMessage implements 
     /**
      * @desc vSwitch type
      */
-    @APIParam(required = false, maxLength = 1024, validValues = {"LinuxBridge", "OvsDpdk", "MacVlan"})
-    private String vSwitchType = "LinuxBridge";
+    @APIParam(required = false, maxLength = 1024, validValues = {L2NetworkConstant.VSWITCH_TYPE_LINUX_BRIDGE, L2NetworkConstant.VSWITCH_TYPE_OVS_DPDK, L2NetworkConstant.VSWITCH_TYPE_MACVLAN})
+    private String vSwitchType = L2NetworkConstant.VSWITCH_TYPE_LINUX_BRIDGE;
 
     public String getName() {
         return name;

--- a/header/src/main/java/org/zstack/header/network/l2/APIDetachL2NetworkFromHostEvent.java
+++ b/header/src/main/java/org/zstack/header/network/l2/APIDetachL2NetworkFromHostEvent.java
@@ -1,0 +1,44 @@
+package org.zstack.header.network.l2;
+
+import org.zstack.header.message.APIEvent;
+import org.zstack.header.rest.RestResponse;
+
+@RestResponse(allTo = "inventory")
+public class APIDetachL2NetworkFromHostEvent extends APIEvent {
+    /**
+     * @desc see :ref:`L2NetworkInventory`
+     */
+    private L2NetworkInventory inventory;
+
+    public L2NetworkInventory getInventory() {
+        return inventory;
+    }
+
+    public void setInventory(L2NetworkInventory inventory) {
+        this.inventory = inventory;
+    }
+
+    public APIDetachL2NetworkFromHostEvent(String apiId) {
+        super(apiId);
+    }
+
+    public APIDetachL2NetworkFromHostEvent() {
+        super(null);
+    }
+
+    public static APIDetachL2NetworkFromHostEvent __example__() {
+        APIDetachL2NetworkFromHostEvent event = new APIDetachL2NetworkFromHostEvent();
+        L2VlanNetworkInventory net = new L2VlanNetworkInventory();
+
+        net.setName("Test-Net");
+        net.setVlan(10);
+        net.setDescription("Test");
+        net.setZoneUuid(uuid());
+        net.setPhysicalInterface("eth0");
+        net.setType("L2VlanNetwork");
+
+        event.setInventory(net);
+        return event;
+    }
+
+}

--- a/header/src/main/java/org/zstack/header/network/l2/APIDetachL2NetworkFromHostEventDoc_zh_cn.groovy
+++ b/header/src/main/java/org/zstack/header/network/l2/APIDetachL2NetworkFromHostEventDoc_zh_cn.groovy
@@ -1,0 +1,32 @@
+package org.zstack.header.network.l2
+
+import org.zstack.header.network.l2.L2NetworkInventory
+import org.zstack.header.errorcode.ErrorCode
+
+doc {
+
+	title "二层网络清单"
+
+	ref {
+		name "inventory"
+		path "org.zstack.header.network.l2.APIDetachL2NetworkFromHostEvent.inventory"
+		desc "null"
+		type "L2NetworkInventory"
+		since "4.8.0"
+		clz L2NetworkInventory.class
+	}
+	field {
+		name "success"
+		desc ""
+		type "boolean"
+		since "4.8.0"
+	}
+	ref {
+		name "error"
+		path "org.zstack.header.network.l2.APIDetachL2NetworkFromHostEvent.error"
+		desc "错误码，若不为null，则表示操作失败, 操作成功时该字段为null",false
+		type "ErrorCode"
+		since "4.8.0"
+		clz ErrorCode.class
+	}
+}

--- a/header/src/main/java/org/zstack/header/network/l2/APIDetachL2NetworkFromHostMsg.java
+++ b/header/src/main/java/org/zstack/header/network/l2/APIDetachL2NetworkFromHostMsg.java
@@ -1,0 +1,50 @@
+package org.zstack.header.network.l2;
+
+import org.springframework.http.HttpMethod;
+import org.zstack.header.host.HostVO;
+import org.zstack.header.message.APIMessage;
+import org.zstack.header.message.APIParam;
+import org.zstack.header.rest.RestRequest;
+
+@RestRequest(
+        path = "/l2-networks/{l2NetworkUuid}/hosts/{hostUuid}",
+        method = HttpMethod.DELETE,
+        responseClass = APIDetachL2NetworkFromHostEvent.class
+)
+public class APIDetachL2NetworkFromHostMsg extends APIMessage implements L2NetworkMessage {
+    /**
+     * @desc l2Network uuid
+     */
+    @APIParam(resourceType = L2NetworkVO.class, checkAccount = true, operationTarget = true)
+    private String l2NetworkUuid;
+    /**
+     * @desc host uuid. See :ref:`HostInventory`
+     */
+    @APIParam(resourceType = HostVO.class)
+    private String hostUuid;
+
+    @Override
+    public String getL2NetworkUuid() {
+        return l2NetworkUuid;
+    }
+
+    public void setL2NetworkUuid(String l2NetworkUuid) {
+        this.l2NetworkUuid = l2NetworkUuid;
+    }
+
+    public String getHostUuid() {
+        return hostUuid;
+    }
+
+    public void setHostUuid(String hostUuid) {
+        this.hostUuid = hostUuid;
+    }
+
+    public static APIDetachL2NetworkFromHostMsg __example__() {
+        APIDetachL2NetworkFromHostMsg msg = new APIDetachL2NetworkFromHostMsg();
+        msg.setL2NetworkUuid(uuid());
+        msg.setHostUuid(uuid());
+
+        return msg;
+    }
+}

--- a/header/src/main/java/org/zstack/header/network/l2/APIDetachL2NetworkFromHostMsgDoc_zh_cn.groovy
+++ b/header/src/main/java/org/zstack/header/network/l2/APIDetachL2NetworkFromHostMsgDoc_zh_cn.groovy
@@ -1,0 +1,67 @@
+package org.zstack.header.network.l2
+
+import org.zstack.header.network.l2.APIDetachL2NetworkFromHostEvent
+
+doc {
+    title "从物理机上卸载二层网络(DetachL2NetworkFromCluster)"
+
+    category "二层网络"
+
+    desc """从物理机上卸载二层网络"""
+
+    rest {
+        request {
+			url "DELETE /v1/l2-networks/{l2NetworkUuid}/hosts/{hostUuid}"
+
+			header (Authorization: 'OAuth the-session-uuid')
+
+            clz APIDetachL2NetworkFromHostMsg.class
+
+            desc """"""
+            
+			params {
+
+				column {
+					name "l2NetworkUuid"
+					enclosedIn ""
+					desc "二层网络UUID"
+					location "url"
+					type "String"
+					optional false
+					since "4.8.0"
+				}
+				column {
+					name "hostUuid"
+					enclosedIn ""
+					desc "物理机UUID"
+					location "url"
+					type "String"
+					optional false
+					since "4.8.0"
+				}
+				column {
+					name "systemTags"
+					enclosedIn ""
+					desc "系统标签"
+					location "body"
+					type "List"
+					optional true
+					since "4.8.0"
+				}
+				column {
+					name "userTags"
+					enclosedIn ""
+					desc "用户标签"
+					location "body"
+					type "List"
+					optional true
+					since "4.8.0"
+				}
+			}
+        }
+
+        response {
+            clz APIDetachL2NetworkFromHostEvent.class
+        }
+    }
+}

--- a/header/src/main/java/org/zstack/header/network/l2/APIGetVSwitchTypesReply.java
+++ b/header/src/main/java/org/zstack/header/network/l2/APIGetVSwitchTypesReply.java
@@ -13,7 +13,7 @@ import java.util.List;
  * "org.zstack.header.network.l2.APIGetVSwitchTypesReply": {
  * "vSwitchTypes": [
  * "LinuxBridge",
- * "OVSDPDK"
+ * "OvsDpdk"
  * ],
  * "success": true
  * }
@@ -38,7 +38,7 @@ public class APIGetVSwitchTypesReply extends APIReply {
 
     public static APIGetVSwitchTypesReply __example__() {
         APIGetVSwitchTypesReply reply = new APIGetVSwitchTypesReply();
-        reply.setVSwitchTypes(Arrays.asList("LinuxBridge", "OVSDPDK"));
+        reply.setVSwitchTypes(Arrays.asList(L2NetworkConstant.VSWITCH_TYPE_LINUX_BRIDGE, L2NetworkConstant.VSWITCH_TYPE_OVS_DPDK));
         return reply;
     }
 }

--- a/header/src/main/java/org/zstack/header/network/l2/AttachL2NetworkToHostMsg.java
+++ b/header/src/main/java/org/zstack/header/network/l2/AttachL2NetworkToHostMsg.java
@@ -1,11 +1,11 @@
 package org.zstack.header.network.l2;
 
-/**
- */
-public class L2NetworkDetachStruct {
+import org.zstack.header.message.NeedReplyMessage;
+
+public class AttachL2NetworkToHostMsg extends NeedReplyMessage implements L2NetworkMessage {
     private String l2NetworkUuid;
-    private String clusterUuid;
     private String hostUuid;
+    private String l2ProviderType;
 
     public String getL2NetworkUuid() {
         return l2NetworkUuid;
@@ -15,19 +15,19 @@ public class L2NetworkDetachStruct {
         this.l2NetworkUuid = l2NetworkUuid;
     }
 
-    public String getClusterUuid() {
-        return clusterUuid;
-    }
-
-    public void setClusterUuid(String clusterUuid) {
-        this.clusterUuid = clusterUuid;
-    }
-
     public String getHostUuid() {
         return hostUuid;
     }
 
     public void setHostUuid(String hostUuid) {
         this.hostUuid = hostUuid;
+    }
+
+    public String getL2ProviderType() {
+        return l2ProviderType;
+    }
+
+    public void setL2ProviderType(String l2ProviderType) {
+        this.l2ProviderType = l2ProviderType;
     }
 }

--- a/header/src/main/java/org/zstack/header/network/l2/AttachL2NetworkToHostReply.java
+++ b/header/src/main/java/org/zstack/header/network/l2/AttachL2NetworkToHostReply.java
@@ -1,0 +1,6 @@
+package org.zstack.header.network.l2;
+
+import org.zstack.header.message.MessageReply;
+
+public class AttachL2NetworkToHostReply extends MessageReply {
+}

--- a/header/src/main/java/org/zstack/header/network/l2/BatchL2NetworkDetachFromHostMsg.java
+++ b/header/src/main/java/org/zstack/header/network/l2/BatchL2NetworkDetachFromHostMsg.java
@@ -1,0 +1,27 @@
+package org.zstack.header.network.l2;
+
+import org.zstack.header.message.NeedReplyMessage;
+
+import java.util.List;
+
+public class BatchL2NetworkDetachFromHostMsg extends NeedReplyMessage implements L2NetworkMessage {
+    private String l2NetworkUuid;
+    private List<String> hostUuids;
+
+    @Override
+    public String getL2NetworkUuid() {
+        return l2NetworkUuid;
+    }
+
+    public void setL2NetworkUuid(String l2NetworkUuid) {
+        this.l2NetworkUuid = l2NetworkUuid;
+    }
+
+    public List<String> getHostUuids() {
+        return hostUuids;
+    }
+
+    public void setHostUuids(List<String> hostUuids) {
+        this.hostUuids = hostUuids;
+    }
+}

--- a/header/src/main/java/org/zstack/header/network/l2/BatchL2NetworkDetachFromHostReply.java
+++ b/header/src/main/java/org/zstack/header/network/l2/BatchL2NetworkDetachFromHostReply.java
@@ -1,0 +1,6 @@
+package org.zstack.header.network.l2;
+
+import org.zstack.header.message.MessageReply;
+
+public class BatchL2NetworkDetachFromHostReply extends MessageReply {
+}

--- a/header/src/main/java/org/zstack/header/network/l2/DetachL2NetworkFromHostMsg.java
+++ b/header/src/main/java/org/zstack/header/network/l2/DetachL2NetworkFromHostMsg.java
@@ -1,26 +1,18 @@
 package org.zstack.header.network.l2;
 
-/**
- */
-public class L2NetworkDetachStruct {
+import org.zstack.header.message.NeedReplyMessage;
+
+public class DetachL2NetworkFromHostMsg extends NeedReplyMessage implements L2NetworkMessage {
     private String l2NetworkUuid;
-    private String clusterUuid;
     private String hostUuid;
 
+    @Override
     public String getL2NetworkUuid() {
         return l2NetworkUuid;
     }
 
     public void setL2NetworkUuid(String l2NetworkUuid) {
         this.l2NetworkUuid = l2NetworkUuid;
-    }
-
-    public String getClusterUuid() {
-        return clusterUuid;
-    }
-
-    public void setClusterUuid(String clusterUuid) {
-        this.clusterUuid = clusterUuid;
     }
 
     public String getHostUuid() {

--- a/header/src/main/java/org/zstack/header/network/l2/DetachL2NetworkFromHostReply.java
+++ b/header/src/main/java/org/zstack/header/network/l2/DetachL2NetworkFromHostReply.java
@@ -1,0 +1,6 @@
+package org.zstack.header.network.l2;
+
+import org.zstack.header.message.MessageReply;
+
+public class DetachL2NetworkFromHostReply extends MessageReply {
+}

--- a/header/src/main/java/org/zstack/header/network/l2/L2NetworkAttachStatus.java
+++ b/header/src/main/java/org/zstack/header/network/l2/L2NetworkAttachStatus.java
@@ -1,8 +1,6 @@
 package org.zstack.header.network.l2;
 
 public enum L2NetworkAttachStatus {
-    None,
-    CheckFailed,
-    AttachFailed,
+    Detached,
     Attached,
 }

--- a/header/src/main/java/org/zstack/header/network/l2/L2NetworkConstant.java
+++ b/header/src/main/java/org/zstack/header/network/l2/L2NetworkConstant.java
@@ -1,6 +1,5 @@
 package org.zstack.header.network.l2;
 
-import org.springframework.security.access.method.P;
 import org.zstack.header.configuration.PythonClass;
 
 @PythonClass
@@ -34,6 +33,8 @@ public interface L2NetworkConstant {
     public static final String VSWITCH_TYPE_OVS_KERNEL = "OvsKernel";
 
     public static final String DETACH_L2NETWORK_CODE = "l2Network.detach";
+
+    public static final String DETACH_L2NETWORK_FROM_HOST_CODE = "l2Network.detach.host";
 
     // https://elixir.bootlin.com/linux/v5.6/source/include/uapi/linux/if.h#L33
     public static final int LINUX_IF_NAME_MAX_SIZE = 15;

--- a/header/src/main/java/org/zstack/header/network/l2/L2NetworkDetachFromHostMsg.java
+++ b/header/src/main/java/org/zstack/header/network/l2/L2NetworkDetachFromHostMsg.java
@@ -1,26 +1,18 @@
 package org.zstack.header.network.l2;
 
-/**
- */
-public class L2NetworkDetachStruct {
+import org.zstack.header.message.NeedReplyMessage;
+
+public class L2NetworkDetachFromHostMsg extends NeedReplyMessage implements L2NetworkMessage {
     private String l2NetworkUuid;
-    private String clusterUuid;
     private String hostUuid;
 
+    @Override
     public String getL2NetworkUuid() {
         return l2NetworkUuid;
     }
 
     public void setL2NetworkUuid(String l2NetworkUuid) {
         this.l2NetworkUuid = l2NetworkUuid;
-    }
-
-    public String getClusterUuid() {
-        return clusterUuid;
-    }
-
-    public void setClusterUuid(String clusterUuid) {
-        this.clusterUuid = clusterUuid;
     }
 
     public String getHostUuid() {

--- a/header/src/main/java/org/zstack/header/network/l2/L2NetworkDetachFromHostReply.java
+++ b/header/src/main/java/org/zstack/header/network/l2/L2NetworkDetachFromHostReply.java
@@ -1,0 +1,6 @@
+package org.zstack.header.network.l2;
+
+import org.zstack.header.message.MessageReply;
+
+public class L2NetworkDetachFromHostReply extends MessageReply {
+}

--- a/header/src/main/java/org/zstack/header/network/l2/L2NetworkHostRefInventory.java
+++ b/header/src/main/java/org/zstack/header/network/l2/L2NetworkHostRefInventory.java
@@ -15,19 +15,15 @@ import java.util.List;
         @ExpandedQuery(expandedField = "host", inventoryClass = HostInventory.class,
                 foreignKey = "hostUuid", expandedInventoryKey = "uuid"),
         @ExpandedQuery(expandedField = "l2Network", inventoryClass = L2NetworkInventory.class,
-                foreignKey = "l2NetworkUuid", expandedInventoryKey = "uuid"),
+                foreignKey = "l2NetworkUuid", expandedInventoryKey = "uuid")
 })
 public class L2NetworkHostRefInventory {
     private String hostUuid;
     private String l2NetworkUuid;
-
     private String l2ProviderType;
-
     private L2NetworkAttachStatus attachStatus;
-
     private Timestamp createDate;
     private Timestamp lastOpDate;
-
 
     public static L2NetworkHostRefInventory valueOf(L2NetworkHostRefVO vo) {
         L2NetworkHostRefInventory inv = new L2NetworkHostRefInventory();

--- a/header/src/main/java/org/zstack/header/network/l2/L2NetworkHostRefVO.java
+++ b/header/src/main/java/org/zstack/header/network/l2/L2NetworkHostRefVO.java
@@ -1,7 +1,5 @@
 package org.zstack.header.network.l2;
 
-import org.zstack.header.cluster.ClusterEO;
-import org.zstack.header.cluster.ClusterVO;
 import org.zstack.header.host.HostEO;
 import org.zstack.header.host.HostVO;
 import org.zstack.header.search.SqlTrigger;
@@ -47,7 +45,7 @@ public class L2NetworkHostRefVO {
     private String l2ProviderType;
 
     @Column
-    @Enumerated
+    @Enumerated(EnumType.STRING)
     private L2NetworkAttachStatus attachStatus;
 
     @Column

--- a/header/src/main/java/org/zstack/header/network/l2/L2NetworkHostRefVO_.java
+++ b/header/src/main/java/org/zstack/header/network/l2/L2NetworkHostRefVO_.java
@@ -10,7 +10,7 @@ public class L2NetworkHostRefVO_ {
     public static volatile SingularAttribute<L2NetworkHostRefVO, String> hostUuid;
     public static volatile SingularAttribute<L2NetworkHostRefVO, String> l2NetworkUuid;
     public static volatile SingularAttribute<L2NetworkHostRefVO, String> l2ProviderType;
-    public static volatile SingularAttribute<L2NetworkAttachStatus, String> attachStatus;
+    public static volatile SingularAttribute<L2NetworkHostRefVO, L2NetworkAttachStatus> attachStatus;
     public static volatile SingularAttribute<L2NetworkHostRefVO, Timestamp> createDate;
     public static volatile SingularAttribute<L2NetworkHostRefVO, Timestamp> lastOpDate;
 }

--- a/header/src/main/java/org/zstack/header/network/l2/L2NetworkInventory.java
+++ b/header/src/main/java/org/zstack/header/network/l2/L2NetworkInventory.java
@@ -41,9 +41,12 @@ import java.util.List;
                 foreignKey = "uuid", expandedInventoryKey = "l2NetworkUuid"),
         @ExpandedQuery(expandedField = "clusterRef", inventoryClass = L2NetworkClusterRefInventory.class,
                 foreignKey = "uuid", expandedInventoryKey = "l2NetworkUuid", hidden = true),
+        @ExpandedQuery(expandedField = "hostRef", inventoryClass = L2NetworkHostRefInventory.class,
+                foreignKey = "uuid", expandedInventoryKey = "l2NetworkUuid", hidden = true),
 })
 @ExpandedQueryAliases({
-        @ExpandedQueryAlias(alias = "cluster", expandedField = "clusterRef.cluster")
+        @ExpandedQueryAlias(alias = "cluster", expandedField = "clusterRef.cluster"),
+        @ExpandedQueryAlias(alias = "host", expandedField = "hostRef.host")
 })
 public class L2NetworkInventory implements Serializable {
     /**
@@ -95,6 +98,8 @@ public class L2NetworkInventory implements Serializable {
             joinColumn = @JoinColumn(name = "l2NetworkUuid", referencedColumnName = "clusterUuid"))
     private List<String> attachedClusterUuids;
 
+    private List<L2NetworkHostRefInventory> attachedHostRefs;
+
     public L2NetworkInventory() {
     }
 
@@ -113,6 +118,7 @@ public class L2NetworkInventory implements Serializable {
         for (L2NetworkClusterRefVO ref : vo.getAttachedClusterRefs()) {
             this.attachedClusterUuids.add(ref.getClusterUuid());
         }
+        this.setAttachedHostRefs(L2NetworkHostRefInventory.valueOf(vo.getAttachedHostRefs()));
     }
 
     public static L2NetworkInventory valueOf(L2NetworkVO vo) {
@@ -213,5 +219,13 @@ public class L2NetworkInventory implements Serializable {
 
     public void setAttachedClusterUuids(List<String> attachedClusterUuids) {
         this.attachedClusterUuids = attachedClusterUuids;
+    }
+
+    public List<L2NetworkHostRefInventory> getAttachedHostRefs() {
+        return attachedHostRefs;
+    }
+
+    public void setAttachedHostRefs(List<L2NetworkHostRefInventory> attachedHostRefs) {
+        this.attachedHostRefs = attachedHostRefs;
     }
 }

--- a/header/src/main/java/org/zstack/header/network/l2/L2NetworkVO.java
+++ b/header/src/main/java/org/zstack/header/network/l2/L2NetworkVO.java
@@ -18,7 +18,8 @@ import java.util.Set;
                 @EntityGraph.Neighbour(type = ZoneVO.class, myField = "zoneUuid", targetField = "uuid")
         },
         friends = {
-                @EntityGraph.Neighbour(type = L2NetworkClusterRefVO.class, myField = "uuid", targetField = "l2NetworkUuid")
+                @EntityGraph.Neighbour(type = L2NetworkClusterRefVO.class, myField = "uuid", targetField = "l2NetworkUuid"),
+                @EntityGraph.Neighbour(type = L2NetworkHostRefVO.class, myField = "uuid", targetField = "l2NetworkUuid")
         }
 )
 public class L2NetworkVO extends L2NetworkAO implements ToInventory, OwnedByAccount {
@@ -26,6 +27,11 @@ public class L2NetworkVO extends L2NetworkAO implements ToInventory, OwnedByAcco
     @JoinColumn(name = "l2NetworkUuid", insertable = false, updatable = false)
     @NoView
     private Set<L2NetworkClusterRefVO> attachedClusterRefs = new HashSet<L2NetworkClusterRefVO>();
+
+    @OneToMany(fetch = FetchType.EAGER)
+    @JoinColumn(name = "l2NetworkUuid", insertable = false, updatable = false)
+    @NoView
+    private Set<L2NetworkHostRefVO> attachedHostRefs = new HashSet<L2NetworkHostRefVO>();
 
     @Transient
     private String accountUuid;
@@ -38,6 +44,7 @@ public class L2NetworkVO extends L2NetworkAO implements ToInventory, OwnedByAcco
     public L2NetworkVO(L2NetworkVO vo) {
         this.setUuid(vo.getUuid());
         this.setAttachedClusterRefs(vo.getAttachedClusterRefs());
+        this.setAttachedHostRefs(vo.getAttachedHostRefs());
         this.setCreateDate(vo.getCreateDate());
         this.setDescription(vo.getDescription());
         this.setLastOpDate(vo.getLastOpDate());
@@ -56,6 +63,14 @@ public class L2NetworkVO extends L2NetworkAO implements ToInventory, OwnedByAcco
 
     public void setAttachedClusterRefs(Set<L2NetworkClusterRefVO> attachedClusterRefs) {
         this.attachedClusterRefs = attachedClusterRefs;
+    }
+
+    public Set<L2NetworkHostRefVO> getAttachedHostRefs() {
+        return attachedHostRefs;
+    }
+
+    public void setAttachedHostRefs(Set<L2NetworkHostRefVO> attachedHostRefs) {
+        this.attachedHostRefs = attachedHostRefs;
     }
 
     @Override

--- a/header/src/main/java/org/zstack/header/network/service/NetworkServiceHostExtensionPoint.java
+++ b/header/src/main/java/org/zstack/header/network/service/NetworkServiceHostExtensionPoint.java
@@ -1,0 +1,13 @@
+package org.zstack.header.network.service;
+
+import org.zstack.header.core.Completion;
+import org.zstack.header.host.HostInventory;
+
+public interface NetworkServiceHostExtensionPoint {
+    String getNetworkServiceName();
+
+    void afterHostConnected(HostInventory host, Completion completion);
+
+    void beforeDeleteHost(HostInventory host, Completion completion);
+
+}

--- a/header/src/main/java/org/zstack/header/vm/VmInstanceConstant.java
+++ b/header/src/main/java/org/zstack/header/vm/VmInstanceConstant.java
@@ -85,4 +85,6 @@ public interface VmInstanceConstant {
 
     String EMPTY_CDROM = "empty";
     String NONE_CDROM = "none";
+
+    String DETACH_NIC_FAILED_REGEX = ".*NIC device is still attached after.*";
 }

--- a/network/src/main/java/org/zstack/network/service/NetworkServiceManagerImpl.java
+++ b/network/src/main/java/org/zstack/network/service/NetworkServiceManagerImpl.java
@@ -11,11 +11,17 @@ import org.zstack.core.db.SimpleQuery.Op;
 import org.zstack.core.workflow.FlowChainBuilder;
 import org.zstack.header.AbstractService;
 import org.zstack.header.core.Completion;
+import org.zstack.header.core.FutureCompletion;
 import org.zstack.header.core.NoErrorCompletion;
+import org.zstack.header.core.NopeCompletion;
 import org.zstack.header.core.workflow.*;
 import org.zstack.header.errorcode.ErrorCode;
 import org.zstack.header.errorcode.OperationFailureException;
 import org.zstack.header.exception.CloudRuntimeException;
+import org.zstack.header.host.HostAfterConnectedExtensionPoint;
+import org.zstack.header.host.HostDeleteExtensionPoint;
+import org.zstack.header.host.HostException;
+import org.zstack.header.host.HostInventory;
 import org.zstack.header.message.APIMessage;
 import org.zstack.header.message.Message;
 import org.zstack.header.network.NetworkException;
@@ -30,13 +36,14 @@ import org.zstack.utils.Utils;
 import org.zstack.utils.logging.CLogger;
 
 import java.util.*;
+import java.util.concurrent.TimeUnit;
 
 import static org.zstack.core.Platform.err;
 import static org.zstack.core.Platform.operr;
 
 public class NetworkServiceManagerImpl extends AbstractService implements NetworkServiceManager, PreVmInstantiateResourceExtensionPoint,
         VmReleaseResourceExtensionPoint, PostVmInstantiateResourceExtensionPoint, ReleaseNetworkServiceOnDetachingNicExtensionPoint,
-        InstantiateResourceOnAttachingNicExtensionPoint {
+        InstantiateResourceOnAttachingNicExtensionPoint, HostAfterConnectedExtensionPoint, HostDeleteExtensionPoint {
 	private static final CLogger logger = Utils.getLogger(NetworkServiceManagerImpl.class);
 
 	@Autowired
@@ -52,6 +59,7 @@ public class NetworkServiceManagerImpl extends AbstractService implements Networ
 	private final Map<String, ApplyNetworkServiceExtensionPoint> providerExts = new HashMap<String, ApplyNetworkServiceExtensionPoint>();
 	private Set<String> supportedVmTypes = new HashSet<>();
     private List<NetworkServiceExtensionPoint> nsExts = new ArrayList<NetworkServiceExtensionPoint>();
+    private List<NetworkServiceHostExtensionPoint> nsHostExts = new ArrayList<NetworkServiceHostExtensionPoint>();
 
 
 	private void populateExtensions() {
@@ -74,6 +82,7 @@ public class NetworkServiceManagerImpl extends AbstractService implements Networ
         }
 
         nsExts = pluginRgty.getExtensionList(NetworkServiceExtensionPoint.class);
+        nsHostExts = pluginRgty.getExtensionList(NetworkServiceHostExtensionPoint.class);
 	}
 
 	private NetworkServiceProviderFactory getProviderFactory(String type) {
@@ -509,5 +518,96 @@ public class NetworkServiceManagerImpl extends AbstractService implements Networ
     public boolean isVmNeedNetworkService(String vmType, NetworkServiceType serviceType) {
 	    /* serviceType is not used now, maybe used in future */
         return supportedVmTypes.contains(vmType);
+    }
+
+    @Override
+    public void afterHostConnected(HostInventory host) {
+        FlowChain schain = FlowChainBuilder.newSimpleFlowChain()
+                .setName(String.format("host-%s-connected-network-service-action", host.getUuid()));
+        schain.allowEmptyFlow();
+
+        for (final NetworkServiceHostExtensionPoint ns : nsHostExts) {
+
+            NoRollbackFlow flow = new NoRollbackFlow() {
+                String __name__ = String.format("host-%s-connected-%s-action", host.getUuid(), ns.getNetworkServiceName());
+
+                @Override
+                public void run(final FlowTrigger chain, Map data) {
+                    ns.afterHostConnected(host, new Completion(chain) {
+                        @Override
+                        public void success() {
+                            chain.next();
+                        }
+
+                        @Override
+                        public void fail(ErrorCode errorCode) {
+                            chain.fail(errorCode);
+                        }
+                    });
+                }
+            };
+
+            schain.then(flow);
+        }
+
+        schain.done(new FlowDoneHandler(new NopeCompletion()) {
+            @Override
+            public void handle(Map data) {
+                logger.debug(String.format("successfully finished network services after host[uuid:%s] connected", host.getUuid()));
+            }
+        }).start();
+
+    }
+
+    @Override
+    public void preDeleteHost(HostInventory inventory) throws HostException {
+
+    }
+
+    @Override
+    public void beforeDeleteHost(HostInventory host) {
+        FlowChain schain = FlowChainBuilder.newSimpleFlowChain()
+                .setName(String.format("host-%s-deletion-network-service-action", host.getUuid()));
+        schain.allowEmptyFlow();
+
+        final FutureCompletion completion = new FutureCompletion(null);
+        for (final NetworkServiceHostExtensionPoint ns : nsHostExts) {
+
+            NoRollbackFlow flow = new NoRollbackFlow() {
+                String __name__ = String.format("host-%s-deletion-%s-action", host.getUuid(), ns.getNetworkServiceName());
+
+                @Override
+                public void run(final FlowTrigger chain, Map data) {
+                    ns.beforeDeleteHost(host, new Completion(chain) {
+                        @Override
+                        public void success() {
+                            chain.next();
+                        }
+
+                        @Override
+                        public void fail(ErrorCode errorCode) {
+                            chain.fail(errorCode);
+                        }
+                    });
+                }
+            };
+
+            schain.then(flow);
+        }
+
+        schain.done(new FlowDoneHandler(completion) {
+            @Override
+            public void handle(Map data) {
+                logger.debug(String.format("successfully finished network services before host[uuid:%s] deletion", host.getUuid()));
+                completion.success();
+            }
+        }).start();
+
+        completion.await(TimeUnit.SECONDS.toMillis(60));
+    }
+
+    @Override
+    public void afterDeleteHost(HostInventory inventory) {
+
     }
 }

--- a/plugin/vxlan/src/main/java/org/zstack/network/l2/vxlan/vxlanNetwork/VxlanNetwork.java
+++ b/plugin/vxlan/src/main/java/org/zstack/network/l2/vxlan/vxlanNetwork/VxlanNetwork.java
@@ -71,7 +71,8 @@ public class VxlanNetwork extends L2NoVlanNetwork implements ReportQuotaExtensio
     @Override
     public void deleteHook(Completion completion) {
         if (L2NetworkGlobalConfig.DeleteL2BridgePhysically.value(Boolean.class)) {
-            deleteL2Bridge(completion);
+            L2NetworkInventory l2Inv = getSelfInventory();
+            deleteL2Bridge(l2Inv.getAttachedClusterUuids(), completion);
         } else {
             completion.success();
         }

--- a/sdk/src/main/java/SourceClassMap.java
+++ b/sdk/src/main/java/SourceClassMap.java
@@ -249,7 +249,9 @@ public class SourceClassMap {
 			put("org.zstack.header.longjob.LongJobInventory", "org.zstack.sdk.LongJobInventory");
 			put("org.zstack.header.longjob.LongJobState", "org.zstack.sdk.LongJobState");
 			put("org.zstack.header.managementnode.ManagementNodeInventory", "org.zstack.sdk.ManagementNodeInventory");
+			put("org.zstack.header.network.l2.L2NetworkAttachStatus", "org.zstack.sdk.L2NetworkAttachStatus");
 			put("org.zstack.header.network.l2.L2NetworkData", "org.zstack.sdk.L2NetworkData");
+			put("org.zstack.header.network.l2.L2NetworkHostRefInventory", "org.zstack.sdk.L2NetworkHostRefInventory");
 			put("org.zstack.header.network.l2.L2NetworkInventory", "org.zstack.sdk.L2NetworkInventory");
 			put("org.zstack.header.network.l2.L2VlanNetworkInventory", "org.zstack.sdk.L2VlanNetworkInventory");
 			put("org.zstack.header.network.l3.AddressPoolInventory", "org.zstack.sdk.AddressPoolInventory");
@@ -945,7 +947,9 @@ public class SourceClassMap {
 			put("org.zstack.sdk.KVMIsoTO", "org.zstack.kvm.KVMIsoTO");
 			put("org.zstack.sdk.KvmHostHypervisorMetadataInventory", "org.zstack.kvm.hypervisor.datatype.KvmHostHypervisorMetadataInventory");
 			put("org.zstack.sdk.KvmHypervisorInfoInventory", "org.zstack.kvm.hypervisor.datatype.KvmHypervisorInfoInventory");
+			put("org.zstack.sdk.L2NetworkAttachStatus", "org.zstack.header.network.l2.L2NetworkAttachStatus");
 			put("org.zstack.sdk.L2NetworkData", "org.zstack.header.network.l2.L2NetworkData");
+			put("org.zstack.sdk.L2NetworkHostRefInventory", "org.zstack.header.network.l2.L2NetworkHostRefInventory");
 			put("org.zstack.sdk.L2NetworkInventory", "org.zstack.header.network.l2.L2NetworkInventory");
 			put("org.zstack.sdk.L2PortGroupNetworkInventory", "org.zstack.network.l2.virtualSwitch.header.L2PortGroupNetworkInventory");
 			put("org.zstack.sdk.L2PortGroupVlanMode", "org.zstack.network.l2.virtualSwitch.header.L2PortGroupVlanMode");

--- a/sdk/src/main/java/org/zstack/sdk/AttachL2NetworkToHostAction.java
+++ b/sdk/src/main/java/org/zstack/sdk/AttachL2NetworkToHostAction.java
@@ -4,7 +4,7 @@ import java.util.HashMap;
 import java.util.Map;
 import org.zstack.sdk.*;
 
-public class GetCandidateNetworkInterfacesAction extends AbstractAction {
+public class AttachL2NetworkToHostAction extends AbstractAction {
 
     private static final HashMap<String, Parameter> parameterMap = new HashMap<>();
 
@@ -12,7 +12,7 @@ public class GetCandidateNetworkInterfacesAction extends AbstractAction {
 
     public static class Result {
         public ErrorCode error;
-        public org.zstack.sdk.GetCandidateNetworkInterfacesResult value;
+        public org.zstack.sdk.AttachL2NetworkToHostResult value;
 
         public Result throwExceptionIfError() {
             if (error != null) {
@@ -26,19 +26,13 @@ public class GetCandidateNetworkInterfacesAction extends AbstractAction {
     }
 
     @Param(required = true, nonempty = false, nullElements = false, emptyString = true, noTrim = false)
-    public java.util.List hostUuids;
+    public java.lang.String l2NetworkUuid;
 
-    @Param(required = false, validValues = {"interface","bonding","all"}, nonempty = false, nullElements = false, emptyString = true, noTrim = false)
-    public java.lang.String interfaceType = "all";
+    @Param(required = true, nonempty = false, nullElements = false, emptyString = true, noTrim = false)
+    public java.lang.String hostUuid;
 
-    @Param(required = false, nonempty = false, nullElements = false, emptyString = true, noTrim = false)
-    public boolean intersecting = true;
-
-    @Param(required = false)
-    public java.lang.Integer limit = 1000;
-
-    @Param(required = false)
-    public java.lang.Integer start = 0;
+    @Param(required = false, validValues = {"LinuxBridge"}, nonempty = false, nullElements = false, emptyString = true, noTrim = false)
+    public java.lang.String l2ProviderType;
 
     @Param(required = false)
     public java.util.List systemTags;
@@ -58,6 +52,12 @@ public class GetCandidateNetworkInterfacesAction extends AbstractAction {
     @Param(required = false)
     public String requestIp;
 
+    @NonAPIParam
+    public long timeout = -1;
+
+    @NonAPIParam
+    public long pollingInterval = -1;
+
 
     private Result makeResult(ApiResult res) {
         Result ret = new Result();
@@ -66,8 +66,8 @@ public class GetCandidateNetworkInterfacesAction extends AbstractAction {
             return ret;
         }
         
-        org.zstack.sdk.GetCandidateNetworkInterfacesResult value = res.getResult(org.zstack.sdk.GetCandidateNetworkInterfacesResult.class);
-        ret.value = value == null ? new org.zstack.sdk.GetCandidateNetworkInterfacesResult() : value; 
+        org.zstack.sdk.AttachL2NetworkToHostResult value = res.getResult(org.zstack.sdk.AttachL2NetworkToHostResult.class);
+        ret.value = value == null ? new org.zstack.sdk.AttachL2NetworkToHostResult() : value; 
 
         return ret;
     }
@@ -96,11 +96,11 @@ public class GetCandidateNetworkInterfacesAction extends AbstractAction {
 
     protected RestInfo getRestInfo() {
         RestInfo info = new RestInfo();
-        info.httpMethod = "GET";
-        info.path = "/cluster/hosts-network-interfaces";
+        info.httpMethod = "POST";
+        info.path = "/l2-networks/{l2NetworkUuid}/hosts/{hostUuid}";
         info.needSession = true;
-        info.needPoll = false;
-        info.parameterName = "";
+        info.needPoll = true;
+        info.parameterName = "params";
         return info;
     }
 

--- a/sdk/src/main/java/org/zstack/sdk/AttachL2NetworkToHostResult.java
+++ b/sdk/src/main/java/org/zstack/sdk/AttachL2NetworkToHostResult.java
@@ -1,0 +1,14 @@
+package org.zstack.sdk;
+
+import org.zstack.sdk.L2NetworkInventory;
+
+public class AttachL2NetworkToHostResult {
+    public L2NetworkInventory inventory;
+    public void setInventory(L2NetworkInventory inventory) {
+        this.inventory = inventory;
+    }
+    public L2NetworkInventory getInventory() {
+        return this.inventory;
+    }
+
+}

--- a/sdk/src/main/java/org/zstack/sdk/DetachL2NetworkFromHostAction.java
+++ b/sdk/src/main/java/org/zstack/sdk/DetachL2NetworkFromHostAction.java
@@ -4,7 +4,7 @@ import java.util.HashMap;
 import java.util.Map;
 import org.zstack.sdk.*;
 
-public class GetCandidateNetworkInterfacesAction extends AbstractAction {
+public class DetachL2NetworkFromHostAction extends AbstractAction {
 
     private static final HashMap<String, Parameter> parameterMap = new HashMap<>();
 
@@ -12,7 +12,7 @@ public class GetCandidateNetworkInterfacesAction extends AbstractAction {
 
     public static class Result {
         public ErrorCode error;
-        public org.zstack.sdk.GetCandidateNetworkInterfacesResult value;
+        public org.zstack.sdk.DetachL2NetworkFromHostResult value;
 
         public Result throwExceptionIfError() {
             if (error != null) {
@@ -26,19 +26,10 @@ public class GetCandidateNetworkInterfacesAction extends AbstractAction {
     }
 
     @Param(required = true, nonempty = false, nullElements = false, emptyString = true, noTrim = false)
-    public java.util.List hostUuids;
+    public java.lang.String l2NetworkUuid;
 
-    @Param(required = false, validValues = {"interface","bonding","all"}, nonempty = false, nullElements = false, emptyString = true, noTrim = false)
-    public java.lang.String interfaceType = "all";
-
-    @Param(required = false, nonempty = false, nullElements = false, emptyString = true, noTrim = false)
-    public boolean intersecting = true;
-
-    @Param(required = false)
-    public java.lang.Integer limit = 1000;
-
-    @Param(required = false)
-    public java.lang.Integer start = 0;
+    @Param(required = true, nonempty = false, nullElements = false, emptyString = true, noTrim = false)
+    public java.lang.String hostUuid;
 
     @Param(required = false)
     public java.util.List systemTags;
@@ -58,6 +49,12 @@ public class GetCandidateNetworkInterfacesAction extends AbstractAction {
     @Param(required = false)
     public String requestIp;
 
+    @NonAPIParam
+    public long timeout = -1;
+
+    @NonAPIParam
+    public long pollingInterval = -1;
+
 
     private Result makeResult(ApiResult res) {
         Result ret = new Result();
@@ -66,8 +63,8 @@ public class GetCandidateNetworkInterfacesAction extends AbstractAction {
             return ret;
         }
         
-        org.zstack.sdk.GetCandidateNetworkInterfacesResult value = res.getResult(org.zstack.sdk.GetCandidateNetworkInterfacesResult.class);
-        ret.value = value == null ? new org.zstack.sdk.GetCandidateNetworkInterfacesResult() : value; 
+        org.zstack.sdk.DetachL2NetworkFromHostResult value = res.getResult(org.zstack.sdk.DetachL2NetworkFromHostResult.class);
+        ret.value = value == null ? new org.zstack.sdk.DetachL2NetworkFromHostResult() : value; 
 
         return ret;
     }
@@ -96,10 +93,10 @@ public class GetCandidateNetworkInterfacesAction extends AbstractAction {
 
     protected RestInfo getRestInfo() {
         RestInfo info = new RestInfo();
-        info.httpMethod = "GET";
-        info.path = "/cluster/hosts-network-interfaces";
+        info.httpMethod = "DELETE";
+        info.path = "/l2-networks/{l2NetworkUuid}/hosts/{hostUuid}";
         info.needSession = true;
-        info.needPoll = false;
+        info.needPoll = true;
         info.parameterName = "";
         return info;
     }

--- a/sdk/src/main/java/org/zstack/sdk/DetachL2NetworkFromHostResult.java
+++ b/sdk/src/main/java/org/zstack/sdk/DetachL2NetworkFromHostResult.java
@@ -1,0 +1,14 @@
+package org.zstack.sdk;
+
+import org.zstack.sdk.L2NetworkInventory;
+
+public class DetachL2NetworkFromHostResult {
+    public L2NetworkInventory inventory;
+    public void setInventory(L2NetworkInventory inventory) {
+        this.inventory = inventory;
+    }
+    public L2NetworkInventory getInventory() {
+        return this.inventory;
+    }
+
+}

--- a/sdk/src/main/java/org/zstack/sdk/GetCandidateNetworkBondingsAction.java
+++ b/sdk/src/main/java/org/zstack/sdk/GetCandidateNetworkBondingsAction.java
@@ -4,7 +4,7 @@ import java.util.HashMap;
 import java.util.Map;
 import org.zstack.sdk.*;
 
-public class GetCandidateNetworkInterfacesAction extends AbstractAction {
+public class GetCandidateNetworkBondingsAction extends AbstractAction {
 
     private static final HashMap<String, Parameter> parameterMap = new HashMap<>();
 
@@ -12,7 +12,7 @@ public class GetCandidateNetworkInterfacesAction extends AbstractAction {
 
     public static class Result {
         public ErrorCode error;
-        public org.zstack.sdk.GetCandidateNetworkInterfacesResult value;
+        public org.zstack.sdk.GetCandidateNetworkBondingsResult value;
 
         public Result throwExceptionIfError() {
             if (error != null) {
@@ -27,12 +27,6 @@ public class GetCandidateNetworkInterfacesAction extends AbstractAction {
 
     @Param(required = true, nonempty = false, nullElements = false, emptyString = true, noTrim = false)
     public java.util.List hostUuids;
-
-    @Param(required = false, validValues = {"interface","bonding","all"}, nonempty = false, nullElements = false, emptyString = true, noTrim = false)
-    public java.lang.String interfaceType = "all";
-
-    @Param(required = false, nonempty = false, nullElements = false, emptyString = true, noTrim = false)
-    public boolean intersecting = true;
 
     @Param(required = false)
     public java.lang.Integer limit = 1000;
@@ -66,8 +60,8 @@ public class GetCandidateNetworkInterfacesAction extends AbstractAction {
             return ret;
         }
         
-        org.zstack.sdk.GetCandidateNetworkInterfacesResult value = res.getResult(org.zstack.sdk.GetCandidateNetworkInterfacesResult.class);
-        ret.value = value == null ? new org.zstack.sdk.GetCandidateNetworkInterfacesResult() : value; 
+        org.zstack.sdk.GetCandidateNetworkBondingsResult value = res.getResult(org.zstack.sdk.GetCandidateNetworkBondingsResult.class);
+        ret.value = value == null ? new org.zstack.sdk.GetCandidateNetworkBondingsResult() : value; 
 
         return ret;
     }
@@ -97,7 +91,7 @@ public class GetCandidateNetworkInterfacesAction extends AbstractAction {
     protected RestInfo getRestInfo() {
         RestInfo info = new RestInfo();
         info.httpMethod = "GET";
-        info.path = "/cluster/hosts-network-interfaces";
+        info.path = "/cluster/hosts-network-bondings";
         info.needSession = true;
         info.needPoll = false;
         info.parameterName = "";

--- a/sdk/src/main/java/org/zstack/sdk/GetCandidateNetworkBondingsResult.java
+++ b/sdk/src/main/java/org/zstack/sdk/GetCandidateNetworkBondingsResult.java
@@ -1,0 +1,14 @@
+package org.zstack.sdk;
+
+
+
+public class GetCandidateNetworkBondingsResult {
+    public java.util.List inventories;
+    public void setInventories(java.util.List inventories) {
+        this.inventories = inventories;
+    }
+    public java.util.List getInventories() {
+        return this.inventories;
+    }
+
+}

--- a/sdk/src/main/java/org/zstack/sdk/L2NetworkAttachStatus.java
+++ b/sdk/src/main/java/org/zstack/sdk/L2NetworkAttachStatus.java
@@ -1,0 +1,6 @@
+package org.zstack.sdk;
+
+public enum L2NetworkAttachStatus {
+	Detached,
+	Attached,
+}

--- a/sdk/src/main/java/org/zstack/sdk/L2NetworkHostRefInventory.java
+++ b/sdk/src/main/java/org/zstack/sdk/L2NetworkHostRefInventory.java
@@ -1,0 +1,55 @@
+package org.zstack.sdk;
+
+import org.zstack.sdk.L2NetworkAttachStatus;
+
+public class L2NetworkHostRefInventory  {
+
+    public java.lang.String hostUuid;
+    public void setHostUuid(java.lang.String hostUuid) {
+        this.hostUuid = hostUuid;
+    }
+    public java.lang.String getHostUuid() {
+        return this.hostUuid;
+    }
+
+    public java.lang.String l2NetworkUuid;
+    public void setL2NetworkUuid(java.lang.String l2NetworkUuid) {
+        this.l2NetworkUuid = l2NetworkUuid;
+    }
+    public java.lang.String getL2NetworkUuid() {
+        return this.l2NetworkUuid;
+    }
+
+    public java.lang.String l2ProviderType;
+    public void setL2ProviderType(java.lang.String l2ProviderType) {
+        this.l2ProviderType = l2ProviderType;
+    }
+    public java.lang.String getL2ProviderType() {
+        return this.l2ProviderType;
+    }
+
+    public L2NetworkAttachStatus attachStatus;
+    public void setAttachStatus(L2NetworkAttachStatus attachStatus) {
+        this.attachStatus = attachStatus;
+    }
+    public L2NetworkAttachStatus getAttachStatus() {
+        return this.attachStatus;
+    }
+
+    public java.sql.Timestamp createDate;
+    public void setCreateDate(java.sql.Timestamp createDate) {
+        this.createDate = createDate;
+    }
+    public java.sql.Timestamp getCreateDate() {
+        return this.createDate;
+    }
+
+    public java.sql.Timestamp lastOpDate;
+    public void setLastOpDate(java.sql.Timestamp lastOpDate) {
+        this.lastOpDate = lastOpDate;
+    }
+    public java.sql.Timestamp getLastOpDate() {
+        return this.lastOpDate;
+    }
+
+}

--- a/sdk/src/main/java/org/zstack/sdk/L2NetworkInventory.java
+++ b/sdk/src/main/java/org/zstack/sdk/L2NetworkInventory.java
@@ -92,4 +92,12 @@ public class L2NetworkInventory  {
         return this.attachedClusterUuids;
     }
 
+    public java.util.List attachedHostRefs;
+    public void setAttachedHostRefs(java.util.List attachedHostRefs) {
+        this.attachedHostRefs = attachedHostRefs;
+    }
+    public java.util.List getAttachedHostRefs() {
+        return this.attachedHostRefs;
+    }
+
 }

--- a/sdk/src/main/java/org/zstack/sdk/UpdateVirtualSwitchUplinkBondingsAction.java
+++ b/sdk/src/main/java/org/zstack/sdk/UpdateVirtualSwitchUplinkBondingsAction.java
@@ -4,7 +4,7 @@ import java.util.HashMap;
 import java.util.Map;
 import org.zstack.sdk.*;
 
-public class GetCandidateNetworkInterfacesAction extends AbstractAction {
+public class UpdateVirtualSwitchUplinkBondingsAction extends AbstractAction {
 
     private static final HashMap<String, Parameter> parameterMap = new HashMap<>();
 
@@ -12,7 +12,7 @@ public class GetCandidateNetworkInterfacesAction extends AbstractAction {
 
     public static class Result {
         public ErrorCode error;
-        public org.zstack.sdk.GetCandidateNetworkInterfacesResult value;
+        public org.zstack.sdk.UpdateVirtualSwitchUplinkBondingsResult value;
 
         public Result throwExceptionIfError() {
             if (error != null) {
@@ -26,19 +26,13 @@ public class GetCandidateNetworkInterfacesAction extends AbstractAction {
     }
 
     @Param(required = true, nonempty = false, nullElements = false, emptyString = true, noTrim = false)
-    public java.util.List hostUuids;
+    public java.lang.String uuid;
 
-    @Param(required = false, validValues = {"interface","bonding","all"}, nonempty = false, nullElements = false, emptyString = true, noTrim = false)
-    public java.lang.String interfaceType = "all";
+    @Param(required = false, validValues = {"802.3ad","active-backup"}, nonempty = false, nullElements = false, emptyString = true, noTrim = false)
+    public java.lang.String mode;
 
-    @Param(required = false, nonempty = false, nullElements = false, emptyString = true, noTrim = false)
-    public boolean intersecting = true;
-
-    @Param(required = false)
-    public java.lang.Integer limit = 1000;
-
-    @Param(required = false)
-    public java.lang.Integer start = 0;
+    @Param(required = false, validValues = {"layer2","layer2+3","layer3+4"}, nonempty = false, nullElements = false, emptyString = true, noTrim = false)
+    public java.lang.String xmitHashPolicy;
 
     @Param(required = false)
     public java.util.List systemTags;
@@ -58,6 +52,12 @@ public class GetCandidateNetworkInterfacesAction extends AbstractAction {
     @Param(required = false)
     public String requestIp;
 
+    @NonAPIParam
+    public long timeout = -1;
+
+    @NonAPIParam
+    public long pollingInterval = -1;
+
 
     private Result makeResult(ApiResult res) {
         Result ret = new Result();
@@ -66,8 +66,8 @@ public class GetCandidateNetworkInterfacesAction extends AbstractAction {
             return ret;
         }
         
-        org.zstack.sdk.GetCandidateNetworkInterfacesResult value = res.getResult(org.zstack.sdk.GetCandidateNetworkInterfacesResult.class);
-        ret.value = value == null ? new org.zstack.sdk.GetCandidateNetworkInterfacesResult() : value; 
+        org.zstack.sdk.UpdateVirtualSwitchUplinkBondingsResult value = res.getResult(org.zstack.sdk.UpdateVirtualSwitchUplinkBondingsResult.class);
+        ret.value = value == null ? new org.zstack.sdk.UpdateVirtualSwitchUplinkBondingsResult() : value; 
 
         return ret;
     }
@@ -96,11 +96,11 @@ public class GetCandidateNetworkInterfacesAction extends AbstractAction {
 
     protected RestInfo getRestInfo() {
         RestInfo info = new RestInfo();
-        info.httpMethod = "GET";
-        info.path = "/cluster/hosts-network-interfaces";
+        info.httpMethod = "PUT";
+        info.path = "/l2-networks/virtual-switch/{uuid}/uplink-bondings";
         info.needSession = true;
-        info.needPoll = false;
-        info.parameterName = "";
+        info.needPoll = true;
+        info.parameterName = "updateVirtualSwitchUplinkBondings";
         return info;
     }
 

--- a/sdk/src/main/java/org/zstack/sdk/UpdateVirtualSwitchUplinkBondingsResult.java
+++ b/sdk/src/main/java/org/zstack/sdk/UpdateVirtualSwitchUplinkBondingsResult.java
@@ -1,0 +1,14 @@
+package org.zstack.sdk;
+
+
+
+public class UpdateVirtualSwitchUplinkBondingsResult {
+    public java.util.List inventories;
+    public void setInventories(java.util.List inventories) {
+        this.inventories = inventories;
+    }
+    public java.util.List getInventories() {
+        return this.inventories;
+    }
+
+}

--- a/testlib/src/main/java/org/zstack/testlib/ApiHelper.groovy
+++ b/testlib/src/main/java/org/zstack/testlib/ApiHelper.groovy
@@ -3473,6 +3473,33 @@ abstract class ApiHelper {
     }
 
 
+    def attachL2NetworkToHost(@DelegatesTo(strategy = Closure.OWNER_FIRST, value = org.zstack.sdk.AttachL2NetworkToHostAction.class) Closure c) {
+        def a = new org.zstack.sdk.AttachL2NetworkToHostAction()
+        a.sessionId = Test.currentEnvSpec?.session?.uuid
+        c.resolveStrategy = Closure.OWNER_FIRST
+        c.delegate = a
+        c()
+        
+
+        if (System.getProperty("apipath") != null) {
+            if (a.apiId == null) {
+                a.apiId = Platform.uuid
+            }
+    
+            def tracker = new ApiPathTracker(a.apiId)
+            def out = errorOut(a.call())
+            def path = tracker.getApiPath()
+            if (!path.isEmpty()) {
+                Test.apiPaths[a.class.name] = path.join(" --->\n")
+            }
+        
+            return out
+        } else {
+            return errorOut(a.call())
+        }
+    }
+
+
     def attachL3NetworkToVm(@DelegatesTo(strategy = Closure.OWNER_FIRST, value = org.zstack.sdk.AttachL3NetworkToVmAction.class) Closure c) {
         def a = new org.zstack.sdk.AttachL3NetworkToVmAction()
         a.sessionId = Test.currentEnvSpec?.session?.uuid
@@ -16433,6 +16460,33 @@ abstract class ApiHelper {
     }
 
 
+    def detachL2NetworkFromHost(@DelegatesTo(strategy = Closure.OWNER_FIRST, value = org.zstack.sdk.DetachL2NetworkFromHostAction.class) Closure c) {
+        def a = new org.zstack.sdk.DetachL2NetworkFromHostAction()
+        a.sessionId = Test.currentEnvSpec?.session?.uuid
+        c.resolveStrategy = Closure.OWNER_FIRST
+        c.delegate = a
+        c()
+        
+
+        if (System.getProperty("apipath") != null) {
+            if (a.apiId == null) {
+                a.apiId = Platform.uuid
+            }
+    
+            def tracker = new ApiPathTracker(a.apiId)
+            def out = errorOut(a.call())
+            def path = tracker.getApiPath()
+            if (!path.isEmpty()) {
+                Test.apiPaths[a.class.name] = path.join(" --->\n")
+            }
+        
+            return out
+        } else {
+            return errorOut(a.call())
+        }
+    }
+
+
     def detachL3NetworkFromVm(@DelegatesTo(strategy = Closure.OWNER_FIRST, value = org.zstack.sdk.DetachL3NetworkFromVmAction.class) Closure c) {
         def a = new org.zstack.sdk.DetachL3NetworkFromVmAction()
         a.sessionId = Test.currentEnvSpec?.session?.uuid
@@ -18649,6 +18703,33 @@ abstract class ApiHelper {
 
     def getCandidateMiniHosts(@DelegatesTo(strategy = Closure.OWNER_FIRST, value = org.zstack.sdk.GetCandidateMiniHostsAction.class) Closure c) {
         def a = new org.zstack.sdk.GetCandidateMiniHostsAction()
+        a.sessionId = Test.currentEnvSpec?.session?.uuid
+        c.resolveStrategy = Closure.OWNER_FIRST
+        c.delegate = a
+        c()
+        
+
+        if (System.getProperty("apipath") != null) {
+            if (a.apiId == null) {
+                a.apiId = Platform.uuid
+            }
+    
+            def tracker = new ApiPathTracker(a.apiId)
+            def out = errorOut(a.call())
+            def path = tracker.getApiPath()
+            if (!path.isEmpty()) {
+                Test.apiPaths[a.class.name] = path.join(" --->\n")
+            }
+        
+            return out
+        } else {
+            return errorOut(a.call())
+        }
+    }
+
+
+    def getCandidateNetworkBondings(@DelegatesTo(strategy = Closure.OWNER_FIRST, value = org.zstack.sdk.GetCandidateNetworkBondingsAction.class) Closure c) {
+        def a = new org.zstack.sdk.GetCandidateNetworkBondingsAction()
         a.sessionId = Test.currentEnvSpec?.session?.uuid
         c.resolveStrategy = Closure.OWNER_FIRST
         c.delegate = a
@@ -41374,6 +41455,33 @@ abstract class ApiHelper {
 
     def updateVirtualRouterSoftwareVersion(@DelegatesTo(strategy = Closure.OWNER_FIRST, value = org.zstack.sdk.UpdateVirtualRouterSoftwareVersionAction.class) Closure c) {
         def a = new org.zstack.sdk.UpdateVirtualRouterSoftwareVersionAction()
+        a.sessionId = Test.currentEnvSpec?.session?.uuid
+        c.resolveStrategy = Closure.OWNER_FIRST
+        c.delegate = a
+        c()
+        
+
+        if (System.getProperty("apipath") != null) {
+            if (a.apiId == null) {
+                a.apiId = Platform.uuid
+            }
+    
+            def tracker = new ApiPathTracker(a.apiId)
+            def out = errorOut(a.call())
+            def path = tracker.getApiPath()
+            if (!path.isEmpty()) {
+                Test.apiPaths[a.class.name] = path.join(" --->\n")
+            }
+        
+            return out
+        } else {
+            return errorOut(a.call())
+        }
+    }
+
+
+    def updateVirtualSwitchUplinkBondings(@DelegatesTo(strategy = Closure.OWNER_FIRST, value = org.zstack.sdk.UpdateVirtualSwitchUplinkBondingsAction.class) Closure c) {
+        def a = new org.zstack.sdk.UpdateVirtualSwitchUplinkBondingsAction()
         a.sessionId = Test.currentEnvSpec?.session?.uuid
         c.resolveStrategy = Closure.OWNER_FIRST
         c.delegate = a


### PR DESCRIPTION
DBImpact
APIImpact

Resolves: ZSTAC-2737

Change-Id: I61786c746e72656473666263676e6a7263676573

sync from gitlab !5431

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 在应用程序中添加了搜索功能，用户现在可以通过顶部的搜索栏快速查找信息。
  - 引入了新的API，允许将二层网络附加到集群和主机。
  - 新增了从主机分离二层网络的API。

- **错误修复**
  - 修正了处理L2网络分离动作的逻辑，确保在不同条件下能够正确获取虚拟机和网络接口卡信息。
  - 修改了特定错误情况下的处理流程，以便在某些条件下继续执行操作。

- **文档**
  - 添加了对新API "APIAttachL2NetworkToHostEvent" 和 "APIDetachL2NetworkFromHostEvent" 的中文文档说明。

- **重构**
  - 更新了枚举 `L2NetworkAttachStatus` 的值，简化了状态表示。
  - 修改了 `L2NetworkHostRefVO` 类中枚举类型的处理方式。

- **样式**
  - 调整了 `APIGetVSwitchTypesReply` 中的字符串表示，以保持一致性。

- **其他**
  - 移除了不再使用的字段和导入声明，以清理代码库。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->