### PR TITLE
<fix>[console]: cancel type conversion

### DIFF
--- a/console/src/main/java/org/zstack/console/ManagementServerConsoleProxyBackend.java
+++ b/console/src/main/java/org/zstack/console/ManagementServerConsoleProxyBackend.java
@@ -458,14 +458,13 @@ public class ManagementServerConsoleProxyBackend extends AbstractConsoleProxyBac
         umsg.setConsoleProxyOverriddenIp(msg.getConsoleProxyOverriddenIp());
         umsg.setConsoleProxyPort(msg.getConsoleProxyPort());
         bus.makeServiceIdByManagementNodeId(umsg, ConsoleConstants.SERVICE_ID, msg.getUuid());
-        bus.send(umsg, new CloudBusCallBack(evt) {
+        bus.send(umsg, new CloudBusCallBack(msg) {
             @Override
             public void run(MessageReply reply) {
                 if (reply.isSuccess()) {
                     bus.publish(evt);
                 } else {
-                    UpdateConsoleProxyAgentReply rly = reply.castReply();
-                    evt.setError(rly.getError());
+                    evt.setError(reply.getError());
                     bus.publish(evt);
                 }
             }


### PR DESCRIPTION
remove code that casts MessageReply to UpdateConsoleProxyAgentReply

Resolves: ZSTAC-61997

Change-Id: I67666b717277677974666c666d7a716c6b737564
(cherry picked from commit 93dafdf3180a5dc678a2c6d43d63b7accc11f5f0)

sync from gitlab !5435

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **功能改进**
  - 优化了控制台代理管理的消息处理逻辑，提升了系统稳定性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->