### PR TITLE
<fix>[sdk]: modify default value of GetCandidateNetworkInterfaces

### DIFF
--- a/sdk/src/main/java/org/zstack/sdk/GetCandidateNetworkInterfacesAction.java
+++ b/sdk/src/main/java/org/zstack/sdk/GetCandidateNetworkInterfacesAction.java
@@ -29,7 +29,7 @@ public class GetCandidateNetworkInterfacesAction extends AbstractAction {
     public java.util.List hostUuids;
 
     @Param(required = false, validValues = {"interface","bonding","all"}, nonempty = false, nullElements = false, emptyString = true, noTrim = false)
-    public java.lang.String interfaceType = "all";
+    public java.lang.String interfaceType = "interface";
 
     @Param(required = false)
     public java.lang.Integer limit = 1000;


### PR DESCRIPTION
Resolves: ZSTAC-57783

Change-Id: I6c716f6373726a7377627a69786d6c6c77636d68

sync from gitlab !5444

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **功能更新**
  - 更新了获取候选网络接口操作的默认行为，`interfaceType` 参数的默认值从 "all" 更改为 "interface"。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->