### PR TITLE
<fix>[compute]: allocate host with architecture in CreateVmInstanceMsg

### DIFF
--- a/compute/src/main/java/org/zstack/compute/vm/InstantiateVmFromNewCreatedStruct.java
+++ b/compute/src/main/java/org/zstack/compute/vm/InstantiateVmFromNewCreatedStruct.java
@@ -1,5 +1,6 @@
 package org.zstack.compute.vm;
 
+import org.zstack.header.host.CpuArchitecture;
 import org.zstack.header.vm.APICreateVmInstanceMsg;
 import org.zstack.header.vm.CreateVmInstanceMsg;
 import org.zstack.header.vm.InstantiateNewCreatedVmInstanceMsg;
@@ -21,6 +22,7 @@ public class InstantiateVmFromNewCreatedStruct {
     private List<VmNicSpec> l3NetworkUuids;
     private String rootDiskOfferingUuid;
     private VmCreationStrategy strategy = VmCreationStrategy.InstantStart;
+    private CpuArchitecture architecture;
     private List<String> rootVolumeSystemTags;
     private List<String> dataVolumeSystemTags;
     private String requiredHostUuid;
@@ -124,6 +126,14 @@ public class InstantiateVmFromNewCreatedStruct {
         return strategy;
     }
 
+    public void setArchitecture(CpuArchitecture architecture) {
+        this.architecture = architecture;
+    }
+
+    public CpuArchitecture getArchitecture() {
+        return architecture;
+    }
+
     public static InstantiateVmFromNewCreatedStruct fromMessage(InstantiateNewCreatedVmInstanceMsg msg) {
         InstantiateVmFromNewCreatedStruct struct = new InstantiateVmFromNewCreatedStruct();
         struct.setDataDiskOfferingUuids(msg.getDataDiskOfferingUuids());
@@ -134,6 +144,7 @@ public class InstantiateVmFromNewCreatedStruct {
         struct.setCandidatePrimaryStorageUuidsForRootVolume(msg.getCandidatePrimaryStorageUuidsForRootVolume());
         struct.setCandidatePrimaryStorageUuidsForDataVolume(msg.getCandidatePrimaryStorageUuidsForDataVolume());
         struct.strategy = VmCreationStrategy.valueOf(msg.getStrategy());
+        struct.architecture = msg.getArchitecture();
         struct.setRootVolumeSystemTags(msg.getRootVolumeSystemTags());
         struct.setDataVolumeSystemTags(msg.getDataVolumeSystemTags());
         struct.setRequiredHostUuid(msg.getHostUuid());
@@ -155,6 +166,7 @@ public class InstantiateVmFromNewCreatedStruct {
         struct.setCandidatePrimaryStorageUuidsForRootVolume(msg.getCandidatePrimaryStorageUuidsForRootVolume());
         struct.setCandidatePrimaryStorageUuidsForDataVolume(msg.getCandidatePrimaryStorageUuidsForDataVolume());
         struct.strategy = VmCreationStrategy.valueOf(msg.getStrategy());
+        struct.architecture = msg.getArchitecture() == null ? null : CpuArchitecture.valueOf(msg.getArchitecture());
         struct.setRootVolumeSystemTags(msg.getRootVolumeSystemTags());
         struct.setDataVolumeSystemTags(msg.getDataVolumeSystemTags());
         struct.setRequiredHostUuid(msg.getHostUuid());

--- a/compute/src/main/java/org/zstack/compute/vm/VmAllocateHostAndPrimaryStorageFlow.java
+++ b/compute/src/main/java/org/zstack/compute/vm/VmAllocateHostAndPrimaryStorageFlow.java
@@ -322,6 +322,10 @@ public class VmAllocateHostAndPrimaryStorageFlow implements Flow {
         if (zoneUuid != null) {
             q.eq(ClusterVO_.zoneUuid, zoneUuid);
         }
+        if (spec.getArchitecture() != null) {
+            q.eq(ClusterVO_.architecture, spec.getArchitecture().name());
+        }
+
         List<String> possibleClusterUuids = q.listValues();
         List<String> needClusterUuids;
         if (!CollectionUtils.isEmpty(spec.getCandidatePrimaryStorageUuidsForRootVolume())) {

--- a/compute/src/main/java/org/zstack/compute/vm/VmAllocateHostFlow.java
+++ b/compute/src/main/java/org/zstack/compute/vm/VmAllocateHostFlow.java
@@ -85,6 +85,7 @@ public class VmAllocateHostFlow implements Flow {
         msg.setCpuCapacity(spec.getVmInventory().getCpuNum());
         msg.setMemoryCapacity(spec.getVmInventory().getMemorySize());
         msg.setClusterUuids(spec.getRequiredClusterUuids());
+        msg.setArchitecture(spec.getArchitecture() == null ? null : spec.getArchitecture().name());
         List<L3NetworkInventory> l3Invs = VmNicSpec.getL3NetworkInventoryOfSpec(spec.getL3Networks());
         msg.setL3NetworkUuids(CollectionUtils.transformToList(l3Invs,
                 new Function<String, L3NetworkInventory>() {

--- a/compute/src/main/java/org/zstack/compute/vm/VmInstanceBase.java
+++ b/compute/src/main/java/org/zstack/compute/vm/VmInstanceBase.java
@@ -6990,6 +6990,7 @@ public class VmInstanceBase extends AbstractVmInstance {
 
         spec.setUserdataList(buildUserdata());
         selectBootOrder(spec);
+        spec.setArchitecture(struct.getArchitecture());
         spec.setConsolePassword(VmSystemTags.CONSOLE_PASSWORD.
                 getTokenByResourceUuid(self.getUuid(), VmSystemTags.CONSOLE_PASSWORD_TOKEN));
         spec.setUsbRedirect(Boolean.parseBoolean(VmSystemTags.USB_REDIRECT.getTokenByResourceUuid(self.getUuid(), VmSystemTags.USB_REDIRECT_TOKEN)));

--- a/compute/src/main/java/org/zstack/compute/vm/VmInstanceManagerImpl.java
+++ b/compute/src/main/java/org/zstack/compute/vm/VmInstanceManagerImpl.java
@@ -39,6 +39,7 @@ import org.zstack.header.errorcode.OperationFailureException;
 import org.zstack.header.exception.CloudConfigureFailException;
 import org.zstack.header.exception.CloudRuntimeException;
 import org.zstack.header.host.AfterChangeHostStatusExtensionPoint;
+import org.zstack.header.host.CpuArchitecture;
 import org.zstack.header.host.HostConstant;
 import org.zstack.header.host.HostInventory;
 import org.zstack.header.host.HostStatus;
@@ -1285,6 +1286,9 @@ public class VmInstanceManagerImpl extends AbstractService implements
                         } else {
                             smsg.setStrategy(msg.getStrategy());
                         }
+
+                        smsg.setArchitecture(msg.getArchitecture() == null ? null :
+                                CpuArchitecture.valueOf(msg.getArchitecture()));
 
                         smsg.setTimeout(msg.getTimeout());
                         smsg.setRootVolumeSystemTags(msg.getRootVolumeSystemTags());

--- a/compute/src/main/java/org/zstack/compute/vm/VmInstanceUtils.java
+++ b/compute/src/main/java/org/zstack/compute/vm/VmInstanceUtils.java
@@ -40,9 +40,6 @@ public class VmInstanceUtils {
         if (CollectionUtils.isNotEmpty(msg.getDataDiskOfferingUuids()) || CollectionUtils.isNotEmpty(msg.getDataDiskSizes())) {
             cmsg.setPrimaryStorageUuidForDataVolume(getPSUuidForDataVolume(msg.getSystemTags()));
         }
-        cmsg.setPlatform(msg.getPlatform());
-        cmsg.setGuestOsType(msg.getGuestOsType());
-        cmsg.setArchitecture(msg.getArchitecture());
         if (msg.getVirtio() == null) {
             cmsg.setVirtio(false);
         } else {

--- a/configuration/src/main/java/org/zstack/configuration/ConfigurationManagerImpl.java
+++ b/configuration/src/main/java/org/zstack/configuration/ConfigurationManagerImpl.java
@@ -46,6 +46,7 @@ import org.zstack.header.vo.EO;
 import org.zstack.header.vo.NoView;
 import org.zstack.identity.AccountManager;
 import org.zstack.tag.TagManager;
+import org.zstack.utils.CollectionUtils;
 import org.zstack.utils.FieldUtils;
 import org.zstack.utils.ObjectUtils;
 import org.zstack.utils.TypeUtils;
@@ -508,6 +509,9 @@ public class ConfigurationManagerImpl extends AbstractService implements Configu
             if (at != null && at.validValues().length != 0) {
                 List<String> values = new ArrayList<>(at.validValues().length);
                 Collections.addAll(values, at.validValues());
+                sb.append(String.format("\n%s#valid values: %s", whiteSpace(8), values));
+            } else if (at != null && at.validEnums().length != 0) {
+                List<String> values = CollectionUtils.valuesForEnums(at.validEnums()).collect(Collectors.toList());
                 sb.append(String.format("\n%s#valid values: %s", whiteSpace(8), values));
             }
             if (at != null && at.validRegexValues() != null && at.validRegexValues().trim().equals("") == false) {

--- a/header/src/main/java/org/zstack/header/message/APIParam.java
+++ b/header/src/main/java/org/zstack/header/message/APIParam.java
@@ -12,6 +12,12 @@ public @interface APIParam {
 
     String[] validValues() default {};
 
+    /**
+     * Specify that this input parameter must be the value of some enumeration.
+     * Note: "validEnums" and {@link #validValues()} cannot be set simultaneously.
+     */
+    Class<? extends Enum<?>>[] validEnums() default {};
+
     String validRegexValues() default "";
 
     Class resourceType() default Object.class;

--- a/header/src/main/java/org/zstack/header/message/ApiMessageParamValidator.java
+++ b/header/src/main/java/org/zstack/header/message/ApiMessageParamValidator.java
@@ -2,6 +2,7 @@ package org.zstack.header.message;
 
 import org.springframework.core.Ordered;
 import org.springframework.util.StringUtils;
+import org.zstack.utils.CollectionUtils;
 import org.zstack.utils.DebugUtils;
 import org.zstack.utils.TypeUtils;
 import org.zstack.header.message.APIMessage.InvalidApiMessageException;
@@ -9,6 +10,7 @@ import org.zstack.header.message.APIMessage.InvalidApiMessageException;
 import java.lang.reflect.Field;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -43,12 +45,17 @@ public class ApiMessageParamValidator implements ApiMessageValidator, Ordered {
         }
     
         if (at.validValues().length > 0) {
-            if (value instanceof Collection) {
-                for (Object v : (Collection<?>) value) {
-                    validateValue(at.validValues(), v.toString(), f.getName(), getClass().getName());
-                }
-            } else {
-                validateValue(at.validValues(), value.toString(), f.getName(), getClass().getName());
+            Collection<?> values = (value instanceof Collection) ?
+                    (Collection<?>) value : Collections.singletonList(value);
+            for (Object v : values) {
+                validateValue(at.validValues(), v.toString(), f.getName(), getClass().getName());
+            }
+        } else if (at.validEnums().length > 0) {
+            Collection<?> values = (value instanceof Collection) ?
+                    (Collection<?>) value : Collections.singletonList(value);
+            final String[] validValues = CollectionUtils.valuesForEnums(at.validEnums()).toArray(String[]::new);
+            for (Object v : values) {
+                validateValue(validValues, v.toString(), f.getName(), getClass().getName());
             }
         }
     

--- a/header/src/main/java/org/zstack/header/vm/APICreateVmInstanceMsg.java
+++ b/header/src/main/java/org/zstack/header/vm/APICreateVmInstanceMsg.java
@@ -5,17 +5,16 @@ import org.zstack.header.cluster.ClusterVO;
 import org.zstack.header.configuration.DiskOfferingVO;
 import org.zstack.header.configuration.InstanceOfferingVO;
 import org.zstack.header.configuration.PythonClassInventory;
+import org.zstack.header.host.CpuArchitecture;
 import org.zstack.header.host.HostVO;
 import org.zstack.header.identity.Action;
 import org.zstack.header.image.ImageVO;
 import org.zstack.header.message.*;
 import org.zstack.header.network.l3.L3NetworkVO;
 import org.zstack.header.other.APIAuditor;
-import org.zstack.header.rest.APINoSee;
 import org.zstack.header.rest.RestRequest;
 import org.zstack.header.storage.primary.PrimaryStorageVO;
 import org.zstack.header.tag.TagResourceType;
-import org.zstack.header.volume.VolumeInventory;
 import org.zstack.header.zone.ZoneVO;
 
 import java.util.Collections;
@@ -203,7 +202,7 @@ public class APICreateVmInstanceMsg extends APICreateMessage implements APIAudit
     @APIParam(required = false, maxLength = 255)
     private String guestOsType;
 
-    @APIParam(required = false, maxLength = 32, validValues = {"x86_64", "aarch64", "mips64el", "loongarch64"})
+    @APIParam(required = false, maxLength = 32, validEnums = {CpuArchitecture.class})
     private String architecture;
 
     @APIParam(required = false)

--- a/header/src/main/java/org/zstack/header/vm/InstantiateNewCreatedVmInstanceMsg.java
+++ b/header/src/main/java/org/zstack/header/vm/InstantiateNewCreatedVmInstanceMsg.java
@@ -1,5 +1,6 @@
 package org.zstack.header.vm;
 
+import org.zstack.header.host.CpuArchitecture;
 import org.zstack.header.message.NeedReplyMessage;
 
 import java.util.ArrayList;
@@ -15,6 +16,7 @@ public class InstantiateNewCreatedVmInstanceMsg extends NeedReplyMessage impleme
     private String rootDiskOfferingUuid;
     private String hostUuid;
     private String strategy;
+    private CpuArchitecture architecture;
     private List<String> rootVolumeSystemTags;
     private List<String> dataVolumeSystemTags;
     private List<String> softAvoidHostUuids;
@@ -139,6 +141,14 @@ public class InstantiateNewCreatedVmInstanceMsg extends NeedReplyMessage impleme
 
     public String getStrategy() {
         return strategy;
+    }
+
+    public void setArchitecture(CpuArchitecture architecture) {
+        this.architecture = architecture;
+    }
+
+    public CpuArchitecture getArchitecture() {
+        return architecture;
     }
 
     public List<String> getRootVolumeSystemTags() {

--- a/header/src/main/java/org/zstack/header/vm/VmInstanceSpec.java
+++ b/header/src/main/java/org/zstack/header/vm/VmInstanceSpec.java
@@ -3,6 +3,7 @@ package org.zstack.header.vm;
 import org.apache.commons.collections.CollectionUtils;
 import org.zstack.header.allocator.AllocationScene;
 import org.zstack.header.configuration.DiskOfferingInventory;
+import org.zstack.header.host.CpuArchitecture;
 import org.zstack.header.host.HostInventory;
 import org.zstack.header.image.ImageBackupStorageRefInventory;
 import org.zstack.header.image.ImageConstant;
@@ -313,6 +314,7 @@ public class VmInstanceSpec implements Serializable {
     private String allocatedPrimaryStorageUuidForDataVolume;
     private final List<String> candidatePrimaryStorageUuidsForRootVolume = new ArrayList<>();
     private final List<String> candidatePrimaryStorageUuidsForDataVolume = new ArrayList<>();
+    private CpuArchitecture architecture;
     private String bootMode;
 
     private List<HostName> hostnames = new ArrayList<>();
@@ -796,6 +798,14 @@ public class VmInstanceSpec implements Serializable {
 
     public void setInstantiateResourcesSkipExisting(boolean instantiateResourcesSkipExisting) {
         this.instantiateResourcesSkipExisting = instantiateResourcesSkipExisting;
+    }
+
+    public CpuArchitecture getArchitecture() {
+        return architecture;
+    }
+
+    public void setArchitecture(CpuArchitecture architecture) {
+        this.architecture = architecture;
     }
 
     public String getBootMode() {

--- a/plugin/kvm/src/main/java/org/zstack/kvm/KVMAgentCommands.java
+++ b/plugin/kvm/src/main/java/org/zstack/kvm/KVMAgentCommands.java
@@ -586,6 +586,10 @@ public class KVMAgentCommands {
             return cpuArchitecture;
         }
 
+        public void setCpuArchitecture(String cpuArchitecture) {
+            this.cpuArchitecture = cpuArchitecture;
+        }
+
         public String getHostCpuModelName() {
             return hostCpuModelName;
         }

--- a/rest/src/main/resources/scripts/RestDocumentationGenerator.groovy
+++ b/rest/src/main/resources/scripts/RestDocumentationGenerator.groovy
@@ -2262,6 +2262,13 @@ ${fieldStr}
                         l.add("\"${it}\"")
                     }
                     values = "values (${l.join(",")})"
+                } else if (ap != null && ap.validEnums().length != 0) {
+                    def l = []
+                    def validValues = CollectionUtils.valuesForEnums(ap.validEnums()).collect(Collectors.toList())
+                    validValues.each {
+                        l.add("\"${it}\"")
+                    }
+                    values = "values (${l.join(",")})"
                 }
 
                 String desc = MUTUAL_FIELDS.get(af.name)

--- a/rest/src/main/resources/scripts/SdkApiTemplate.groovy
+++ b/rest/src/main/resources/scripts/SdkApiTemplate.groovy
@@ -13,11 +13,13 @@ import org.zstack.header.rest.SDK
 import org.zstack.header.rest.SDKPackage
 import org.zstack.rest.sdk.SdkTemplate
 import org.zstack.rest.sdk.SdkFile
+import org.zstack.utils.CollectionUtils
 import org.zstack.utils.FieldUtils
 import org.zstack.utils.Utils
 import org.zstack.utils.logging.CLogger
 
 import java.lang.reflect.Field
+import java.util.stream.Collectors
 
 /**
  * Created by xing5 on 2016/12/9.
@@ -136,6 +138,15 @@ class SdkApiTemplate implements SdkTemplate {
                     annotationFields.add(String.format("validValues = {%s}", { ->
                         def vv = []
                         for (String v : apiParam.validValues()) {
+                            vv.add("\"${v}\"")
+                        }
+                        return vv.join(",")
+                    }()))
+                } else if (apiParam.validEnums().length > 0) {
+                    annotationFields.add(String.format("validValues = {%s}", { ->
+                        def vv = []
+                        def validValues = CollectionUtils.valuesForEnums(apiParam.validEnums()).collect(Collectors.toList())
+                        for (String v : validValues) {
                             vv.add("\"${v}\"")
                         }
                         return vv.join(",")

--- a/testlib/src/main/java/org/zstack/testlib/PythonSdkGenerator.groovy
+++ b/testlib/src/main/java/org/zstack/testlib/PythonSdkGenerator.groovy
@@ -2,7 +2,6 @@ package org.zstack.testlib
 
 import com.google.common.base.Charsets
 import com.google.common.io.Resources
-import org.apache.commons.lang.StringEscapeUtils
 import org.apache.commons.lang.StringUtils
 import org.zstack.core.Platform
 import org.zstack.header.identity.SuppressCredentialCheck
@@ -10,9 +9,11 @@ import org.zstack.header.message.*
 import org.zstack.header.query.APIQueryMessage
 import org.zstack.header.rest.APINoSee
 import org.zstack.header.rest.RestRequest
+import org.zstack.utils.CollectionUtils
 import org.zstack.utils.FieldUtils
 
 import java.lang.reflect.Field
+import java.util.stream.Collectors
 
 /**
  * Created by xing5 on 2017/3/31.
@@ -46,6 +47,9 @@ class PythonSdkGenerator {
                 ap.add("required=${toPythonBoolean(apiParam.required())}")
                 if (apiParam.validValues().length > 0) {
                     ap.add("valid_values=[${apiParam.validValues().collect { "'" + it + "'" }.join(",")}]")
+                } else if (apiParam.validEnums().length > 0) {
+                    def validValues = CollectionUtils.valuesForEnums(apiParam.validEnums()).collect(Collectors.toList())
+                    ap.add("valid_values=[${validValues.collect { "'" + it + "'" }.join(",")}]")
                 }
                 if (!apiParam.validRegexValues().isEmpty()) {
                     String regex = apiParam.validRegexValues().replace("'", "\\\'")

--- a/utils/src/main/java/org/zstack/utils/CollectionUtils.java
+++ b/utils/src/main/java/org/zstack/utils/CollectionUtils.java
@@ -5,10 +5,12 @@ import org.zstack.utils.function.Function;
 import org.zstack.utils.function.ListFunction;
 import org.zstack.utils.logging.CLogger;
 
+import java.lang.reflect.Method;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  */
@@ -160,5 +162,21 @@ public class CollectionUtils {
             }
         }
         return false;
+    }
+
+    public static Stream<String> valuesForEnums(Class<? extends Enum<?>>[] enumClasses) {
+        return Arrays.stream(enumClasses)
+                    .flatMap(CollectionUtils::valuesForEnum)
+                    .distinct();
+    }
+
+    public static Stream<String> valuesForEnum(Class<? extends Enum<?>> enumClass) {
+        try {
+            final Method method = enumClass.getMethod("values");
+            final Object[] strings = (Object[]) method.invoke(null);
+            return Arrays.stream(strings).map(Object::toString);
+        } catch (Exception e) {
+            throw new RuntimeException("failed to parse valid values from enumClass: " + enumClass, e);
+        }
     }
 }


### PR DESCRIPTION
When selecting the assigned hosts for a newly created VM,
we will select the hosts that match the architecture defined
in APICreateVmInstanceMsg. If no architecture is specified,
assign hosts that match the architecture information of the
ImageVO.

Resolves: ZSV-3410

Change-Id: I73797765646e796f786d696861696e61686d7278

sync from gitlab !5448

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 优化了虚拟机实例化过程中的架构设置逻辑，提高了兼容性和性能。

- **Bug修复**
  - 修复了虚拟机实例在特定条件下无法正确选择集群的问题。

- **文档**
  - 更新了相关文档，以反映虚拟机CPU架构选择的新功能。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->