### PR TITLE
<fix>[shareblock]:Fix create snapshot group failure residual data

### DIFF
--- a/header/src/main/java/org/zstack/header/vm/VmInstanceVO.java
+++ b/header/src/main/java/org/zstack/header/vm/VmInstanceVO.java
@@ -8,10 +8,7 @@ import org.zstack.header.image.ImageVO;
 import org.zstack.header.vm.cdrom.VmCdRomVO;
 import org.zstack.header.vo.*;
 import org.zstack.header.vo.EntityGraph;
-import org.zstack.header.volume.Volume;
-import org.zstack.header.volume.VolumeAO;
-import org.zstack.header.volume.VolumeInventory;
-import org.zstack.header.volume.VolumeVO;
+import org.zstack.header.volume.*;
 import org.zstack.header.zone.ZoneVO;
 
 import javax.persistence.*;
@@ -107,6 +104,13 @@ public class VmInstanceVO extends VmInstanceAO implements OwnedByAccount, ToInve
 
     public Set<VolumeVO> getAllDiskVolumes() {
         return getAllVolumes(VolumeVO::isDisk);
+    }
+
+    public VolumeVO getMemoryVolume() {
+        if (allVolumes == null) {
+            return null;
+        }
+        return allVolumes.stream().filter(v -> v.getType().equals(VolumeType.Memory)).findAny().orElse(null);
     }
 
     public VolumeVO getRootVolume() {

--- a/header/src/main/java/org/zstack/header/volume/VolumeAO.java
+++ b/header/src/main/java/org/zstack/header/volume/VolumeAO.java
@@ -192,6 +192,10 @@ public class VolumeAO extends ResourceVO implements ShadowEntity {
         return type == VolumeType.Data;
     }
 
+    public boolean isMemoryVolume() {
+        return type == VolumeType.Memory;
+    }
+
     public long getSize() {
         return size;
     }


### PR DESCRIPTION
Added interface for obtaining memory type disk

Resolves: ZSTAC-59805

Change-Id: I6467598058676e6d666175747477786a71677963

sync from gitlab !5469

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 新增了内存卷类型判断的方法。
  - 在虚拟机信息中添加了获取特定类型卷和所有磁盘卷的方法。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->