### PR TITLE
<fix>[kvm]: filter out stopped VM when invoke getVirtualizerInfo

### DIFF
--- a/plugin/kvm/src/main/java/org/zstack/kvm/hypervisor/datatype/ResourceHypervisorInfo.java
+++ b/plugin/kvm/src/main/java/org/zstack/kvm/hypervisor/datatype/ResourceHypervisorInfo.java
@@ -75,6 +75,7 @@ public class ResourceHypervisorInfo {
                     String type = tuple.get(1, String.class);
                     return mapResourceHypervisorInfo(uuid, type, uuidVoMap.get(uuid));
                 })
+                .filter(Objects::nonNull)
                 .collect(Collectors.toList());
 
         fillMatchTargetInfo(results);
@@ -82,6 +83,11 @@ public class ResourceHypervisorInfo {
     }
 
     private static ResourceHypervisorInfo mapResourceHypervisorInfo(String uuid, String type, KvmHypervisorInfoVO vo) {
+        if (vo == null) {
+            // maybe vm is in stopped states
+            return null;
+        }
+
         ResourceHypervisorInfo target = new ResourceHypervisorInfo();
         target.uuid = uuid;
         target.resourceType = type;


### PR DESCRIPTION
Resolves: ZSTAC-61743

Change-Id: I657a6d777363616c7a6a68727a6a707a7672676e

sync from gitlab !5401

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Bug修复**
  - 优化了虚拟机停止状态下的资源映射逻辑，增加了空值检查，确保稳定性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->