### PR TITLE
<feature>[compute]: get the candidate image according to ps

### DIFF
--- a/conf/serviceConfig/hostAllocator.xml
+++ b/conf/serviceConfig/hostAllocator.xml
@@ -14,4 +14,8 @@
     <message>
         <name>org.zstack.header.image.APIGetCandidateBackupStorageForCreatingImageMsg</name>
     </message>
+
+    <message>
+        <name>org.zstack.header.image.APIGetCandidateImagesForCreatingVmMsg</name>
+    </message>
 </service>

--- a/header/src/main/java/org/zstack/header/image/APIGetCandidateImagesForCreatingVmMsg.java
+++ b/header/src/main/java/org/zstack/header/image/APIGetCandidateImagesForCreatingVmMsg.java
@@ -1,0 +1,35 @@
+package org.zstack.header.image;
+
+import org.springframework.http.HttpMethod;
+import org.zstack.header.identity.Action;
+import org.zstack.header.message.APIParam;
+import org.zstack.header.message.APISyncCallMessage;
+import org.zstack.header.rest.RestRequest;
+import org.zstack.header.storage.primary.PrimaryStorageVO;
+
+
+@Action(category = ImageConstant.ACTION_CATEGORY, names = {"read"})
+@RestRequest(
+        path = "/images/primaryStorage/{primaryStorageUuid}/candidate-image",
+        method = HttpMethod.GET,
+        responseClass = APIGetCandidateImagesForCreatingVmReply.class
+)
+public class APIGetCandidateImagesForCreatingVmMsg extends APISyncCallMessage {
+    @APIParam(resourceType = PrimaryStorageVO.class)
+    private String primaryStorageUuid;
+
+    public String getPrimaryStorageUuid() {
+        return primaryStorageUuid;
+    }
+
+    public void setPrimaryStorageUuid(String primaryStorageUuid) {
+        this.primaryStorageUuid = primaryStorageUuid;
+    }
+
+    public static APIGetCandidateImagesForCreatingVmMsg __example__() {
+        APIGetCandidateImagesForCreatingVmMsg msg = new APIGetCandidateImagesForCreatingVmMsg();
+        msg.setPrimaryStorageUuid(uuid());
+        return msg;
+    }
+
+}

--- a/header/src/main/java/org/zstack/header/image/APIGetCandidateImagesForCreatingVmMsgDoc_zh_cn.groovy
+++ b/header/src/main/java/org/zstack/header/image/APIGetCandidateImagesForCreatingVmMsgDoc_zh_cn.groovy
@@ -1,0 +1,58 @@
+package org.zstack.header.image
+
+import org.zstack.header.image.APIGetCandidateImagesForCreatingVmReply
+
+doc {
+    title "GetCandidateImagesForCreatingVm"
+
+    category "host.allocator"
+
+    desc """获取用于创建云主机的候选镜像"""
+
+    rest {
+        request {
+			url "GET /v1/images/primaryStorage/{primaryStorageUuid}/candidate-image"
+
+			header (Authorization: 'OAuth the-session-uuid')
+
+            clz APIGetCandidateImagesForCreatingVmMsg.class
+
+            desc """"""
+            
+			params {
+
+				column {
+					name "primaryStorageUuid"
+					enclosedIn ""
+					desc "主存储UUID"
+					location "url"
+					type "String"
+					optional false
+					since "4.1.1"
+				}
+				column {
+					name "systemTags"
+					enclosedIn ""
+					desc "系统标签"
+					location "query"
+					type "List"
+					optional true
+					since "4.1.1"
+				}
+				column {
+					name "userTags"
+					enclosedIn ""
+					desc "用户标签"
+					location "query"
+					type "List"
+					optional true
+					since "4.1.1"
+				}
+			}
+        }
+
+        response {
+            clz APIGetCandidateImagesForCreatingVmReply.class
+        }
+    }
+}

--- a/header/src/main/java/org/zstack/header/image/APIGetCandidateImagesForCreatingVmReply.java
+++ b/header/src/main/java/org/zstack/header/image/APIGetCandidateImagesForCreatingVmReply.java
@@ -1,0 +1,26 @@
+package org.zstack.header.image;
+
+import org.zstack.header.message.APIReply;
+import org.zstack.header.rest.RestResponse;
+
+import java.util.List;
+
+
+@RestResponse(allTo = "inventories")
+public class APIGetCandidateImagesForCreatingVmReply extends APIReply {
+    private List<ImageInventory> inventories;
+
+    public List<ImageInventory> getInventories() {
+        return inventories;
+    }
+
+    public void setInventories(List<ImageInventory> inventories) {
+        this.inventories = inventories;
+    }
+
+    public static APIGetCandidateImagesForCreatingVmReply __example__() {
+        APIGetCandidateImagesForCreatingVmReply reply = new APIGetCandidateImagesForCreatingVmReply();
+        return reply;
+    }
+
+}

--- a/header/src/main/java/org/zstack/header/image/APIGetCandidateImagesForCreatingVmReplyDoc_zh_cn.groovy
+++ b/header/src/main/java/org/zstack/header/image/APIGetCandidateImagesForCreatingVmReplyDoc_zh_cn.groovy
@@ -1,0 +1,32 @@
+package org.zstack.header.image
+
+import org.zstack.header.image.ImageInventory
+import org.zstack.header.errorcode.ErrorCode
+
+doc {
+
+	title "获取用于创建云主机的候选镜像返回"
+
+	ref {
+		name "inventories"
+		path "org.zstack.header.image.APIGetCandidateImagesForCreatingVmReply.inventories"
+		desc "候选镜像"
+		type "List"
+		since "4.1.1"
+		clz ImageInventory.class
+	}
+	field {
+		name "success"
+		desc ""
+		type "boolean"
+		since "4.1.1"
+	}
+	ref {
+		name "error"
+		path "org.zstack.header.image.APIGetCandidateImagesForCreatingVmReply.error"
+		desc "错误码，若不为null，则表示操作失败, 操作成功时该字段为null",false
+		type "ErrorCode"
+		since "4.1.1"
+		clz ErrorCode.class
+	}
+}

--- a/sdk/src/main/java/org/zstack/sdk/GetCandidateImagesForCreatingVmAction.java
+++ b/sdk/src/main/java/org/zstack/sdk/GetCandidateImagesForCreatingVmAction.java
@@ -1,0 +1,95 @@
+package org.zstack.sdk;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.zstack.sdk.*;
+
+public class GetCandidateImagesForCreatingVmAction extends AbstractAction {
+
+    private static final HashMap<String, Parameter> parameterMap = new HashMap<>();
+
+    private static final HashMap<String, Parameter> nonAPIParameterMap = new HashMap<>();
+
+    public static class Result {
+        public ErrorCode error;
+        public org.zstack.sdk.GetCandidateImagesForCreatingVmResult value;
+
+        public Result throwExceptionIfError() {
+            if (error != null) {
+                throw new ApiException(
+                    String.format("error[code: %s, description: %s, details: %s]", error.code, error.description, error.details)
+                );
+            }
+            
+            return this;
+        }
+    }
+
+    @Param(required = true, nonempty = false, nullElements = false, emptyString = true, noTrim = false)
+    public java.lang.String primaryStorageUuid;
+
+    @Param(required = false)
+    public java.util.List systemTags;
+
+    @Param(required = false)
+    public java.util.List userTags;
+
+    @Param(required = false)
+    public String sessionId;
+
+    @Param(required = false)
+    public String accessKeyId;
+
+    @Param(required = false)
+    public String accessKeySecret;
+
+    @Param(required = false)
+    public String requestIp;
+
+
+    private Result makeResult(ApiResult res) {
+        Result ret = new Result();
+        if (res.error != null) {
+            ret.error = res.error;
+            return ret;
+        }
+        
+        org.zstack.sdk.GetCandidateImagesForCreatingVmResult value = res.getResult(org.zstack.sdk.GetCandidateImagesForCreatingVmResult.class);
+        ret.value = value == null ? new org.zstack.sdk.GetCandidateImagesForCreatingVmResult() : value; 
+
+        return ret;
+    }
+
+    public Result call() {
+        ApiResult res = ZSClient.call(this);
+        return makeResult(res);
+    }
+
+    public void call(final Completion<Result> completion) {
+        ZSClient.call(this, new InternalCompletion() {
+            @Override
+            public void complete(ApiResult res) {
+                completion.complete(makeResult(res));
+            }
+        });
+    }
+
+    protected Map<String, Parameter> getParameterMap() {
+        return parameterMap;
+    }
+
+    protected Map<String, Parameter> getNonAPIParameterMap() {
+        return nonAPIParameterMap;
+    }
+
+    protected RestInfo getRestInfo() {
+        RestInfo info = new RestInfo();
+        info.httpMethod = "GET";
+        info.path = "/images/primaryStorage/{primaryStorageUuid}/candidate-image";
+        info.needSession = true;
+        info.needPoll = false;
+        info.parameterName = "";
+        return info;
+    }
+
+}

--- a/sdk/src/main/java/org/zstack/sdk/GetCandidateImagesForCreatingVmResult.java
+++ b/sdk/src/main/java/org/zstack/sdk/GetCandidateImagesForCreatingVmResult.java
@@ -1,0 +1,14 @@
+package org.zstack.sdk;
+
+
+
+public class GetCandidateImagesForCreatingVmResult {
+    public java.util.List inventories;
+    public void setInventories(java.util.List inventories) {
+        this.inventories = inventories;
+    }
+    public java.util.List getInventories() {
+        return this.inventories;
+    }
+
+}

--- a/testlib/src/main/java/org/zstack/testlib/ApiHelper.groovy
+++ b/testlib/src/main/java/org/zstack/testlib/ApiHelper.groovy
@@ -18566,6 +18566,33 @@ abstract class ApiHelper {
     }
 
 
+    def getCandidateImagesForCreatingVm(@DelegatesTo(strategy = Closure.OWNER_FIRST, value = org.zstack.sdk.GetCandidateImagesForCreatingVmAction.class) Closure c) {
+        def a = new org.zstack.sdk.GetCandidateImagesForCreatingVmAction()
+        a.sessionId = Test.currentEnvSpec?.session?.uuid
+        c.resolveStrategy = Closure.OWNER_FIRST
+        c.delegate = a
+        c()
+
+
+        if (System.getProperty("apipath") != null) {
+            if (a.apiId == null) {
+                a.apiId = Platform.uuid
+            }
+
+            def tracker = new ApiPathTracker(a.apiId)
+            def out = errorOut(a.call())
+            def path = tracker.getApiPath()
+            if (!path.isEmpty()) {
+                Test.apiPaths[a.class.name] = path.join(" --->\n")
+            }
+
+            return out
+        } else {
+            return errorOut(a.call())
+        }
+    }
+
+
     def getCandidateInterfaceVlanIds(@DelegatesTo(strategy = Closure.OWNER_FIRST, value = org.zstack.sdk.GetCandidateInterfaceVlanIdsAction.class) Closure c) {
         def a = new org.zstack.sdk.GetCandidateInterfaceVlanIdsAction()
         a.sessionId = Test.currentEnvSpec?.session?.uuid


### PR DESCRIPTION
APIImpact

Resolves: ZSV-4237

Change-Id: I696a78777061727168747174746479626f747a78

sync from gitlab !5579

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 新增了根据指定主存储 UUID 查询创建虚拟机备选镜像的功能。

- **文档**
  - 提供了新 API `GetCandidateImagesForCreatingVm` 和 `APIGetCandidateImagesForCreatingVmReply` 的中文文档，包括 REST API 的使用细节和示例。

- **测试**
  - 测试库增加了支持新 API 的方法，以便进行集成测试。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->