### PR TITLE
<fix>[storage]: update reference after mark snapshot as volume

### DIFF
--- a/storage/src/main/java/org/zstack/storage/snapshot/VolumeSnapshotTreeBase.java
+++ b/storage/src/main/java/org/zstack/storage/snapshot/VolumeSnapshotTreeBase.java
@@ -61,7 +61,6 @@ import org.zstack.header.volume.*;
 import org.zstack.longjob.LongJobUtils;
 import org.zstack.storage.primary.PrimaryStorageCapacityUpdater;
 import org.zstack.storage.primary.PrimaryStorageGlobalProperty;
-import org.zstack.storage.snapshot.group.VolumeSnapshotGroupOperationValidator;
 import org.zstack.storage.snapshot.reference.VolumeSnapshotReferenceUtils;
 import org.zstack.storage.volume.FireSnapShotCanonicalEvent;
 import org.zstack.tag.TagManager;
@@ -2318,8 +2317,11 @@ public class VolumeSnapshotTreeBase {
                             logger.debug(String.format("reset latest snapshot of tree[uuid:%s] to snapshot[uuid:%s]",
                                     currentRoot.getTreeUuid(), currentRoot.getParentUuid()));
                         }
+
+                        VolumeSnapshotReferenceUtils.updateReferenceAfterMarkSnapshotAsVolume(currentRoot);
                     }
                 }.execute();
+
                 cleanup();
 
                 bus.reply(msg, reply);

--- a/storage/src/main/java/org/zstack/storage/snapshot/reference/VolumeSnapshotReferenceUtils.java
+++ b/storage/src/main/java/org/zstack/storage/snapshot/reference/VolumeSnapshotReferenceUtils.java
@@ -281,6 +281,22 @@ public class VolumeSnapshotReferenceUtils {
         }
     }
 
+    public static void updateReferenceAfterMarkSnapshotAsVolume(VolumeSnapshotVO snapshot) {
+        if (VolumeSnapshotConstant.STORAGE_SNAPSHOT_TYPE.toString().equals(snapshot.getType())) {
+            return;
+        }
+
+        VolumeSnapshotReferenceVO ref = getVolumeBackingRef(snapshot.getVolumeUuid());
+        if (ref != null && snapshot.getPrimaryStorageInstallPath().equals(ref.getReferenceInstallUrl())) {
+            SQL.New(VolumeSnapshotReferenceVO.class).eq(VolumeSnapshotReferenceVO_.id, ref.getId())
+                    .set(VolumeSnapshotReferenceVO_.referenceUuid, snapshot.getVolumeUuid())
+                    .set(VolumeSnapshotReferenceVO_.referenceType, VolumeVO.class.getSimpleName())
+                    .update();
+            logger.debug(String.format("update volume snapshot reference[referVolumeSnapshotUuid:%s, referVolumeUuid:%s] after mark snapshot as volume",
+                    snapshot.getUuid(), snapshot.getVolumeUuid()));
+        }
+    }
+
     public static void cleanTemporaryImageReference(List<ImageInventory> images) {
         if (!PrimaryStorageGlobalProperty.USE_SNAPSHOT_AS_INCREMENTAL_CACHE || CollectionUtils.isEmpty(images)) {
             return;


### PR DESCRIPTION
Resolves: ZSV-4233

Change-Id: I6d666e626c7a75756f766167706373687a786577

sync from gitlab !5593

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新功能**
  - 在应用中增加了快照标记为卷后更新卷快照引用的功能。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->