### PR TITLE
<fix>[zwatch]: management-server-exporter rebuild

### DIFF
--- a/storage/src/main/java/org/zstack/storage/primary/AbstractUsageReport.java
+++ b/storage/src/main/java/org/zstack/storage/primary/AbstractUsageReport.java
@@ -203,7 +203,7 @@ public abstract class AbstractUsageReport<T extends PrimaryStorageHistoricalUsag
         if (lastRecordDate == null) {
             return new ArrayList<>();
         }
-        if (lastRecordDate < now) {
+        if (lastRecordDate < now && !percents.isEmpty()) {
             percents.remove(0);
         }
 


### PR DESCRIPTION
1. fix AbstractUsageReport.getFutureForecastsInPercent(resourceUuid) of IndexOutOfBoundsException
2. improve PrometheusCollector print log

Resolves: ZSTAC-62333

Change-Id: I7168666f74616269706e6f6b666a7a7a63647476

sync from gitlab !5602

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - 修正了预测百分比计算逻辑，现在在尝试移除元素前会检查百分比列表是否为空。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->