### PR TITLE
<fix>[header]: add field VmSchedHistoryInventory.reason

### DIFF
--- a/conf/db/upgrade/V2024.4.1.6__schema.sql
+++ b/conf/db/upgrade/V2024.4.1.6__schema.sql
@@ -1,4 +1,0 @@
--- in version zsv_4.1.6
--- from issue: (feature) ZSV-4408
-
-ALTER TABLE `zstack`.`VmSchedHistoryVO` ADD COLUMN `reason` text DEFAULT NULL;

--- a/conf/db/upgrade/V4.8.0.2__schema.sql
+++ b/conf/db/upgrade/V4.8.0.2__schema.sql
@@ -1,5 +1,10 @@
+-- in version zsv_4.1.6
+
 ALTER TABLE AuditsVO ADD COLUMN `resourceName` varchar(255) DEFAULT NULL;
 
 ALTER TABLE `zstack`.`HostNetworkInterfaceVO` ADD COLUMN `deviceName` VARCHAR(64) DEFAULT NULL AFTER `deviceId`;
 ALTER TABLE `zstack`.`HostNetworkInterfaceVO` ADD COLUMN `vendorName` VARCHAR(64) DEFAULT NULL AFTER `deviceName`;
 ALTER TABLE `zstack`.`HostNetworkInterfaceVO` ADD COLUMN `subvendorName` VARCHAR(64) DEFAULT NULL AFTER `subdeviceId`;
+
+-- from issue: (feature) ZSV-4408
+ALTER TABLE `zstack`.`VmSchedHistoryVO` ADD COLUMN `reason` text DEFAULT NULL;

--- a/header/src/main/java/org/zstack/header/vm/VmSchedHistoryInventory.java
+++ b/header/src/main/java/org/zstack/header/vm/VmSchedHistoryInventory.java
@@ -3,7 +3,6 @@ package org.zstack.header.vm;
 import org.zstack.header.configuration.PythonClassInventory;
 import org.zstack.header.query.ExpandedQueries;
 import org.zstack.header.query.ExpandedQuery;
-import org.zstack.header.rest.APINoSee;
 import org.zstack.header.search.Inventory;
 import org.zstack.header.zone.ZoneInventory;
 
@@ -24,6 +23,7 @@ public class VmSchedHistoryInventory implements Serializable {
     private String vmInstanceUuid;
     private String accountUuid;
     private String schedType;
+    private String reason;
     private Boolean success;
     private String lastHostUuid;
     private String destHostUuid;
@@ -31,7 +31,7 @@ public class VmSchedHistoryInventory implements Serializable {
     private Timestamp lastOpDate;
 
     /**
-     * @desc uuid of zone this vm is in. See :ref:`ZoneInventory`
+     * uuid of zone this vm is in. See :ref:`ZoneInventory`
      */
     private String zoneUuid;
 
@@ -44,6 +44,7 @@ public class VmSchedHistoryInventory implements Serializable {
         inv.setVmInstanceUuid(vo.getVmInstanceUuid());
         inv.setAccountUuid(vo.getAccountUuid());
         inv.setSchedType(vo.getSchedType());
+        inv.setReason(vo.getReason());
         inv.setSuccess(vo.getSuccess());
         inv.setLastHostUuid(vo.getLastHostUuid());
         inv.setDestHostUuid(vo.getDestHostUuid());
@@ -95,6 +96,14 @@ public class VmSchedHistoryInventory implements Serializable {
 
     public void setSchedType(String schedType) {
         this.schedType = schedType;
+    }
+
+    public String getReason() {
+        return reason;
+    }
+
+    public void setReason(String reason) {
+        this.reason = reason;
     }
 
     public Boolean getSuccess() {

--- a/header/src/main/java/org/zstack/header/vm/VmSchedHistoryInventoryDoc_zh_cn.groovy
+++ b/header/src/main/java/org/zstack/header/vm/VmSchedHistoryInventoryDoc_zh_cn.groovy
@@ -27,6 +27,12 @@ doc {
 		since "4.4.24"
 	}
 	field {
+		name "reason"
+		desc "调度的详情，具体说明为什么进行虚拟机的调度"
+		type "String"
+		since "zsv 4.1.6"
+	}
+	field {
 		name "success"
 		desc "是否成功"
 		type "Boolean"

--- a/sdk/src/main/java/org/zstack/sdk/VmSchedHistoryInventory.java
+++ b/sdk/src/main/java/org/zstack/sdk/VmSchedHistoryInventory.java
@@ -36,6 +36,14 @@ public class VmSchedHistoryInventory  {
         return this.schedType;
     }
 
+    public java.lang.String reason;
+    public void setReason(java.lang.String reason) {
+        this.reason = reason;
+    }
+    public java.lang.String getReason() {
+        return this.reason;
+    }
+
     public java.lang.Boolean success;
     public void setSuccess(java.lang.Boolean success) {
         this.success = success;


### PR DESCRIPTION
Resolves: ZSV-4408

Change-Id: I787264746776647677706576796a6f6e6566627a

sync from gitlab !5716

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 在虚拟机调度历史信息中添加了一个新字段“原因”，用以说明虚拟机调度的详细原因。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->