### PR TITLE
i<fix>[rest]: get clientIp by `X-Request-Ip`

### DIFF
--- a/rest/src/main/java/org/zstack/rest/RestServer.java
+++ b/rest/src/main/java/org/zstack/rest/RestServer.java
@@ -1408,7 +1408,10 @@ public class RestServer implements Component, CloudBusEventListener {
 
     private String getClientIP(HttpServletRequest request) {
         if (request == null) return "";
-        String ipAddress = request.getHeader("X-Forwarded-For");
+        String ipAddress = request.getHeader("X-Request-Ip");
+        if (ipAddress == null || ipAddress.isEmpty() || "unknown".equalsIgnoreCase(ipAddress)) {
+            ipAddress = request.getHeader("X-Forwarded-For");
+        }
         if (ipAddress == null || ipAddress.isEmpty() || "unknown".equalsIgnoreCase(ipAddress)) {
             ipAddress = request.getHeader("Proxy-Client-IP");
         }


### PR DESCRIPTION
get client ip by http request header of `X-Request-Ip`

Resolves: ZSV-4451

Change-Id: I6270687563736b6462756563746f6d797a777a67

sync from gitlab !5729

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **功能更新**
  - 更新了从HTTP请求头获取客户端IP地址的逻辑，优先使用“X-Request-Ip”头，如果未找到或为空，则使用“X-Forwarded-For”头。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->