### PR TITLE
<fix>[storage]: fix usage collection on two management nodes

### DIFF
--- a/plugin/localstorage/src/main/java/org/zstack/storage/primary/local/LocalStorageHostUsageReport.java
+++ b/plugin/localstorage/src/main/java/org/zstack/storage/primary/local/LocalStorageHostUsageReport.java
@@ -16,6 +16,8 @@ public class LocalStorageHostUsageReport extends
 
     @Override
     public void managementNodeReady() {
-        start();
+        // UI only show localStoragePrimaryStorage Capacity Usage, don't show the localHost Capacity Usage.
+        // therefore, do not need to collect and forecast localHost Capacity Usage.
+        //start();
     }
 }

--- a/storage/src/main/java/org/zstack/storage/primary/PrimaryStorageGlobalConfig.java
+++ b/storage/src/main/java/org/zstack/storage/primary/PrimaryStorageGlobalConfig.java
@@ -46,4 +46,7 @@ public class PrimaryStorageGlobalConfig {
     @BindResourceConfig({PrimaryStorageVO.class})
     @GlobalConfigDef(defaultValue = "false", type = Boolean.class, description = "Whether undo temp snapshot after template uploaded")
     public static GlobalConfig UNDO_TEMP_SNAPSHOT = new GlobalConfig(CATEGORY, "undo.tempSnapshot");
+    @GlobalConfigValidation(numberGreaterThan = 1)
+    @GlobalConfigDef(defaultValue = "1", type = Long.class)
+    public static GlobalConfig COLLECT_AND_FORECAST_INTERVAL = new GlobalConfig(CATEGORY, "collect.forecast.interval");
 }


### PR DESCRIPTION
Resolves: ZSV-4477

Change-Id: I646c676d6b75777261716a6d706262777a6c6d68

sync from gitlab !5740

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **功能更新**
	- 优化了本地存储容量使用的收集和预测功能，以改善用户界面显示。

- **新特性**
	- 新增全局配置项，允许自定义存储容量数据收集和预测的间隔时间。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->