### PR TITLE
<fix>[storage]: fix snapshot concurrence deletion

### DIFF
--- a/storage/src/main/java/org/zstack/storage/snapshot/group/VolumeSnapshotGroupBase.java
+++ b/storage/src/main/java/org/zstack/storage/snapshot/group/VolumeSnapshotGroupBase.java
@@ -212,7 +212,7 @@ public class VolumeSnapshotGroupBase implements VolumeSnapshotGroup {
             logger.debug(String.format("skip snapshots not belong to origin vm[uuid:%s]", self.getVmInstanceUuid()));
         }
 
-        new While<>(snapshots).all((snapshot, compl) -> {
+        new While<>(snapshots).each((snapshot, compl) -> {
             DeleteVolumeSnapshotMsg rmsg = new DeleteVolumeSnapshotMsg();
             rmsg.setSnapshotUuid(snapshot.getUuid());
             rmsg.setVolumeUuid(snapshot.getVolumeUuid());


### PR DESCRIPTION
concurrency deletion on qemu 6.2 may cause vm crash.

Resolves: ZSTAC-63255

Change-Id: I6574736577737173626b7263646c78716c766b76

sync from gitlab !5790

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **重构**
	- 优化了快照处理的控制流程，通过在循环迭代快照时将 `all` 方法替换为 `each`。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->