### PR TITLE
<fix>[Kvm]: move refresh security group to host afterConnected extension

### DIFF
--- a/conf/springConfigXml/Kvm.xml
+++ b/conf/springConfigXml/Kvm.xml
@@ -91,7 +91,7 @@
     <bean id="KVMSecurityGroupBackend" class="org.zstack.kvm.KVMSecurityGroupBackend">
         <zstack:plugin>
             <zstack:extension interface="org.zstack.network.securitygroup.SecurityGroupHypervisorBackend" />
-            <zstack:extension interface="org.zstack.kvm.KVMHostConnectExtensionPoint" />
+            <zstack:extension interface="org.zstack.kvm.HostAfterConnectedExtensionPoint" />
         </zstack:plugin>
     </bean>	
 

--- a/test/src/test/resources/springConfigXml/Kvm.xml
+++ b/test/src/test/resources/springConfigXml/Kvm.xml
@@ -85,7 +85,7 @@
     <bean id="KVMSecurityGroupBackend" class="org.zstack.kvm.KVMSecurityGroupBackend">
         <zstack:plugin>
             <zstack:extension interface="org.zstack.network.securitygroup.SecurityGroupHypervisorBackend" />
-            <zstack:extension interface="org.zstack.kvm.KVMHostConnectExtensionPoint" />
+            <zstack:extension interface="org.zstack.kvm.HostAfterConnectedExtensionPoint" />
         </zstack:plugin>
     </bean>	
 


### PR DESCRIPTION
Resolves: ZSTAC-62915

Change-Id: I6c6377746e6870616c65656d6a697a7a66757867

sync from gitlab !5797

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **重构**
	- 优化了KVM安全组后端的代码结构，提高了代码的可读性和维护性。
	- 改进了主机连接后的安全组规则刷新机制，确保更加高效和准确地应用安全规则。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->