### PR TITLE
<doc>[conf]: add i18n for revoking sharing USB devices

### DIFF
--- a/conf/i18n/messages_en_US.properties
+++ b/conf/i18n/messages_en_US.properties
@@ -13498,6 +13498,10 @@ cannot\ disable\ usb\ device[uuid\:%s]\ when\ it's\ attached\ to\ a\ vm\ instanc
 # args: VmInstanceUuid
 please\ umount\ all\ usb\ devices\ of\ the\ vm[%s]\ and\ try\ again = please umount all usb devices of the vm[{0}] and try again
 
+# at: src/main/java/org/zstack/usbDevice/UsbDeviceApiInterceptor.java:341
+# args: usbDeviceUuid, usbName, hostUuid, hostName, accountUuid, accountName, vmInstanceUuid, vmName
+the\ usb\ devices[uuid\:%s,\ name\:%s]\ in\ host[uuid\:%s,\ name\:%s]\ is\ occupied\ by\ account[uuid\:%s,\ name\:%s]\ and\ vm[uuid\:%s,\ name\:%s] = failed to revoke sharing USB devices: the USB device[uuid:{0}, name:{1}] in host[uuid:{2}, name:{3}] is occupied by virtual machine[uuid:{6}, name:{7}] owner by account[uuid:{4}, name:{5}]
+
 # at: src/main/java/org/zstack/usbDevice/UsbDeviceManager.java:795
 # args: msg.getVmInstanceUuid()
 cannot\ migrate\ vm[uuid\:%s]\ because\ there\ are\ pci\ devices\ attached = cannot migrate vm[uuid:{0}] because there are pci devices attached

--- a/conf/i18n/messages_zh_CN.properties
+++ b/conf/i18n/messages_zh_CN.properties
@@ -13498,6 +13498,10 @@ cannot\ disable\ usb\ device[uuid\:%s]\ when\ it's\ attached\ to\ a\ vm\ instanc
 # args: VmInstanceUuid
 please\ umount\ all\ usb\ devices\ of\ the\ vm[%s]\ and\ try\ again = 请卸载云主机[{0}]的所有USB设备，然后重试
 
+# at: src/main/java/org/zstack/usbDevice/UsbDeviceApiInterceptor.java:341
+# args: usbDeviceUuid, usbName, hostUuid, hostName, accountUuid, accountName, vmInstanceUuid, vmName
+the\ usb\ devices[uuid\:%s,\ name\:%s]\ in\ host[uuid\:%s,\ name\:%s]\ is\ occupied\ by\ account[uuid\:%s,\ name\:%s]\ and\ vm[uuid\:%s,\ name\:%s] = 在物理机[uuid:{2}, 名称:{3}]上的USB设备[uuid:{0}, 名称:{1}]被用户[uuid:{4}, 名称:{5}]的虚拟机[uuid:{6}, 名称:{7}]占用，无法撤销分享
+
 # at: src/main/java/org/zstack/usbDevice/UsbDeviceManager.java:795
 # args: msg.getVmInstanceUuid()
 cannot\ migrate\ vm[uuid\:%s]\ because\ there\ are\ pci\ devices\ attached = 云主机[uuid:{0}]加载了pci设备无法迁移


### PR DESCRIPTION
Try to revoke USB device used by other users will raise error

Related: ZSV-4726

Change-Id: I6e76707562646d6d716677636f617470626a6a72

sync from gitlab !5843

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新功能**
	- 增加了与USB设备共享和所有权相关的新消息。
- **文档**
	- 更新了一条消息，关于由于附加了PCI设备而无法迁移虚拟机的情况。
	- 为USB设备被另一个账户占用的情况添加了新消息。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->