### PR TITLE
<fix>[compute]: add host and storage connectivity check

### DIFF
--- a/compute/src/main/java/org/zstack/compute/vm/VmInstantiateAttachingVolumeFlow.java
+++ b/compute/src/main/java/org/zstack/compute/vm/VmInstantiateAttachingVolumeFlow.java
@@ -7,9 +7,13 @@ import org.zstack.core.cloudbus.CloudBus;
 import org.zstack.core.cloudbus.CloudBusCallBack;
 import org.zstack.core.cloudbus.EventFacade;
 import org.zstack.core.db.DatabaseFacade;
+import org.zstack.core.db.Q;
 import org.zstack.header.core.workflow.FlowTrigger;
 import org.zstack.header.core.workflow.NoRollbackFlow;
 import org.zstack.header.message.MessageReply;
+import org.zstack.header.storage.primary.PrimaryStorageHostRefVO;
+import org.zstack.header.storage.primary.PrimaryStorageHostRefVO_;
+import org.zstack.header.storage.primary.PrimaryStorageHostStatus;
 import org.zstack.header.storage.primary.PrimaryStorageInventory;
 import org.zstack.header.vm.VmInstanceConstant;
 import org.zstack.header.vm.VmInstanceSpec;
@@ -19,6 +23,8 @@ import org.zstack.header.volume.VolumeConstant;
 import org.zstack.header.volume.VolumeInventory;
 
 import java.util.Map;
+
+import static org.zstack.core.Platform.operr;
 
 @Configurable(preConstruction = true, autowire = Autowire.BY_TYPE)
 public class VmInstantiateAttachingVolumeFlow extends NoRollbackFlow {
@@ -38,6 +44,18 @@ public class VmInstantiateAttachingVolumeFlow extends NoRollbackFlow {
 
         final PrimaryStorageInventory pinv = (PrimaryStorageInventory) ctx.get(VmInstanceConstant.Params.DestPrimaryStorageInventoryForAttachingVolume.toString());
         final String allocatedUrl = (String) ctx.get(VmInstanceConstant.Params.AllocatedUrlForAttachingVolume.toString());
+
+        PrimaryStorageHostStatus status = Q.New(PrimaryStorageHostRefVO.class)
+                .eq(PrimaryStorageHostRefVO_.hostUuid, spec.getDestHost().getUuid())
+                .eq(PrimaryStorageHostRefVO_.primaryStorageUuid, pinv.getUuid())
+                .select(PrimaryStorageHostRefVO_.status)
+                .findValue();
+        if (status != null && !PrimaryStorageHostStatus.Connected.equals(status)) {
+            chain.fail(operr("Failed to instantiate volume. Because vm's" +
+                    " host[uuid: %s] and allocated primary storage[uuid: %s] is not connected.",
+                    spec.getDestHost().getUuid(), pinv.getUuid()));
+            return;
+        }
 
         InstantiateVolumeMsg msg = new InstantiateVolumeMsg();
         msg.setPrimaryStorageAllocated(true);

--- a/plugin/ceph/src/main/java/org/zstack/storage/ceph/CephMonBase.java
+++ b/plugin/ceph/src/main/java/org/zstack/storage/ceph/CephMonBase.java
@@ -134,7 +134,7 @@ public abstract class CephMonBase {
             this.success = success;
         }
 
-        protected ErrorCode buildErrorCode() {
+        public ErrorCode buildErrorCode() {
             if (success) {
                 return null;
             }

--- a/plugin/ceph/src/main/java/org/zstack/storage/ceph/primary/CephPrimaryStorageBase.java
+++ b/plugin/ceph/src/main/java/org/zstack/storage/ceph/primary/CephPrimaryStorageBase.java
@@ -4481,16 +4481,24 @@ public class CephPrimaryStorageBase extends PrimaryStorageBase {
             public void run(MessageReply reply) {
                 KVMHostAsyncHttpCallReply kr = reply.castReply();
                 CheckHostStorageConnectionRsp rsp = kr.toResponse(CheckHostStorageConnectionRsp.class);
-                if (!rsp.isSuccess()) {
-                    wc.addError(operr("operation error, because:%s", rsp.getError()));
-                    wc.done();
-                    return;
-                }
 
                 UpdatePrimaryStorageHostStatusMsg umsg = new UpdatePrimaryStorageHostStatusMsg();
                 umsg.setHostUuid(msg.getHostUuid());
                 umsg.setPrimaryStorageUuid(self.getUuid());
-                umsg.setStatus(PrimaryStorageHostStatus.Connected);
+
+                if (rsp == null) {
+                    wc.addError(operr("operation error, because: failed to get response"));
+                    umsg.setStatus(PrimaryStorageHostStatus.Disconnected);
+                } else {
+                    ErrorCode errorCode = rsp.buildErrorCode();
+                    if (errorCode != null) {
+                        wc.addError(operr("operation error, because:%s", errorCode));
+                        umsg.setStatus(PrimaryStorageHostStatus.Disconnected);
+                    } else {
+                        umsg.setStatus(PrimaryStorageHostStatus.Connected);
+                    }
+                }
+
                 bus.makeTargetServiceIdByResourceUuid(umsg, PrimaryStorageConstant.SERVICE_ID, umsg.getPrimaryStorageUuid());
                 bus.send(umsg);
                 wc.done();
@@ -4499,8 +4507,7 @@ public class CephPrimaryStorageBase extends PrimaryStorageBase {
             @Override
             public void done(ErrorCodeList errorCodeList) {
                 if (!errorCodeList.getCauses().isEmpty()) {
-                    completion.fail(errorCodeList.getCauses().get(0));
-                    return;
+                    logger.warn(String.format("check host storage connection failed, because: %s", errorCodeList.getCauses()));
                 }
 
                 completion.success();

--- a/storage/src/main/java/org/zstack/storage/volume/VolumeApiInterceptor.java
+++ b/storage/src/main/java/org/zstack/storage/volume/VolumeApiInterceptor.java
@@ -25,6 +25,9 @@ import org.zstack.header.image.ImageVO;
 import org.zstack.header.message.APIMessage;
 import org.zstack.header.storage.primary.PrimaryStorageClusterRefVO;
 import org.zstack.header.storage.primary.PrimaryStorageClusterRefVO_;
+import org.zstack.header.storage.primary.PrimaryStorageHostRefVO;
+import org.zstack.header.storage.primary.PrimaryStorageHostRefVO_;
+import org.zstack.header.storage.primary.PrimaryStorageHostStatus;
 import org.zstack.header.storage.snapshot.ConsistentType;
 import org.zstack.header.storage.snapshot.group.*;
 import org.zstack.header.vm.*;
@@ -329,7 +332,24 @@ public class VolumeApiInterceptor implements ApiMessageInterceptor, Component {
                             hvType, maxDataVolumeNum, count, msg.getVmInstanceUuid()));
                 }
 
+                String hostUuid = Q.New(VmInstanceVO.class)
+                        .eq(VmInstanceVO_.uuid, msg.getVmInstanceUuid())
+                        .select(VmInstanceVO_.hostUuid)
+                        .findValue();
+                if (hostUuid == null) {
+                    return;
+                }
 
+                PrimaryStorageHostStatus primaryStorageHostStatus = Q.New(PrimaryStorageHostRefVO.class)
+                        .eq(PrimaryStorageHostRefVO_.hostUuid, hostUuid)
+                        .eq(PrimaryStorageHostRefVO_.primaryStorageUuid, vol.getPrimaryStorageUuid())
+                        .select(PrimaryStorageHostRefVO_.status)
+                        .findValue();
+                if (primaryStorageHostStatus == PrimaryStorageHostStatus.Disconnected) {
+                    throw new ApiMessageInterceptionException(argerr("Can not attach volume to vm runs" +
+                            " on host[uuid: %s] which is disconnected with volume's storage[uuid: %s]",
+                            hostUuid, vol.getPrimaryStorageUuid()));
+                }
             }
         }.execute();
 


### PR DESCRIPTION
Add check to interceptor when volume is Ready, check
 its storage and vm's host connectivity

Add check to VmInstantiateAttachingVolumeFlow check allocated
 storage and vm's host connectivity

Resolves: ZSTAC-51648

Change-Id: I64776f7763696a63766b7373776c756961786b67
Signed-off-by: AlanJager <ye.zou@zstack.io>
(cherry picked from commit 1bbf38f293c94e6aca4c0d931ce383105d520ae0)

sync from gitlab !5852

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 在卷实例化前增加了对主存储主机状态的检查。
	- 更新了对主存储连接状态的检查逻辑，现在能够更准确地反映连接状态，并在连接检查失败时记录警告日志。

- **改进**
	- 将 `CephMonBase.java` 文件中的 `buildErrorCode` 方法的访问修饰符从 `protected` 改为 `public`，以提高其可用性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->