### PR TITLE
<fix>[vm]:imageUuid is not empty string

### DIFF
--- a/compute/src/main/java/org/zstack/compute/vm/VmInstanceUtils.java
+++ b/compute/src/main/java/org/zstack/compute/vm/VmInstanceUtils.java
@@ -1,6 +1,7 @@
 package org.zstack.compute.vm;
 
 import org.apache.commons.collections.CollectionUtils;
+import org.springframework.util.StringUtils;
 import org.zstack.core.Platform;
 import org.zstack.core.db.Q;
 import org.zstack.header.configuration.InstanceOfferingInventory;
@@ -30,7 +31,7 @@ public class VmInstanceUtils {
 
         cmsg.setImageUuid(msg.getImageUuid());
         // create vm without image is supported
-        if (msg.getImageUuid() != null) {
+        if (!StringUtils.isEmpty(msg.getImageUuid())) {
             ImageVO image = Q.New(ImageVO.class).eq(ImageVO_.uuid, msg.getImageUuid()).find();
             cmsg.setPlatform(msg.getPlatform() == null ? image.getPlatform().toString() : msg.getPlatform());
             cmsg.setGuestOsType(msg.getGuestOsType() == null ? image.getGuestOsType() : msg.getGuestOsType());

--- a/header/src/main/java/org/zstack/header/vm/APICreateVmInstanceMsg.java
+++ b/header/src/main/java/org/zstack/header/vm/APICreateVmInstanceMsg.java
@@ -106,7 +106,7 @@ public class APICreateVmInstanceMsg extends APICreateMessage implements APIAudit
     /**
      * @desc uuid of image. See :ref:`ImageInventory`
      */
-    @APIParam(resourceType = ImageVO.class, checkAccount = true, required = false)
+    @APIParam(resourceType = ImageVO.class, checkAccount = true, required = false, emptyString = false)
     private String imageUuid;
     /**
      * @desc a list of L3Network uuid the vm will create nic on. See :ref:`L3NetworkInventory`

--- a/sdk/src/main/java/org/zstack/sdk/CreateVmInstanceAction.java
+++ b/sdk/src/main/java/org/zstack/sdk/CreateVmInstanceAction.java
@@ -40,7 +40,7 @@ public class CreateVmInstanceAction extends AbstractAction {
     @Param(required = false, nonempty = false, nullElements = false, emptyString = true, numberRange = {0L,9223372036854775807L}, noTrim = false)
     public java.lang.Long reservedMemorySize;
 
-    @Param(required = false, nonempty = false, nullElements = false, emptyString = true, noTrim = false)
+    @Param(required = false, nonempty = false, nullElements = false, emptyString = false, noTrim = false)
     public java.lang.String imageUuid;
 
     @Param(required = false, nonempty = false, nullElements = false, emptyString = true, noTrim = false)


### PR DESCRIPTION
APIImpact

Resolves: ZSTAC-63683

Change-Id: I646a6c646b7a7963776b67637575746f6f626c78

sync from gitlab !5879

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
	- 增加了对字符串操作的更强大支持。
- **改进**
	- 改进了虚拟机创建时对镜像 UUID 的校验，现在不允许空字符串作为有效输入。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->