### PR TITLE
<fix>[kvm]: add KVMHostAsyncHttpCallReply.unwrap methods

### DIFF
--- a/header/src/main/java/org/zstack/header/errorcode/ErrorableValue.java
+++ b/header/src/main/java/org/zstack/header/errorcode/ErrorableValue.java
@@ -1,0 +1,29 @@
+package org.zstack.header.errorcode;
+
+import java.util.Objects;
+
+/**
+ * Created by Wenhao.Zhang on 22/11/21
+ */
+public class ErrorableValue<T> {
+    public final T result;
+    public final ErrorCode error;
+
+    public static <T> ErrorableValue<T> of(T result) {
+        return new ErrorableValue<>(result, null);
+    }
+
+    public static <T> ErrorableValue<T> ofErrorCode(ErrorCode error) {
+        return new ErrorableValue<>(null,
+                Objects.requireNonNull(error, "errorCode in ErrorableValue can not be null"));
+    }
+
+    protected ErrorableValue(T result, ErrorCode error) {
+        this.result = result;
+        this.error = error;
+    }
+
+    public boolean isSuccess() {
+        return error == null;
+    }
+}

--- a/plugin/kvm/src/main/java/org/zstack/kvm/KVMHostAsyncHttpCallReply.java
+++ b/plugin/kvm/src/main/java/org/zstack/kvm/KVMHostAsyncHttpCallReply.java
@@ -1,10 +1,14 @@
 package org.zstack.kvm;
 
+import org.zstack.header.errorcode.ErrorableValue;
 import org.zstack.header.message.MessageReply;
 import org.zstack.header.message.NoJsonSchema;
+import org.zstack.kvm.KVMAgentCommands.AgentResponse;
 import org.zstack.utils.gson.JSONObjectUtil;
 
 import java.util.LinkedHashMap;
+
+import static org.zstack.core.Platform.*;
 
 /**
  */
@@ -22,5 +26,33 @@ public class KVMHostAsyncHttpCallReply extends MessageReply {
 
     public <T> T toResponse(Class<T> clz) {
         return JSONObjectUtil.rehashObject(response, clz);
+    }
+
+    public static ErrorableValue<AgentResponse> unwrap(MessageReply reply) {
+        return unwrap(reply, AgentResponse.class);
+    }
+
+    public static <T extends AgentResponse> ErrorableValue<T> unwrap(MessageReply reply, Class<T> responseClass) {
+        if (!reply.isSuccess()) {
+            return ErrorableValue.ofErrorCode(reply.getError());
+        }
+
+        if (!(reply instanceof KVMHostAsyncHttpCallReply)) {
+            return ErrorableValue.ofErrorCode(
+                    operr("reply[%s] is not a KVMHostAsyncHttpCallReply", reply.getClass().getSimpleName()));
+        }
+
+        final KVMHostAsyncHttpCallReply castReply = (KVMHostAsyncHttpCallReply) reply;
+        if (castReply.response == null) {
+            return ErrorableValue.ofErrorCode(
+                    operr("reply[%s] return with empty response", reply.getClass().getSimpleName()));
+        }
+
+        final T response = castReply.toResponse(responseClass);
+        if (!response.isSuccess()) {
+            return ErrorableValue.ofErrorCode(
+                    operr("%s operation failed: %s", response.getClass().getSimpleName(), response.getError()));
+        }
+        return ErrorableValue.of(response);
     }
 }


### PR DESCRIPTION
Add "KVMHostAsyncHttpCallReply.unwrap" static method
to help parse replies sent from KVM hosts.

Related: ZSTAC-62579

Change-Id: I6d6b71766b716f6e726e766961736e716374686c
(cherry picked from commit 7b4d53730733fae4f093074311bc8405c3aa8bef)

sync from gitlab !5883

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 增加了一个可以表示结果或错误代码的 `ErrorableValue` 类。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->