### PR TITLE
<fix>[compute]: delete vm device address if BIOS mode changed

### DIFF
--- a/compute/src/main/java/org/zstack/compute/vm/VmInstanceBase.java
+++ b/compute/src/main/java/org/zstack/compute/vm/VmInstanceBase.java
@@ -3608,6 +3608,8 @@ public class VmInstanceBase extends AbstractVmInstance {
     }
 
     private void handle(APISetVmBootModeMsg msg) {
+        final boolean[] bootModeChanged = {false};
+
         FlowChain chain = new SimpleFlowChain();
         chain.then(new Flow() {
             String __name__ = "set-vm-boot-mode";
@@ -3624,6 +3626,9 @@ public class VmInstanceBase extends AbstractVmInstance {
                 creator.create();
 
                 originLevel = msg.getBootMode();
+
+                bootModeChanged[0] = true;
+
                 trigger.next();
             }
 
@@ -3660,6 +3665,10 @@ public class VmInstanceBase extends AbstractVmInstance {
             public void handle(Map data) {
                 APISetVmBootModeEvent evt = new APISetVmBootModeEvent(msg.getId());
                 bus.publish(evt);
+
+                if (bootModeChanged[0]) {
+                    vidm.deleteAllDeviceAddressesByVm(self.getUuid());
+                }
             }
         }).start();
     }

--- a/compute/src/main/java/org/zstack/compute/vm/VmInstanceBase.java
+++ b/compute/src/main/java/org/zstack/compute/vm/VmInstanceBase.java
@@ -3618,17 +3618,29 @@ public class VmInstanceBase extends AbstractVmInstance {
 
             @Override
             public void run(FlowTrigger trigger, Map data) {
-                SystemTagCreator creator = VmSystemTags.BOOT_MODE.newSystemTagCreator(self.getUuid());
-                creator.setTagByTokens(map(
-                        e(VmSystemTags.BOOT_MODE_TOKEN, msg.getBootMode())
-                ));
-                creator.recreate = true;
-                creator.create();
+                String bootMode = VmSystemTags.BOOT_MODE
+                        .getTokenByResourceUuid(self.getUuid(),
+                                VmSystemTags.BOOT_MODE_TOKEN);
 
-                originLevel = msg.getBootMode();
+                originLevel = bootMode;
+
+                if (bootMode != null && bootMode.equals(msg.getBootMode())) {
+                    trigger.next();
+                    return;
+                }
+
+                if (msg.getBootMode() == null) {
+                    VmSystemTags.BOOT_MODE.delete(self.getUuid());
+                } else {
+                    SystemTagCreator creator = VmSystemTags.BOOT_MODE.newSystemTagCreator(self.getUuid());
+                    creator.tag = VmSystemTags.BOOT_MODE.instantiateTag(map(
+                            e(VmSystemTags.BOOT_MODE_TOKEN, msg.getBootMode())
+                    ));
+                    creator.recreate = true;
+                    creator.create();
+                }
 
                 bootModeChanged[0] = true;
-
                 trigger.next();
             }
 

--- a/test/src/test/groovy/org/zstack/test/integration/kvm/vm/VmBootModeCase.groovy
+++ b/test/src/test/groovy/org/zstack/test/integration/kvm/vm/VmBootModeCase.groovy
@@ -4,6 +4,8 @@ import org.zstack.compute.vm.VmSystemTags
 import org.zstack.core.db.Q
 import org.zstack.header.tag.SystemTagVO
 import org.zstack.header.tag.SystemTagVO_
+import org.zstack.header.vm.devices.VmInstanceDeviceAddressVO
+import org.zstack.header.vm.devices.VmInstanceDeviceAddressVO_
 import org.zstack.sdk.ImageInventory
 import org.zstack.sdk.InstanceOfferingInventory
 import org.zstack.sdk.L3NetworkInventory
@@ -42,6 +44,10 @@ class VmBootModeCase extends SubCase{
     void testSetVmBootMode() {
         def vm = env.inventoryByName("vm") as VmInstanceInventory
 
+        assert Q.New(VmInstanceDeviceAddressVO.class)
+                .eq(VmInstanceDeviceAddressVO_.vmInstanceUuid, vm.uuid)
+                .count() != 0
+
         assert !VmSystemTags.BOOT_MODE.hasTag(vm.uuid)
 
         setVmBootMode {
@@ -50,6 +56,9 @@ class VmBootModeCase extends SubCase{
         }
 
         assert VmSystemTags.BOOT_MODE.hasTag(vm.uuid)
+        assert Q.New(VmInstanceDeviceAddressVO.class)
+                .eq(VmInstanceDeviceAddressVO_.vmInstanceUuid, vm.uuid)
+                .count() == 0
 
         setVmBootMode {
             uuid = vm.uuid


### PR DESCRIPTION
Resolves: ZSTAC-59291

Change-Id: I7a756a626867657168616d677975717a61676f75
Signed-off-by: AlanJager <ye.zou@zstack.io>
(cherry picked from commit babed020dc5138a6a7da435c8e5bb3abf638685b)

sync from gitlab !5912

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 对虚拟机启动模式设置进行更改时，现在可以检测到启动模式的变化，并相应地创建或删除标签。
- **测试**
	- 增加了对虚拟机启动模式设置功能的测试，确保在设置启动模式前后，相关的虚拟机设备地址记录能够正确存在。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->