### PR TITLE
<feature>[conf]: refactor vf pci assignment

### DIFF
--- a/compute/src/main/java/org/zstack/compute/vm/VmInstanceApiInterceptor.java
+++ b/compute/src/main/java/org/zstack/compute/vm/VmInstanceApiInterceptor.java
@@ -886,7 +886,7 @@ public class VmInstanceApiInterceptor implements ApiMessageInterceptor {
                     newAddedL3Uuids, l2Uuids));
         }
 
-        String sql = "select ip.l3NetworkUuid from UsedIpVO ip, VmNicVO nic where ip.vmNicUuid = nic.uuid and nic.vmInstanceUuid = :vmUuid and ip.l3NetworkUuid in (:l3Uuids)";
+        String sql = "select nic.l3NetworkUuid from VmNicVO nic where nic.vmInstanceUuid = :vmUuid and nic.l3NetworkUuid in (:l3Uuids)";
         List<String> attachedL3Uuids = SQL.New(sql, String.class)
                 .param("vmUuid", msg.getVmInstanceUuid())
                 .param("l3Uuids", newAddedL3Uuids)

--- a/compute/src/main/java/org/zstack/compute/vm/VmInstanceBase.java
+++ b/compute/src/main/java/org/zstack/compute/vm/VmInstanceBase.java
@@ -2194,6 +2194,10 @@ public class VmInstanceBase extends AbstractVmInstance {
         flowChain.getData().put(VmInstanceConstant.Params.VmInstanceSpec.toString(), spec);
         flowChain.getData().put(VmInstanceConstant.Params.VmAllocateNicFlow_allowDuplicatedAddress.toString(), setStaticIp.allowDupicatedAddress);
         flowChain.getData().put(VmInstanceConstant.Params.VmAllocateNicFlow_nicNetworkInfo.toString(), setStaticIp.nicNetworkInfo);
+        for (VmNicPrepareResourceExtensionPoint exp : pluginRgty.getExtensionList(VmNicPrepareResourceExtensionPoint.class)) {
+            flowChain.then(exp.getPreparationFlow());
+        }
+
         flowChain.then(new VmAllocateNicFlow());
         flowChain.then(new VmAllocateNicIpFlow());
         flowChain.then(new VmSetDefaultL3NetworkOnAttachingFlow());
@@ -2426,6 +2430,11 @@ public class VmInstanceBase extends AbstractVmInstance {
                     public void rollback(FlowRollback trigger, Map data) {
                         refreshVO();
                         VmNicInventory nic = (VmNicInventory) data.get(vmNicInvKey);
+                        if (nic == null) {
+                            trigger.rollback();
+                            return;
+                        }
+
                         doDetachNic(nic, true, true, new Completion(trigger) {
                             @Override
                             public void success() {

--- a/compute/src/main/java/org/zstack/compute/vm/VmNicManager.java
+++ b/compute/src/main/java/org/zstack/compute/vm/VmNicManager.java
@@ -1,7 +1,9 @@
 package org.zstack.compute.vm;
 
+import org.zstack.header.network.l3.L3NetworkInventory;
 import org.zstack.header.vm.VmInstanceInventory;
 import org.zstack.header.vm.VmNicInventory;
+import org.zstack.header.vm.VmNicType;
 
 import java.util.List;
 
@@ -16,4 +18,6 @@ public interface VmNicManager {
     String getPcNetNicDriver();
 
     void setNicDriverType(VmNicInventory nic, boolean isImageSupportVirtIo, boolean isParaVirtualization, VmInstanceInventory vm);
+
+    VmNicType getVmNicType(String vmUuid, L3NetworkInventory l3nw);
 }

--- a/compute/src/main/java/org/zstack/compute/vm/VmNicPrepareResourceExtensionPoint.java
+++ b/compute/src/main/java/org/zstack/compute/vm/VmNicPrepareResourceExtensionPoint.java
@@ -1,0 +1,7 @@
+package org.zstack.compute.vm;
+
+import org.zstack.header.core.workflow.Flow;
+
+public interface VmNicPrepareResourceExtensionPoint {
+    Flow getPreparationFlow();
+}

--- a/conf/db/upgrade/V4.8.0.3__schema.sql
+++ b/conf/db/upgrade/V4.8.0.3__schema.sql
@@ -10,3 +10,17 @@ select '36c27e8ff05c4780bf6d2fa65700f22e', '36c27e8ff05c4780bf6d2fa65700f22e', u
 alter table `zstack`.`LongJobVO` modify `uuid` char(32) not null;
 alter table `zstack`.`LongJobVO` add column `parentUuid` char(32) default null;
 
+-- Feature: support SR-IOV | ZSV-5082
+CREATE TABLE IF NOT EXISTS `zstack`.`EthernetVfPciDeviceVO` (
+    `uuid` varchar(32) NOT NULL UNIQUE,
+    `hostDevUuid` varchar(32) DEFAULT NULL,
+    `interfaceName` varchar(32) DEFAULT NULL,
+    `vmUuid` varchar(32) DEFAULT NULL,
+    `l3NetworkUuid` varchar(32) DEFAULT NULL,
+    `vfStatus` varchar(32) NOT NULL,
+    PRIMARY KEY  (`uuid`),
+    CONSTRAINT `fkEthernetVfPciDeviceVOVmInstanceEO` FOREIGN KEY (`vmUuid`) REFERENCES `VmInstanceEO` (`uuid`) ON DELETE SET NULL,
+    CONSTRAINT `fkEthernetVfPciDeviceVOHostEO` FOREIGN KEY (`hostDevUuid`) REFERENCES `HostEO` (`uuid`) ON DELETE CASCADE,
+    CONSTRAINT `fkEthernetVfPciDeviceVO` FOREIGN KEY (`uuid`) REFERENCES `PciDeviceVO` (`uuid`) ON DELETE CASCADE,
+    CONSTRAINT `fkEthernetVfPciDeviceVOL3NetworkEO` FOREIGN KEY (`l3NetworkUuid`) REFERENCES `L3NetworkEO` (`uuid`) ON DELETE SET NULL
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8;

--- a/header/src/main/java/org/zstack/header/network/l2/L2NetworkType.java
+++ b/header/src/main/java/org/zstack/header/network/l2/L2NetworkType.java
@@ -6,6 +6,7 @@ public class L2NetworkType {
     private static Map<String, L2NetworkType> types = Collections.synchronizedMap(new HashMap<String, L2NetworkType>());
     private final String typeName;
     private boolean exposed = true;
+    private boolean sriovSupported = false;
 
     public static boolean hasType(String typeName) {
         return types.containsKey(typeName);
@@ -21,12 +22,25 @@ public class L2NetworkType {
         this.exposed = exposed;
     }
 
+    public L2NetworkType(String typeName, boolean exposed, boolean sriovSupported) {
+        this(typeName, exposed);
+        this.sriovSupported = sriovSupported;
+    }
+
     public boolean isExposed() {
         return exposed;
     }
 
     public void setExposed(boolean exposed) {
         this.exposed = exposed;
+    }
+
+    public boolean isSriovSupported() {
+        return sriovSupported;
+    }
+
+    public void setSriovSupported(boolean isSupportSriov) {
+        this.sriovSupported = isSupportSriov;
     }
 
     public static L2NetworkType valueOf(String typeName) {
@@ -65,5 +79,15 @@ public class L2NetworkType {
             }
         }
         return exposedTypes;
+    }
+
+    public static Set<String> getSriovSupportedTypeName() {
+        HashSet<String> supportedTypes = new HashSet<String>();
+        for (L2NetworkType type : types.values()) {
+            if (type.isSriovSupported()) {
+                supportedTypes.add(type.toString());
+            }
+        }
+        return supportedTypes;
     }
 }

--- a/header/src/main/java/org/zstack/header/network/l2/VSwitchType.java
+++ b/header/src/main/java/org/zstack/header/network/l2/VSwitchType.java
@@ -29,10 +29,7 @@ public class VSwitchType {
     public VSwitchType(String typeName, VmNicType nicType) {
         this.typeName = typeName;
         types.put(typeName, this);
-        if (vSwitchSupportNicTypesMap.get(typeName) == null) {
-            vSwitchSupportNicTypesMap.put(typeName, new ArrayList<VmNicType>());
-        }
-        vSwitchSupportNicTypesMap.get(typeName).add(nicType);
+        vSwitchSupportNicTypesMap.computeIfAbsent(typeName, k -> new ArrayList<VmNicType>()).add(nicType);
     }
 
     public boolean isExposed() {

--- a/header/src/main/java/org/zstack/header/vm/VmInstanceNicFactory.java
+++ b/header/src/main/java/org/zstack/header/vm/VmInstanceNicFactory.java
@@ -37,4 +37,8 @@ public interface VmInstanceNicFactory {
     default String  getPhysicalNicName(VmNicInventory nic) {
         return null;
     }
+
+    default void releaseVmNic(VmNicInventory nic) {
+        return;
+    }
 }

--- a/network/src/main/java/org/zstack/network/l2/L2NoVlanL2NetworkFactory.java
+++ b/network/src/main/java/org/zstack/network/l2/L2NoVlanL2NetworkFactory.java
@@ -13,7 +13,7 @@ import org.zstack.utils.data.FieldPrinter;
 import org.zstack.utils.logging.CLogger;
 
 public class L2NoVlanL2NetworkFactory implements L2NetworkFactory, Component, L2NetworkDefaultMtu, L2NetworkGetVniExtensionPoint {
-    private static L2NetworkType type = new L2NetworkType(L2NetworkConstant.L2_NO_VLAN_NETWORK_TYPE);
+    private static L2NetworkType type = new L2NetworkType(L2NetworkConstant.L2_NO_VLAN_NETWORK_TYPE, true, true);
     private static CLogger logger = Utils.getLogger(L2NoVlanL2NetworkFactory.class);
     private static FieldPrinter printer = Utils.getFieldPrinter();
     

--- a/network/src/main/java/org/zstack/network/l2/L2VlanNetworkFactory.java
+++ b/network/src/main/java/org/zstack/network/l2/L2VlanNetworkFactory.java
@@ -23,7 +23,7 @@ import java.util.List;
 
 public class L2VlanNetworkFactory extends AbstractService implements L2NetworkFactory, L2NetworkDefaultMtu, L2NetworkGetVniExtensionPoint {
     private static CLogger logger = Utils.getLogger(L2VlanNetworkFactory.class);
-    static L2NetworkType type = new L2NetworkType(L2NetworkConstant.L2_VLAN_NETWORK_TYPE);
+    static L2NetworkType type = new L2NetworkType(L2NetworkConstant.L2_VLAN_NETWORK_TYPE, true, true);
     
     @Autowired
     private DatabaseFacade dbf;

--- a/plugin/hostNetworkInterface/src/main/java/org/zstack/network/hostNetworkInterface/HostNetworkInterfaceUpdateExtensionPoint.java
+++ b/plugin/hostNetworkInterface/src/main/java/org/zstack/network/hostNetworkInterface/HostNetworkInterfaceUpdateExtensionPoint.java
@@ -1,0 +1,7 @@
+package org.zstack.network.hostNetworkInterface;
+
+import java.util.List;
+
+public interface HostNetworkInterfaceUpdateExtensionPoint {
+    public void afterCreated(String hostUuid, List<HostNetworkInterfaceVO> interfaceVOS, List<HostNetworkBondingVO> bondingVOS);
+}

--- a/sdk/src/main/java/SourceClassMap.java
+++ b/sdk/src/main/java/SourceClassMap.java
@@ -284,6 +284,8 @@ public class SourceClassMap {
 			put("org.zstack.header.securitymachine.SecretResourcePoolInventory", "org.zstack.sdk.SecretResourcePoolInventory");
 			put("org.zstack.header.securitymachine.SecurityMachineInventory", "org.zstack.sdk.SecurityMachineInventory");
 			put("org.zstack.header.simulator.SimulatorHostInventory", "org.zstack.sdk.SimulatorHostInventory");
+			put("org.zstack.header.sriov.EthernetVfPciDeviceInventory", "org.zstack.sdk.EthernetVfPciDeviceInventory");
+			put("org.zstack.header.sriov.EthernetVfStatus", "org.zstack.sdk.EthernetVfStatus");
 			put("org.zstack.header.sriov.VmVfNicInventory", "org.zstack.sdk.VmVfNicInventory");
 			put("org.zstack.header.sshkeypair.SshKeyPairInventory", "org.zstack.sdk.SshKeyPairInventory");
 			put("org.zstack.header.sshkeypair.SshPrivateKeyPairInventory", "org.zstack.sdk.SshPrivateKeyPairInventory");
@@ -872,6 +874,8 @@ public class SourceClassMap {
 			put("org.zstack.sdk.EmailTriggerActionInventory", "org.zstack.monitoring.actions.EmailTriggerActionInventory");
 			put("org.zstack.sdk.ErrorCode", "org.zstack.header.errorcode.ErrorCode");
 			put("org.zstack.sdk.ErrorCodeList", "org.zstack.header.errorcode.ErrorCodeList");
+			put("org.zstack.sdk.EthernetVfPciDeviceInventory", "org.zstack.header.sriov.EthernetVfPciDeviceInventory");
+			put("org.zstack.sdk.EthernetVfStatus", "org.zstack.header.sriov.EthernetVfStatus");
 			put("org.zstack.sdk.EventLogInventory", "org.zstack.core.eventlog.EventLogInventory");
 			put("org.zstack.sdk.ExternalBackupInventory", "org.zstack.externalbackup.ExternalBackupInventory");
 			put("org.zstack.sdk.ExternalBackupState", "org.zstack.externalbackup.ExternalBackupState");

--- a/sdk/src/main/java/org/zstack/sdk/EthernetVfPciDeviceInventory.java
+++ b/sdk/src/main/java/org/zstack/sdk/EthernetVfPciDeviceInventory.java
@@ -1,0 +1,47 @@
+package org.zstack.sdk;
+
+import org.zstack.sdk.EthernetVfStatus;
+
+public class EthernetVfPciDeviceInventory extends org.zstack.sdk.PciDeviceInventory {
+
+    public java.lang.String hostDevUuid;
+    public void setHostDevUuid(java.lang.String hostDevUuid) {
+        this.hostDevUuid = hostDevUuid;
+    }
+    public java.lang.String getHostDevUuid() {
+        return this.hostDevUuid;
+    }
+
+    public java.lang.String interfaceName;
+    public void setInterfaceName(java.lang.String interfaceName) {
+        this.interfaceName = interfaceName;
+    }
+    public java.lang.String getInterfaceName() {
+        return this.interfaceName;
+    }
+
+    public java.lang.String vmUuid;
+    public void setVmUuid(java.lang.String vmUuid) {
+        this.vmUuid = vmUuid;
+    }
+    public java.lang.String getVmUuid() {
+        return this.vmUuid;
+    }
+
+    public java.lang.String l3NetworkUuid;
+    public void setL3NetworkUuid(java.lang.String l3NetworkUuid) {
+        this.l3NetworkUuid = l3NetworkUuid;
+    }
+    public java.lang.String getL3NetworkUuid() {
+        return this.l3NetworkUuid;
+    }
+
+    public EthernetVfStatus vfStatus;
+    public void setVfStatus(EthernetVfStatus vfStatus) {
+        this.vfStatus = vfStatus;
+    }
+    public EthernetVfStatus getVfStatus() {
+        return this.vfStatus;
+    }
+
+}

--- a/sdk/src/main/java/org/zstack/sdk/EthernetVfStatus.java
+++ b/sdk/src/main/java/org/zstack/sdk/EthernetVfStatus.java
@@ -1,0 +1,8 @@
+package org.zstack.sdk;
+
+public enum EthernetVfStatus {
+	Available,
+	Reserved,
+	Attached,
+	Releasing,
+}

--- a/sdk/src/main/java/org/zstack/sdk/QueryEthernetVFAction.java
+++ b/sdk/src/main/java/org/zstack/sdk/QueryEthernetVFAction.java
@@ -1,0 +1,75 @@
+package org.zstack.sdk;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.zstack.sdk.*;
+
+public class QueryEthernetVFAction extends QueryAction {
+
+    private static final HashMap<String, Parameter> parameterMap = new HashMap<>();
+
+    private static final HashMap<String, Parameter> nonAPIParameterMap = new HashMap<>();
+
+    public static class Result {
+        public ErrorCode error;
+        public org.zstack.sdk.QueryEthernetVFResult value;
+
+        public Result throwExceptionIfError() {
+            if (error != null) {
+                throw new ApiException(
+                    String.format("error[code: %s, description: %s, details: %s]", error.code, error.description, error.details)
+                );
+            }
+            
+            return this;
+        }
+    }
+
+
+
+    private Result makeResult(ApiResult res) {
+        Result ret = new Result();
+        if (res.error != null) {
+            ret.error = res.error;
+            return ret;
+        }
+        
+        org.zstack.sdk.QueryEthernetVFResult value = res.getResult(org.zstack.sdk.QueryEthernetVFResult.class);
+        ret.value = value == null ? new org.zstack.sdk.QueryEthernetVFResult() : value; 
+
+        return ret;
+    }
+
+    public Result call() {
+        ApiResult res = ZSClient.call(this);
+        return makeResult(res);
+    }
+
+    public void call(final Completion<Result> completion) {
+        ZSClient.call(this, new InternalCompletion() {
+            @Override
+            public void complete(ApiResult res) {
+                completion.complete(makeResult(res));
+            }
+        });
+    }
+
+    protected Map<String, Parameter> getParameterMap() {
+        return parameterMap;
+    }
+
+    protected Map<String, Parameter> getNonAPIParameterMap() {
+        return nonAPIParameterMap;
+    }
+
+    protected RestInfo getRestInfo() {
+        RestInfo info = new RestInfo();
+        info.httpMethod = "GET";
+        info.path = "/pci-device/ethernet-vfs";
+        info.needSession = true;
+        info.needPoll = false;
+        info.parameterName = "";
+        return info;
+    }
+
+}

--- a/sdk/src/main/java/org/zstack/sdk/QueryEthernetVFResult.java
+++ b/sdk/src/main/java/org/zstack/sdk/QueryEthernetVFResult.java
@@ -1,0 +1,22 @@
+package org.zstack.sdk;
+
+
+
+public class QueryEthernetVFResult {
+    public java.util.List inventories;
+    public void setInventories(java.util.List inventories) {
+        this.inventories = inventories;
+    }
+    public java.util.List getInventories() {
+        return this.inventories;
+    }
+
+    public java.lang.Long total;
+    public void setTotal(java.lang.Long total) {
+        this.total = total;
+    }
+    public java.lang.Long getTotal() {
+        return this.total;
+    }
+
+}

--- a/testlib/src/main/java/org/zstack/testlib/ApiHelper.groovy
+++ b/testlib/src/main/java/org/zstack/testlib/ApiHelper.groovy
@@ -27458,6 +27458,35 @@ abstract class ApiHelper {
     }
 
 
+    def queryEthernetVF(@DelegatesTo(strategy = Closure.OWNER_FIRST, value = org.zstack.sdk.QueryEthernetVFAction.class) Closure c) {
+        def a = new org.zstack.sdk.QueryEthernetVFAction()
+        a.sessionId = Test.currentEnvSpec?.session?.uuid
+        c.resolveStrategy = Closure.OWNER_FIRST
+        c.delegate = a
+        c()
+        
+        a.conditions = a.conditions.collect { it.toString() }
+
+
+        if (System.getProperty("apipath") != null) {
+            if (a.apiId == null) {
+                a.apiId = Platform.uuid
+            }
+    
+            def tracker = new ApiPathTracker(a.apiId)
+            def out = errorOut(a.call())
+            def path = tracker.getApiPath()
+            if (!path.isEmpty()) {
+                Test.apiPaths[a.class.name] = path.join(" --->\n")
+            }
+        
+            return out
+        } else {
+            return errorOut(a.call())
+        }
+    }
+
+
     def queryEventFromResourceStack(@DelegatesTo(strategy = Closure.OWNER_FIRST, value = org.zstack.sdk.QueryEventFromResourceStackAction.class) Closure c) {
         def a = new org.zstack.sdk.QueryEventFromResourceStackAction()
         a.sessionId = Test.currentEnvSpec?.session?.uuid


### PR DESCRIPTION
更新了sriov vf pci设备，和vdpa vf pci设备分配：
1. 新增EthernetVfPciDeviceVO记录vf pci设备信息，比使用pciDeviceVO方便
2. 修改了pci设备分配逻辑：
   2.a)  关闭云主机，不释放pci设备，这样避免刚开始是sriov vf网卡，关机，再启动因为vf资源不足变成了virtio设备，
           旧逻辑看起来尽量让云主机启动，但是用户很疑惑为啥vf网卡变成了virtio
   2.b)  同理，启动失败，重启失败也不释放pci 设备。
3. 在物理机重连的过程中，建立EthernetVfPciDeviceVO信息

Resolves: ZSV-5082

Change-Id: I776d75646f64666f696d647276776a7962767777
(cherry picked from commit e279d3564b19376852e6d811f029c5744ef4254c)

sync from gitlab !5920

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新功能**
  - 引入了支持 SR-IOV 的 `EthernetVfPciDeviceVO` 新表和相关枚举 `EthernetVfStatus`，以及查询 Ethernet VF 信息的 API。
  - 新增了虚拟机网卡资源准备扩展点接口 `VmNicPrepareResourceExtensionPoint`。
  - 在虚拟机网络接口卡工厂接口中添加了释放 VM NIC 的新默认方法。
  - 引入了处理主机网络接口和绑定配置后动作的接口。

- **改进**
  - 优化了虚拟机网卡类型选择逻辑，基于网络属性动态确定 `VmNicType`。
  - 改进了虚拟机实例在附加 L3 网络时的验证逻辑，提高了查询效率。
  - 增强了虚拟机在分配和释放网卡资源时的流程控制。
  - 更新了 `VSwitchType` 构造函数，使用 `computeIfAbsent` 进行类型检查和映射。

- **Bug 修复**
  - 修正了 `ApplianceVmAllocateNicFlow` 中网卡数据库删除和回滚逻辑的处理，确保了使用 IP 和数据库操作的正确性。

- **重构**
  - 对多个类进行了重构，提高了代码的可维护性和扩展性，特别是在处理虚拟机网卡类型和资源准备方面。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->