### PR TITLE
<feature>[header]: add hostUuid, strategy to APIConvertVmTemplateToVmInstanceMsg

### DIFF
--- a/header/src/main/java/org/zstack/header/vm/APIConvertVmTemplateToVmInstanceMsg.java
+++ b/header/src/main/java/org/zstack/header/vm/APIConvertVmTemplateToVmInstanceMsg.java
@@ -1,6 +1,7 @@
 package org.zstack.header.vm;
 
 import org.springframework.http.HttpMethod;
+import org.zstack.header.host.HostVO;
 import org.zstack.header.message.APICreateMessage;
 import org.zstack.header.message.APIParam;
 import org.zstack.header.rest.RestRequest;
@@ -15,6 +16,12 @@ public class APIConvertVmTemplateToVmInstanceMsg extends APICreateMessage {
     @APIParam(resourceType = VmTemplateVO.class, checkAccount = true)
     private String vmTemplateUuid;
 
+    @APIParam(required = false, validValues = { "InstantStart", "JustConvert" })
+    private String strategy = VmTemplateConversionStrategy.InstantStart.toString();
+
+    @APIParam(required = false, resourceType = HostVO.class)
+    private String hostUuid;
+
     public String getVmTemplateUuid() {
         return vmTemplateUuid;
     }
@@ -23,9 +30,27 @@ public class APIConvertVmTemplateToVmInstanceMsg extends APICreateMessage {
         this.vmTemplateUuid = vmTemplateUuid;
     }
 
+    public String getStrategy() {
+        return strategy;
+    }
+
+    public void setStrategy(String strategy) {
+        this.strategy = strategy;
+    }
+
+    public String getHostUuid() {
+        return hostUuid;
+    }
+
+    public void setHostUuid(String hostUuid) {
+        this.hostUuid = hostUuid;
+    }
+
     public static APIConvertVmTemplateToVmInstanceMsg __example__() {
         APIConvertVmTemplateToVmInstanceMsg msg = new APIConvertVmTemplateToVmInstanceMsg();
         msg.setVmTemplateUuid(uuid());
+        msg.setHostUuid(uuid());
+        msg.setStrategy(VmTemplateConversionStrategy.InstantStart.toString());
         return msg;
     }
 }

--- a/header/src/main/java/org/zstack/header/vm/APIConvertVmTemplateToVmInstanceMsgDoc_zh_cn.groovy
+++ b/header/src/main/java/org/zstack/header/vm/APIConvertVmTemplateToVmInstanceMsgDoc_zh_cn.groovy
@@ -31,6 +31,25 @@ doc {
 					since "zsv 4.2.0"
 				}
 				column {
+					name "strategy"
+					enclosedIn "params"
+					desc "模板转换为虚拟机的策略，转换后立即启动或仅转换"
+					location "body"
+					type "String"
+					optional true
+					since "zsv 4.2.0"
+					values ("InstantStart","JustConvert")
+				}
+				column {
+					name "hostUuid"
+					enclosedIn "params"
+					desc "物理机UUID"
+					location "body"
+					type "String"
+					optional true
+					since "zsv 4.2.0"
+				}
+				column {
 					name "resourceUuid"
 					enclosedIn "params"
 					desc "资源UUID"

--- a/header/src/main/java/org/zstack/header/vm/VmTemplateConversionStrategy.java
+++ b/header/src/main/java/org/zstack/header/vm/VmTemplateConversionStrategy.java
@@ -1,0 +1,6 @@
+package org.zstack.header.vm;
+
+public enum VmTemplateConversionStrategy {
+    InstantStart,
+    JustConvert,
+}

--- a/sdk/src/main/java/org/zstack/sdk/ConvertVmTemplateToVmInstanceAction.java
+++ b/sdk/src/main/java/org/zstack/sdk/ConvertVmTemplateToVmInstanceAction.java
@@ -28,6 +28,12 @@ public class ConvertVmTemplateToVmInstanceAction extends AbstractAction {
     @Param(required = true, nonempty = false, nullElements = false, emptyString = true, noTrim = false)
     public java.lang.String vmTemplateUuid;
 
+    @Param(required = false, validValues = {"InstantStart","JustConvert"}, nonempty = false, nullElements = false, emptyString = true, noTrim = false)
+    public java.lang.String strategy = "InstantStart";
+
+    @Param(required = false, nonempty = false, nullElements = false, emptyString = true, noTrim = false)
+    public java.lang.String hostUuid;
+
     @Param(required = false)
     public java.lang.String resourceUuid;
 


### PR DESCRIPTION
user can select conversion strategy and hostUuid when converting vm template to vm

APIImpact

Related: ZSTAC-4992

Change-Id: I72696667646c746169646a71707a6c6f796e6973

sync from gitlab !5935

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新功能**
	- 增加了从模板创建虚拟机时检查主机状态和连接状态的功能。
	- 在虚拟机模板转换为虚拟机实例的API中添加了“策略”和“主机UUID”字段，提供了即时启动和仅转换两种转换策略。

- **文档**
	- 更新了将虚拟机模板转换为虚拟机实例的API文档，新增了“策略”和“主机UUID”字段的说明。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->