### PR TITLE
<fix>[kvm]: update host os extension point

### DIFF
--- a/build/pom.xml
+++ b/build/pom.xml
@@ -420,6 +420,11 @@
                 </dependency>
                 <dependency>
                     <groupId>org.zstack</groupId>
+                    <artifactId>upgrade-hack</artifactId>
+                    <version>${project.version}</version>
+                </dependency>
+                <dependency>
+                    <groupId>org.zstack</groupId>
                     <artifactId>yunshan</artifactId>
                     <version>${project.version}</version>
                 </dependency>

--- a/plugin/kvm/src/main/java/org/zstack/kvm/KVMAgentCommands.java
+++ b/plugin/kvm/src/main/java/org/zstack/kvm/KVMAgentCommands.java
@@ -3360,6 +3360,15 @@ public class KVMAgentCommands {
     }
 
     public static class UpdateHostOSRsp extends AgentResponse {
+        public String libvirtVersion;
+
+        public String getLibvirtVersion() {
+            return libvirtVersion;
+        }
+
+        public void setLibvirtVersion(String libvirtVersion) {
+            this.libvirtVersion = libvirtVersion;
+        }
     }
 
     public static class UpdateDependencyCmd extends AgentCommand {

--- a/plugin/kvm/src/main/java/org/zstack/kvm/KVMGlobalConfig.java
+++ b/plugin/kvm/src/main/java/org/zstack/kvm/KVMGlobalConfig.java
@@ -99,4 +99,9 @@ public class KVMGlobalConfig {
     @GlobalConfigValidation(validValues = {"true", "false"})
     @GlobalConfigDef(defaultValue = "false", type = Boolean.class, description = "enable install host shutdown hook")
     public static GlobalConfig INSTALL_HOST_SHUTDOWN_HOOK = new GlobalConfig(CATEGORY, "install.host.shutdown.hook");
+
+    @GlobalConfigValidation(validValues = {"true", "false"})
+    @GlobalConfigDef(defaultValue = "false", description = "restart kvm host libvirtd service or not")
+    @BindResourceConfig({HostVO.class, ClusterVO.class})
+    public static GlobalConfig RECONNECT_HOST_RESTART_LIBVIRTD_SERVICE = new GlobalConfig(CATEGORY, "reconnect.host.restart.libvirtd.service");
 }

--- a/plugin/kvm/src/main/java/org/zstack/kvm/KVMHost.java
+++ b/plugin/kvm/src/main/java/org/zstack/kvm/KVMHost.java
@@ -4344,6 +4344,7 @@ public class KVMHost extends HostBase implements Host {
                             }
                             runner.putArgument("skip_packages", info.getSkipPackages());
                             runner.putArgument("update_packages", String.valueOf(CoreGlobalProperty.UPDATE_PKG_WHEN_CONNECT));
+                            runner.putArgument("restart_libvirtd", rcf.getResourceConfigValue(KVMGlobalConfig.RECONNECT_HOST_RESTART_LIBVIRTD_SERVICE, self.getUuid(), String.class));
 
                             UriComponentsBuilder ub = UriComponentsBuilder.fromHttpUrl(restf.getBaseUrl());
                             ub.path(new StringBind(KVMConstant.KVM_ANSIBLE_LOG_PATH_FROMAT).bind("uuid", self.getUuid()).toString());

--- a/plugin/kvm/src/main/java/org/zstack/kvm/KvmHostUpdateOsExtensionPoint.java
+++ b/plugin/kvm/src/main/java/org/zstack/kvm/KvmHostUpdateOsExtensionPoint.java
@@ -1,0 +1,11 @@
+package org.zstack.kvm;
+
+import org.zstack.header.host.HostInventory;
+
+import java.util.Map;
+
+public interface KvmHostUpdateOsExtensionPoint {
+    String UPDATE_OS_RSP = "UPDATE_OS_RSP";
+
+    void afterUpdateOs(Map data, HostInventory host);
+}


### PR DESCRIPTION
Resolves: ZSTAC-63777

Change-Id: I79726e646b766979777177797562697271637676
Signed-off-by: AlanJager <ye.zou@zstack.io>
(cherry picked from commit 40d9f79326fedebaf1bfb95c4bafd3a1f834ae5f)

sync from gitlab !5969

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新特性**
    - 添加了对 KVM 主机 `libvirtd` 服务重启的全局配置支持。
    - 增加了在更新主机操作系统后执行后续动作的能力。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->