### PR TITLE
<chore>[testlib]: add VolumeSystemTags parameters in VmSpec

### DIFF
--- a/testlib/src/main/java/org/zstack/testlib/VmSpec.groovy
+++ b/testlib/src/main/java/org/zstack/testlib/VmSpec.groovy
@@ -20,6 +20,12 @@ class VmSpec extends Spec implements HasSession {
     String name
     @SpecParam
     String description
+    @SpecParam
+    List<String> rootVolumeSystemTags = []
+    @SpecParam
+    List<String> dataVolumeSystemTags = []
+    @SpecParam
+    Map<String, List<String>> dataVolumeSystemTagsOnIndex = [:]
     private List<String> volumeToAttach = []
 
     VmInstanceInventory inventory
@@ -169,6 +175,9 @@ class VmSpec extends Spec implements HasSession {
             delegate.l3NetworkUuids = l3Networks()
             delegate.defaultL3NetworkUuid = defaultL3Network()
             delegate.systemTags = systemTags
+            delegate.rootVolumeSystemTags = rootVolumeSystemTags
+            delegate.dataVolumeSystemTags = dataVolumeSystemTags
+            delegate.dataVolumeSystemTagsOnIndex = dataVolumeSystemTagsOnIndex
         }
 
         postCreate {


### PR DESCRIPTION
Related: ZSV-4749

Change-Id: I626f77786d7364666967707a6a78616e6f6d6b6e

sync from gitlab !5975

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 为虚拟机规格添加了根卷和数据卷系统标签的新参数及其相应映射。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->