### PR TITLE
<fix>[compute]: Fix NPE in rollback of failed Vm migration

### DIFF
--- a/compute/src/main/java/org/zstack/compute/allocator/HostAllocatorManagerImpl.java
+++ b/compute/src/main/java/org/zstack/compute/allocator/HostAllocatorManagerImpl.java
@@ -562,14 +562,16 @@ public class HostAllocatorManagerImpl extends AbstractService implements HostAll
 
                 @Override
                 public void rollback(FlowRollback trigger, Map data) {
-                    ReturnHostCapacityMsg rmsg = new ReturnHostCapacityMsg();
-                    rmsg.setHostUuid(reply.getHost().getUuid());
-                    rmsg.setMemoryCapacity(spec.getMemoryCapacity());
-                    rmsg.setCpuCapacity(spec.getCpuCapacity());
-                    bus.makeTargetServiceIdByResourceUuid(rmsg, HostAllocatorConstant.SERVICE_ID, rmsg.getHostUuid());
-                    bus.send(rmsg);
-                    trigger.rollback();
-                }
+                    if(reply.getHost() != null){
+                        ReturnHostCapacityMsg rmsg = new ReturnHostCapacityMsg();
+                        rmsg.setHostUuid(reply.getHost().getUuid());
+                        rmsg.setMemoryCapacity(spec.getMemoryCapacity());
+                        rmsg.setCpuCapacity(spec.getCpuCapacity());
+                        bus.makeTargetServiceIdByResourceUuid(rmsg, HostAllocatorConstant.SERVICE_ID, rmsg.getHostUuid());
+                        bus.send(rmsg);
+                    }
+                    trigger.rollback();               
+ 		}
             }).then(new NoRollbackFlow() {
                 @Override
                 public void run(FlowTrigger trigger, Map data) {

--- a/compute/src/main/java/org/zstack/compute/allocator/HostSortorChain.java
+++ b/compute/src/main/java/org/zstack/compute/allocator/HostSortorChain.java
@@ -195,7 +195,7 @@ public class HostSortorChain implements HostSortorStrategy {
             @Override
             public void done(ErrorCodeList errorCodeList) {
                 if (selectedHost.get() == null) {
-                    completion.fail(errorCodeList);
+		    completion.fail(errorCodeList.getCauses().get(errorCodeList.getCauses().size()-1));
                     return;
                 }
                 completion.success(selectedHost.get());


### PR DESCRIPTION
Some NPEs occurred during the rollback process caused by
the failure of migrating virtual machines using
ANTIAFFINITY scheduling rules

Resolves: ZSV-5016

Change-Id: I6a796868736366727773686d7570686d68666869

sync from gitlab !5978

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug 修复**
	- 优化了主机分配管理逻辑，确保仅在获取到有效的主机信息时才发送返回主机容量的消息。
	- 更新了主机排序链中的错误处理逻辑，改进了从错误代码列表中获取特定错误原因的方法。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->