### PR TITLE
<fix>[loadBalancer]: add ipVersion for LoadBalancerServerGroup

### DIFF
--- a/conf/db/upgrade/V5.1.0__schema.sql
+++ b/conf/db/upgrade/V5.1.0__schema.sql
@@ -26,3 +26,5 @@ CREATE TABLE IF NOT EXISTS `zstack`.`SlbVmInstanceConfigTaskVO` (
 ALTER TABLE `zstack`.`SlbGroupVO` ADD COLUMN `configVersion` bigint unsigned DEFAULT 0;
 ALTER TABLE `zstack`.`SlbVmInstanceVO` ADD COLUMN `configVersion` bigint unsigned DEFAULT 0;
 UPDATE `zstack`.`SlbGroupVO` SET deployType = "NoHA";
+
+ALTER TABLE `zstack`.`LoadBalancerServerGroupVO` ADD COLUMN `ipVersion` int(10) unsigned DEFAULT 4 AFTER `loadBalancerUuid`;

--- a/plugin/loadBalancer/src/main/java/org/zstack/network/service/lb/APICreateLoadBalancerServerGroupMsg.java
+++ b/plugin/loadBalancer/src/main/java/org/zstack/network/service/lb/APICreateLoadBalancerServerGroupMsg.java
@@ -26,6 +26,8 @@ public class APICreateLoadBalancerServerGroupMsg extends APICreateMessage implem
     private String description;
     @APIParam(resourceType = LoadBalancerVO.class, checkAccount = true, operationTarget = true)
     private String loadBalancerUuid;
+    @APIParam(required = false)
+    private Integer ipVersion;
 
     public String getName() {
         return name;
@@ -51,11 +53,20 @@ public class APICreateLoadBalancerServerGroupMsg extends APICreateMessage implem
         this.loadBalancerUuid = loadBalancerUuid;
     }
 
+    public Integer getIpVersion() {
+        return ipVersion;
+    }
+
+    public void setIpVersion(Integer ipVersion) {
+        this.ipVersion = ipVersion;
+    }
+
 
     public static APICreateLoadBalancerServerGroupMsg __example__() {
         APICreateLoadBalancerServerGroupMsg msg = new APICreateLoadBalancerServerGroupMsg();
         msg.setName("create-Lb");
         msg.setLoadBalancerUuid(uuid());
+        msg.setIpVersion(4);
 
         return msg;
     }

--- a/plugin/loadBalancer/src/main/java/org/zstack/network/service/lb/APICreateLoadBalancerServerGroupMsgDoc_zh_cn.groovy
+++ b/plugin/loadBalancer/src/main/java/org/zstack/network/service/lb/APICreateLoadBalancerServerGroupMsgDoc_zh_cn.groovy
@@ -84,6 +84,15 @@ doc {
 					optional true
 					since "0.6"
 				}
+				column {
+					name "ipVersion"
+					enclosedIn "params"
+					desc "IP版本"
+					location "body"
+					type "Integer"
+					optional true
+					since "5.0.0"
+				}
 			}
         }
 

--- a/plugin/loadBalancer/src/main/java/org/zstack/network/service/lb/LoadBalancerApiInterceptor.java
+++ b/plugin/loadBalancer/src/main/java/org/zstack/network/service/lb/LoadBalancerApiInterceptor.java
@@ -1422,6 +1422,11 @@ public class LoadBalancerApiInterceptor implements ApiMessageInterceptor, Global
 
     private void validate(APICreateLoadBalancerServerGroupMsg msg){
         isExist(msg.getLoadBalancerUuid());
+        if (msg.getIpVersion() == null) {
+            msg.setIpVersion(IPv6Constants.IPv4);
+        } else if (!msg.getIpVersion().equals(IPv6Constants.IPv4) && !msg.getIpVersion().equals(IPv6Constants.IPv6)) {
+            throw new ApiMessageInterceptionException(argerr("invalid ip version[%s], it must be %s or %s", msg.getIpVersion(), IPv6Constants.IPv4, IPv6Constants.IPv6));
+        }
     }
 
     private void validate(APIDeleteLoadBalancerServerGroupMsg msg){

--- a/plugin/loadBalancer/src/main/java/org/zstack/network/service/lb/LoadBalancerBase.java
+++ b/plugin/loadBalancer/src/main/java/org/zstack/network/service/lb/LoadBalancerBase.java
@@ -2577,6 +2577,7 @@ public class LoadBalancerBase {
         vo.setName(msg.getName());
         vo.setDescription(msg.getDescription());
         vo.setLoadBalancerUuid(msg.getLoadBalancerUuid());
+        vo.setIpVersion(msg.getIpVersion());
         vo.setAccountUuid(msg.getSession().getAccountUuid());
         vo.setUuid(msg.getResourceUuid() == null ? Platform.getUuid() : msg.getResourceUuid());
         vo = dbf.persistAndRefresh(vo);

--- a/plugin/loadBalancer/src/main/java/org/zstack/network/service/lb/LoadBalancerServerGroupInventory.java
+++ b/plugin/loadBalancer/src/main/java/org/zstack/network/service/lb/LoadBalancerServerGroupInventory.java
@@ -34,6 +34,7 @@ public class LoadBalancerServerGroupInventory implements Serializable {
     private String description;
 
     private String loadBalancerUuid;
+    private Integer ipVersion;
     private Timestamp createDate;
     private Timestamp lastOpDate;
     private List<LoadBalancerListenerServerGroupRefInventory> listenerServerGroupRefs;
@@ -46,6 +47,7 @@ public class LoadBalancerServerGroupInventory implements Serializable {
         this.setUuid(vo.getUuid());
         this.setDescription(vo.getDescription());
         this.setLoadBalancerUuid(vo.getLoadBalancerUuid());
+        this.setIpVersion(vo.getIpVersion());
         this.setCreateDate(vo.getCreateDate());
         this.setLastOpDate(vo.getLastOpDate());
         this.setListenerServerGroupRefs(LoadBalancerListenerServerGroupRefInventory.valueOf(vo.getLoadBalancerListenerServerGroupRefs()));
@@ -63,6 +65,7 @@ public class LoadBalancerServerGroupInventory implements Serializable {
         inv.setUuid(vo.getUuid());
         inv.setDescription(vo.getDescription());
         inv.setLoadBalancerUuid(vo.getLoadBalancerUuid());
+        inv.setIpVersion(vo.getIpVersion());
         inv.setCreateDate(vo.getCreateDate());
         inv.setLastOpDate(vo.getLastOpDate());
         inv.setListenerServerGroupRefs(LoadBalancerListenerServerGroupRefInventory.valueOf(vo.getLoadBalancerListenerServerGroupRefs()));
@@ -164,5 +167,13 @@ public class LoadBalancerServerGroupInventory implements Serializable {
         List<String> l3Uuids = Q.New(VmNicVO.class).select(VmNicVO_.l3NetworkUuid)
                 .in(VmNicVO_.uuid, attachedVmNics).listValues();
         return l3Uuids.stream().distinct().collect(Collectors.toList());
+    }
+
+    public Integer getIpVersion() {
+        return ipVersion;
+    }
+
+    public void setIpVersion(Integer ipVersion) {
+        this.ipVersion = ipVersion;
     }
 }

--- a/plugin/loadBalancer/src/main/java/org/zstack/network/service/lb/LoadBalancerServerGroupVO.java
+++ b/plugin/loadBalancer/src/main/java/org/zstack/network/service/lb/LoadBalancerServerGroupVO.java
@@ -11,6 +11,7 @@ import org.zstack.header.vo.NoView;
 import org.zstack.header.vo.ResourceVO;
 
 import javax.persistence.*;
+
 import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -39,6 +40,9 @@ public class LoadBalancerServerGroupVO extends ResourceVO  implements OwnedByAcc
     @Column
     @ForeignKey(parentEntityClass = LoadBalancerVO.class, parentKey = "uuid", onDeleteAction = ForeignKey.ReferenceOption.RESTRICT)
     private String loadBalancerUuid;
+
+    @Column
+    private Integer ipVersion;
 
     @Column
     private Timestamp createDate;
@@ -143,6 +147,14 @@ public class LoadBalancerServerGroupVO extends ResourceVO  implements OwnedByAcc
 
     public void setLoadBalancerUuid(String loadBalancerUuid) {
         this.loadBalancerUuid = loadBalancerUuid;
+    }
+
+    public Integer getIpVersion() {
+        return ipVersion;
+    }
+
+    public void setIpVersion(Integer ipVersion) {
+        this.ipVersion = ipVersion;
     }
 }
     

--- a/plugin/loadBalancer/src/main/java/org/zstack/network/service/lb/LoadBalancerServerGroupVO_.java
+++ b/plugin/loadBalancer/src/main/java/org/zstack/network/service/lb/LoadBalancerServerGroupVO_.java
@@ -12,6 +12,7 @@ public class LoadBalancerServerGroupVO_ extends ResourceVO_ {
     public static volatile SingularAttribute<LoadBalancerServerGroupVO, String> name;
     public static volatile SingularAttribute<LoadBalancerServerGroupVO, String> description;
     public static volatile SingularAttribute<LoadBalancerServerGroupVO, String> loadBalancerUuid;
+    public static volatile SingularAttribute<LoadBalancerServerGroupVO, Integer> ipVersion;
     public static volatile SingularAttribute<LoadBalancerServerGroupVO, Timestamp> createDate;
     public static volatile SingularAttribute<LoadBalancerServerGroupVO, Timestamp> lastOpDate;
 }

--- a/sdk/src/main/java/org/zstack/sdk/CreateLoadBalancerServerGroupAction.java
+++ b/sdk/src/main/java/org/zstack/sdk/CreateLoadBalancerServerGroupAction.java
@@ -34,6 +34,9 @@ public class CreateLoadBalancerServerGroupAction extends AbstractAction {
     @Param(required = true, nonempty = false, nullElements = false, emptyString = true, noTrim = false)
     public java.lang.String loadBalancerUuid;
 
+    @Param(required = false, nonempty = false, nullElements = false, emptyString = true, noTrim = false)
+    public java.lang.Integer ipVersion;
+
     @Param(required = false)
     public java.lang.String resourceUuid;
 

--- a/sdk/src/main/java/org/zstack/sdk/LoadBalancerServerGroupInventory.java
+++ b/sdk/src/main/java/org/zstack/sdk/LoadBalancerServerGroupInventory.java
@@ -36,6 +36,14 @@ public class LoadBalancerServerGroupInventory  {
         return this.loadBalancerUuid;
     }
 
+    public java.lang.Integer ipVersion;
+    public void setIpVersion(java.lang.Integer ipVersion) {
+        this.ipVersion = ipVersion;
+    }
+    public java.lang.Integer getIpVersion() {
+        return this.ipVersion;
+    }
+
     public java.sql.Timestamp createDate;
     public void setCreateDate(java.sql.Timestamp createDate) {
         this.createDate = createDate;


### PR DESCRIPTION
DBImpact
APIImpact

Resolves: ZSTAC-64338

Change-Id: I7a706c63787577726c6763736674756b68727470

sync from gitlab !5980

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 在负载均衡服务器组中添加了对 IP 版本（IPv4 或 IPv6）的支持，以增强网络服务的灵活性。
- **文档**
	- 更新了创建负载均衡服务器组的文档，包括新的 `ipVersion` 字段说明。
- **Bug 修复**
	- 添加了对 `ipVersion` 字段值的验证，确保只能是 IPv4 或 IPv6，避免了无效值的错误。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->