### PR TITLE
<fix>[slb-ha]: add local/peer IpV6 for dual stack

### DIFF
--- a/plugin/virtualRouterProvider/src/main/java/org/zstack/network/service/virtualrouter/vyos/VyosKeepalivedCommands.java
+++ b/plugin/virtualRouterProvider/src/main/java/org/zstack/network/service/virtualrouter/vyos/VyosKeepalivedCommands.java
@@ -30,8 +30,12 @@ public class VyosKeepalivedCommands {
         public String heartbeatNic;
         @GrayVersion(value = "5.0.0")
         public String peerIp;
+        @GrayVersion(value = "5.1.0")
+        public String peerIpV6;
         @GrayVersion(value = "5.0.0")
         public String localIp;
+        @GrayVersion(value = "5.1.0")
+        public String localIpV6;
         @GrayVersion(value = "5.0.0")
         public List<String> monitors;
         @GrayVersion(value = "5.0.0")
@@ -63,6 +67,14 @@ public class VyosKeepalivedCommands {
             this.peerIp = peerIp;
         }
 
+        public String getPeerIpV6 () {
+            return peerIpV6;
+        }
+
+        public void setPeerIpV6(String peerIpV6) {
+            this.peerIpV6 = peerIpV6;
+        }
+
         public List<String> getMonitors() {
             return monitors;
         }
@@ -85,6 +97,14 @@ public class VyosKeepalivedCommands {
 
         public void setLocalIp(String localIp) {
             this.localIp = localIp;
+        }
+
+        public String getLocalIpV6() {
+            return localIpV6;
+        }
+
+        public void setLocalIpV6(String localIpV6) {
+            this.localIpV6 = localIpV6;
         }
 
         public String getCallbackUrl() {


### PR DESCRIPTION
Resolves: ZSTAC-64349

Change-Id: I626175647163786262746669667779727766646d

Signed-off-by: zhangjianjun <jianjun.zhang@zstack.io>

sync from gitlab !5998

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 在版本5.1.0中，增加了对IPv6地址（`peerIpV6`和`localIpV6`）的支持，以及现有的IPv4地址（`peerIp`和`localIp`）。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->