### PR TITLE
<fix>[network]: zsv support SR-IOV

### DIFF
--- a/compute/src/main/java/org/zstack/compute/VmNicUtils.java
+++ b/compute/src/main/java/org/zstack/compute/VmNicUtils.java
@@ -3,7 +3,8 @@ package org.zstack.compute;
 import org.apache.commons.lang.StringUtils;
 import org.zstack.compute.vm.VmGlobalConfig;
 import org.zstack.header.apimediator.ApiMessageInterceptionException;
-import org.zstack.header.vm.VmNicParm;
+import org.zstack.header.vm.VmInstanceType;
+import org.zstack.header.vm.VmNicParam;
 import org.zstack.header.vm.VmNicState;
 import org.zstack.utils.CollectionUtils;
 
@@ -14,17 +15,17 @@ import static java.util.Arrays.asList;
 import static org.zstack.core.Platform.argerr;
 
 public class VmNicUtils {
-    public static void validateVmParms(List<VmNicParm> vmNicParms, List<String> l3Uuids, List<String> supportNicDriverTypes) {
-        if (CollectionUtils.isEmpty(vmNicParms)) {
+    public static void validateVmParams(List<VmNicParam> vmNicParams, List<String> l3Uuids, List<String> supportNicDriverTypes, String vmType) {
+        if (CollectionUtils.isEmpty(vmNicParams)) {
             return;
         }
 
-        List<String> l3UuidsInParms = vmNicParms.stream().map(VmNicParm::getL3NetworkUuid).distinct().collect(Collectors.toList());
-        if (!VmGlobalConfig.MULTI_VNIC_SUPPORT.value(Boolean.class) && l3UuidsInParms.size() != vmNicParms.size()) {
+        List<String> l3UuidsInParams = vmNicParams.stream().map(VmNicParam::getL3NetworkUuid).distinct().collect(Collectors.toList());
+        if (!VmGlobalConfig.MULTI_VNIC_SUPPORT.value(Boolean.class) && l3UuidsInParams.size() != vmNicParams.size()) {
             throw new ApiMessageInterceptionException(argerr("duplicate nic params"));
         }
 
-        for (VmNicParm nic : vmNicParms) {
+        for (VmNicParam nic : vmNicParams) {
             String l3 = nic.getL3NetworkUuid();
             if (StringUtils.isEmpty(l3)) {
                 throw new ApiMessageInterceptionException(argerr("l3NetworkUuid of vm nic can not be null"));
@@ -60,6 +61,14 @@ public class VmNicUtils {
             String driverType = nic.getDriverType();
             if (!StringUtils.isEmpty(driverType) && !CollectionUtils.isEmpty(supportNicDriverTypes) && !supportNicDriverTypes.contains(driverType)){
                 throw new ApiMessageInterceptionException(argerr("vm nic driver %s not support yet", driverType));
+            }
+
+            if (nic.isSriovEnabled() && vmType != null && !VmInstanceType.valueOf(vmType).isSriovSupported()) {
+                throw new ApiMessageInterceptionException(argerr("vm type[%s] is not supported SR-IOV", vmType));
+            }
+
+            if (!nic.isSriovEnabled() && nic.getVfParentUuid() != null) {
+                throw new ApiMessageInterceptionException(argerr("vm nic with vf parent uuid[%s] should be SR-IOV enabled", nic.getVfParentUuid()));
             }
         }
     }

--- a/compute/src/main/java/org/zstack/compute/vm/NewVmInstanceMsgBuilder.java
+++ b/compute/src/main/java/org/zstack/compute/vm/NewVmInstanceMsgBuilder.java
@@ -25,9 +25,9 @@ public class NewVmInstanceMsgBuilder {
         if (CollectionUtils.isEmpty(msg.getL3NetworkUuids())) {
             return Collections.EMPTY_LIST;
         }
-        List<VmNicParm> vmNicParms = Collections.emptyList();
-        if (msg.getVmNicParams() != null && !msg.getVmNicParams().isEmpty()) {
-            vmNicParms = JSONObjectUtil.toCollection(msg.getVmNicParams(), ArrayList.class, VmNicParm.class);
+        List<VmNicParam> vmNicParams = new ArrayList<>();
+        if (!StringUtils.isEmpty(msg.getVmNicParams())) {
+            vmNicParams.addAll(JSONObjectUtil.toCollection(msg.getVmNicParams(), ArrayList.class, VmNicParam.class));
         }
 
         List<VmNicSpec> nicSpecs = new ArrayList<>();
@@ -38,18 +38,14 @@ public class NewVmInstanceMsgBuilder {
             l3Invs.add(inv);
 
             VmNicSpec vmNicSpec = new VmNicSpec(l3Invs);
-
-
-            if (!vmNicParms.isEmpty()) {
-                List<VmNicParm> nicParmOfL3 = vmNicParms.stream().filter(vmNicParm -> vmNicParm.getL3NetworkUuid().equals(l3Uuid)).distinct().collect(Collectors.toList());
-                if (!nicParmOfL3.isEmpty()) {
-                    vmNicSpec.setVmNicParms(nicParmOfL3);
-                    vmNicSpec.setNicDriverType(nicParmOfL3.get(0).getDriverType());
+            if (!vmNicParams.isEmpty()) {
+                List<VmNicParam> nicParamOfL3 = vmNicParams.stream().filter(vmNicParam -> vmNicParam.getL3NetworkUuid().equals(l3Uuid)).distinct().collect(Collectors.toList());
+                if (!nicParamOfL3.isEmpty()) {
+                    vmNicSpec.setVmNicParams(nicParamOfL3);
+                    vmNicSpec.setNicDriverType(nicParamOfL3.get(0).getDriverType());
                 }
             }
             nicSpecs.add(vmNicSpec);
-//            nicSpecs.add(new VmNicSpec(l3Invs,
-//                    vmNicParms != null && !vmNicParms.isEmpty() ? vmNicParms.get(i) : null));
         }
 
 
@@ -60,8 +56,8 @@ public class NewVmInstanceMsgBuilder {
         if (StringUtils.isEmpty(msg.getVmNicParams())) {
             return Collections.EMPTY_LIST;
         }
-        List<VmNicParm> vmNicParms = JSONObjectUtil.toCollection(msg.getVmNicParams(), ArrayList.class, VmNicParm.class);
-        return vmNicParms.stream().filter(nic -> VmNicState.disable.toString().equals(nic.getState())).map(VmNicParm::getL3NetworkUuid).collect(Collectors.toList());
+        List<VmNicParam> vmNicParams = JSONObjectUtil.toCollection(msg.getVmNicParams(), ArrayList.class, VmNicParam.class);
+        return vmNicParams.stream().filter(nic -> VmNicState.disable.toString().equals(nic.getState())).map(VmNicParam::getL3NetworkUuid).collect(Collectors.toList());
     }
 
     public static CreateVmInstanceMsg fromAPINewVmInstanceMsg(NewVmInstanceMessage2 msg) {

--- a/compute/src/main/java/org/zstack/compute/vm/UserVmFactory.java
+++ b/compute/src/main/java/org/zstack/compute/vm/UserVmFactory.java
@@ -7,7 +7,11 @@ import org.zstack.header.vm.*;
 
 public class UserVmFactory implements VmInstanceFactory {
     private static final VmInstanceType type = new VmInstanceType(VmInstanceConstant.USER_VM_TYPE);
-    
+
+    static {
+        type.setSriovSupported(true);
+    }
+
     @Autowired
     private DatabaseFacade dbf;
     

--- a/compute/src/main/java/org/zstack/compute/vm/VmAllocateHostFlow.java
+++ b/compute/src/main/java/org/zstack/compute/vm/VmAllocateHostFlow.java
@@ -6,7 +6,6 @@ import org.springframework.beans.factory.annotation.Configurable;
 import org.zstack.core.cloudbus.CloudBus;
 import org.zstack.core.cloudbus.CloudBusCallBack;
 import org.zstack.core.db.DatabaseFacade;
-import org.zstack.core.db.Q;
 import org.zstack.core.db.SQL;
 import org.zstack.core.errorcode.ErrorFacade;
 import org.zstack.header.allocator.*;
@@ -15,7 +14,6 @@ import org.zstack.header.configuration.DiskOfferingVO;
 import org.zstack.header.core.workflow.Flow;
 import org.zstack.header.core.workflow.FlowRollback;
 import org.zstack.header.core.workflow.FlowTrigger;
-import org.zstack.header.errorcode.ErrorCode;
 import org.zstack.header.exception.CloudRuntimeException;
 import org.zstack.header.host.HostInventory;
 import org.zstack.header.host.HostVO;
@@ -23,8 +21,6 @@ import org.zstack.header.image.ImageConstant.ImageMediaType;
 import org.zstack.header.image.ImageInventory;
 import org.zstack.header.message.MessageReply;
 import org.zstack.header.network.l3.L3NetworkInventory;
-import org.zstack.header.storage.primary.PrimaryStorageClusterRefVO;
-import org.zstack.header.storage.primary.PrimaryStorageClusterRefVO_;
 import org.zstack.header.vm.*;
 import org.zstack.header.vm.VmInstanceConstant.VmOperation;
 import org.zstack.utils.CollectionUtils;
@@ -39,7 +35,6 @@ import java.util.Map;
 import java.util.*;
 import java.util.stream.Collectors;
 
-import static org.zstack.core.Platform.operr;
 import static org.zstack.core.progress.ProgressReportService.taskProgress;
 
 @Configurable(preConstruction = true, autowire = Autowire.BY_TYPE)
@@ -94,6 +89,7 @@ public class VmAllocateHostFlow implements Flow {
                 return arg.getUuid();
             }
         }));
+        msg.setVmNicParams(VmNicSpec.getVmNicParamsOfSpec(spec.getL3Networks()));
         msg.setImage(image);
         msg.setVmOperation(spec.getCurrentVmOperation().toString());
 

--- a/compute/src/main/java/org/zstack/compute/vm/VmAllocateHostForAbnormallyStartedVmFlow.java
+++ b/compute/src/main/java/org/zstack/compute/vm/VmAllocateHostForAbnormallyStartedVmFlow.java
@@ -16,13 +16,11 @@ import org.zstack.header.message.MessageReply;
 import org.zstack.header.network.l3.L3NetworkInventory;
 import org.zstack.header.vm.VmInstanceConstant;
 import org.zstack.header.vm.VmInstanceSpec;
-import org.zstack.header.vm.VmNicHelper;
 import org.zstack.header.vm.VmNicSpec;
 import org.zstack.header.volume.VolumeInventory;
 import org.zstack.utils.CollectionUtils;
 import org.zstack.utils.function.Function;
 
-import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
@@ -58,6 +56,7 @@ public class VmAllocateHostForAbnormallyStartedVmFlow implements Flow {
                 return arg.getUuid();
             }
         }));
+        msg.setVmNicParams(VmNicSpec.getVmNicParamsOfSpec(spec.getL3Networks()));
         msg.setServiceId(bus.makeLocalServiceId(HostAllocatorConstant.SERVICE_ID));
         bus.send(msg, new CloudBusCallBack(chain) {
             @Override

--- a/compute/src/main/java/org/zstack/compute/vm/VmAllocateHostForMigrateVmFlow.java
+++ b/compute/src/main/java/org/zstack/compute/vm/VmAllocateHostForMigrateVmFlow.java
@@ -75,6 +75,7 @@ public class VmAllocateHostForMigrateVmFlow implements Flow {
                 return arg.getUuid();
             }
         }));
+        msg.setVmNicParams(VmNicSpec.getVmNicParamsOfSpec(spec.getL3Networks()));
         msg.setAllowNoL3Networks(true);
         bus.send(msg, new CloudBusCallBack(chain) {
             @Override

--- a/compute/src/main/java/org/zstack/compute/vm/VmAllocateHostForStoppedVmFlow.java
+++ b/compute/src/main/java/org/zstack/compute/vm/VmAllocateHostForStoppedVmFlow.java
@@ -76,6 +76,7 @@ public class VmAllocateHostForStoppedVmFlow implements Flow {
                 return arg.getUuid();
             }
         }));
+        msg.setVmNicParams(VmNicSpec.getVmNicParamsOfSpec(spec.getL3Networks()));
         if (spec.getRequiredClusterUuid() == null) {
             if (CollectionUtils.isEmpty(spec.getVmInventory().getVmNics())) {
                 msg.setClusterUuid(spec.getVmInventory().getClusterUuid());

--- a/compute/src/main/java/org/zstack/compute/vm/VmInstanceBase.java
+++ b/compute/src/main/java/org/zstack/compute/vm/VmInstanceBase.java
@@ -850,6 +850,7 @@ public class VmInstanceBase extends AbstractVmInstance {
             amsg.setImage(ImageInventory.valueOf(dbf.findByUuid(self.getImageUuid(), ImageVO.class)));
         }
         amsg.setL3NetworkUuids(VmNicHelper.getL3Uuids(VmNicInventory.valueOf(self.getVmNics())));
+        amsg.setVmNicParams(VmNicHelper.getVmNicParamsWithVfNic(self));
         amsg.setDryRun(true);
         amsg.setListAllHosts(true);
 
@@ -1885,6 +1886,7 @@ public class VmInstanceBase extends AbstractVmInstance {
         amsg.setAllocatorStrategy(HostAllocatorConstant.MIGRATE_VM_ALLOCATOR_TYPE);
         amsg.setVmOperation(VmOperation.Migrate.toString());
         amsg.setL3NetworkUuids(VmNicHelper.getL3Uuids(VmNicInventory.valueOf(self.getVmNics())));
+        amsg.setVmNicParams(VmNicHelper.getVmNicParamsWithVfNic(self));
         amsg.setDryRun(true);
         amsg.setAllowNoL3Networks(true);
 
@@ -2174,8 +2176,8 @@ public class VmInstanceBase extends AbstractVmInstance {
 
             String vmNicParams = msg1.getVmNicParams();
             if (!StringUtils.isEmpty(vmNicParams)) {
-                VmNicParm nicParams = JSONObjectUtil.toObject(vmNicParams, VmNicParm.class);
-                nicSpec.setVmNicParms(Arrays.asList(nicParams));
+                VmNicParam nicParams = JSONObjectUtil.toObject(vmNicParams, VmNicParam.class);
+                nicSpec.setVmNicParams(Arrays.asList(nicParams));
                 if (VmNicState.disable.toString().equals(nicParams.getState())) {
                     spec.getDisableL3Networks().add(nicParams.getL3NetworkUuid());
                 }
@@ -2194,6 +2196,10 @@ public class VmInstanceBase extends AbstractVmInstance {
         flowChain.getData().put(VmInstanceConstant.Params.VmInstanceSpec.toString(), spec);
         flowChain.getData().put(VmInstanceConstant.Params.VmAllocateNicFlow_allowDuplicatedAddress.toString(), setStaticIp.allowDupicatedAddress);
         flowChain.getData().put(VmInstanceConstant.Params.VmAllocateNicFlow_nicNetworkInfo.toString(), setStaticIp.nicNetworkInfo);
+        for (VmNicPrepareResourceExtensionPoint exp : pluginRgty.getExtensionList(VmNicPrepareResourceExtensionPoint.class)) {
+            flowChain.then(exp.getPreparationFlow());
+        }
+
         flowChain.then(new VmAllocateNicFlow());
         flowChain.then(new VmAllocateNicIpFlow());
         flowChain.then(new VmSetDefaultL3NetworkOnAttachingFlow());
@@ -2426,6 +2432,11 @@ public class VmInstanceBase extends AbstractVmInstance {
                     public void rollback(FlowRollback trigger, Map data) {
                         refreshVO();
                         VmNicInventory nic = (VmNicInventory) data.get(vmNicInvKey);
+                        if (nic == null) {
+                            trigger.rollback();
+                            return;
+                        }
+
                         doDetachNic(nic, true, true, new Completion(trigger) {
                             @Override
                             public void success() {
@@ -6946,7 +6957,7 @@ public class VmInstanceBase extends AbstractVmInstance {
             List<VmNicSpec> nicSpecs = new ArrayList<>();
             for (VmNicSpec nicSpec : struct.getL3NetworkUuids()) {
                 List<L3NetworkInventory> l3s = new ArrayList<>();
-                for (L3NetworkInventory inv : nicSpec.l3Invs) {
+                for (L3NetworkInventory inv : nicSpec.getL3Invs()) {
                     L3NetworkInventory l3 = CollectionUtils.find(nws, new Function<L3NetworkInventory, L3NetworkInventory>() {
                         @Override
                         public L3NetworkInventory call(L3NetworkInventory arg) {
@@ -6964,7 +6975,7 @@ public class VmInstanceBase extends AbstractVmInstance {
                 if (!l3s.isEmpty()) {
                     VmNicSpec nicSpec1 = new VmNicSpec(l3s);
                     nicSpec1.setNicDriverType(nicSpec.getNicDriverType());
-                    nicSpec1.setVmNicParms(nicSpec.getVmNicParms());
+                    nicSpec1.setVmNicParams(nicSpec.getVmNicParams());
                     nicSpecs.add(nicSpec1);
                 }
             }

--- a/compute/src/main/java/org/zstack/compute/vm/VmNicManager.java
+++ b/compute/src/main/java/org/zstack/compute/vm/VmNicManager.java
@@ -1,7 +1,9 @@
 package org.zstack.compute.vm;
 
+import org.zstack.header.network.l3.L3NetworkInventory;
 import org.zstack.header.vm.VmInstanceInventory;
 import org.zstack.header.vm.VmNicInventory;
+import org.zstack.header.vm.VmNicType;
 
 import java.util.List;
 
@@ -16,4 +18,6 @@ public interface VmNicManager {
     String getPcNetNicDriver();
 
     void setNicDriverType(VmNicInventory nic, boolean isImageSupportVirtIo, boolean isParaVirtualization, VmInstanceInventory vm);
+
+    VmNicType getVmNicType(String vmUuid, L3NetworkInventory l3nw, boolean enableSriov);
 }

--- a/compute/src/main/java/org/zstack/compute/vm/VmNicManagerImpl.java
+++ b/compute/src/main/java/org/zstack/compute/vm/VmNicManagerImpl.java
@@ -6,6 +6,7 @@ import org.springframework.beans.factory.annotation.Autowire;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Configurable;
 import org.zstack.core.componentloader.PluginRegistry;
+import org.zstack.core.db.DatabaseFacade;
 import org.zstack.core.db.Q;
 import org.zstack.core.db.SQL;
 import org.zstack.core.db.SimpleQuery;
@@ -14,13 +15,16 @@ import org.zstack.header.Component;
 import org.zstack.header.errorcode.OperationFailureException;
 import org.zstack.header.image.ImagePlatform;
 import org.zstack.header.managementnode.PrepareDbInitialValueExtensionPoint;
+import org.zstack.header.network.l2.L2NetworkConstant;
+import org.zstack.header.network.l2.L2NetworkVO;
+import org.zstack.header.network.l2.VSwitchType;
+import org.zstack.header.network.l3.L3NetworkInventory;
 import org.zstack.header.network.l3.UsedIpVO;
 import org.zstack.header.network.l3.UsedIpVO_;
-import org.zstack.header.tag.SystemTagInventory;
-import org.zstack.header.tag.SystemTagLifeCycleListener;
-import org.zstack.header.tag.SystemTagValidator;
+import org.zstack.header.tag.*;
 import org.zstack.header.vm.*;
 import org.zstack.header.vm.devices.VmInstanceDeviceManager;
+import org.zstack.network.service.NetworkServiceGlobalConfig;
 import org.zstack.utils.Utils;
 import org.zstack.utils.logging.CLogger;
 import org.zstack.utils.network.IPv6Constants;
@@ -39,6 +43,8 @@ public class VmNicManagerImpl implements VmNicManager, VmNicExtensionPoint, Prep
     private VmInstanceDeviceManager vidm;
     @Autowired
     private PluginRegistry pluginRegistry;
+    @Autowired
+    private DatabaseFacade dbf;
 
     private List<String> supportNicDriverTypes;
     private String defaultPVNicDriver;
@@ -265,6 +271,24 @@ public class VmNicManagerImpl implements VmNicManager, VmNicExtensionPoint, Prep
         } else {
             nic.setDriverType(getDefaultNicDriver());
         }
+    }
+
+    @Override
+    public VmNicType getVmNicType(String vmUuid, L3NetworkInventory l3nw, boolean enableSriov) {
+        logger.debug(String.format("create %s on l3 network[uuid:%s] inside VmAllocateNicFlow",
+                enableSriov ? "vf nic" : "vnic", l3nw.getUuid()));
+        boolean enableVhostUser = NetworkServiceGlobalConfig.ENABLE_VHOSTUSER.value(Boolean.class);
+
+        L2NetworkVO l2nw =  dbf.findByUuid(l3nw.getL2NetworkUuid(), L2NetworkVO.class);
+        VmNicType type;
+        if (l2nw.getType().equals(L2NetworkConstant.L2_TF_NETWORK_TYPE)) {
+            type = VmNicType.valueOf(VmInstanceConstant.TF_VIRTUAL_NIC_TYPE);
+        } else {
+            VSwitchType vSwitchType = VSwitchType.valueOf(l2nw.getvSwitchType());
+            type = vSwitchType.getVmNicTypeWithCondition(enableSriov, enableVhostUser);
+        }
+
+        return type;
     }
 
     @Override

--- a/compute/src/main/java/org/zstack/compute/vm/VmNicPrepareResourceExtensionPoint.java
+++ b/compute/src/main/java/org/zstack/compute/vm/VmNicPrepareResourceExtensionPoint.java
@@ -1,0 +1,7 @@
+package org.zstack.compute.vm;
+
+import org.zstack.header.core.workflow.Flow;
+
+public interface VmNicPrepareResourceExtensionPoint {
+    Flow getPreparationFlow();
+}

--- a/conf/db/upgrade/V4.8.0.3__schema.sql
+++ b/conf/db/upgrade/V4.8.0.3__schema.sql
@@ -68,3 +68,20 @@ DELETE FROM `zstack`.`HostKernelInterfaceVO` WHERE `l3NetworkUuid` IS NULL;
 ALTER TABLE `zstack`.`HostKernelInterfaceVO` DROP FOREIGN KEY `fkHostKernelInterfaceVOL3NetworkVO`;
 ALTER TABLE `zstack`.`HostKernelInterfaceVO` MODIFY `l3NetworkUuid` varchar(32) NOT NULL;
 ALTER TABLE `zstack`.`HostKernelInterfaceVO` ADD CONSTRAINT `fkHostKernelInterfaceVOL3NetworkVO` FOREIGN KEY (`l3NetworkUuid`) REFERENCES L3NetworkEO (`uuid`) ON DELETE CASCADE;
+
+-- Feature: support SR-IOV | ZSV-5082
+CREATE TABLE IF NOT EXISTS `zstack`.`EthernetVfPciDeviceVO` (
+    `uuid` varchar(32) NOT NULL UNIQUE,
+    `hostDevUuid` varchar(32) DEFAULT NULL,
+    `interfaceName` varchar(32) DEFAULT NULL,
+    `vmUuid` varchar(32) DEFAULT NULL,
+    `l3NetworkUuid` varchar(32) DEFAULT NULL,
+    `vfStatus` varchar(32) NOT NULL,
+    PRIMARY KEY  (`uuid`),
+    CONSTRAINT `fkEthernetVfPciDeviceVOVmInstanceEO` FOREIGN KEY (`vmUuid`) REFERENCES `VmInstanceEO` (`uuid`) ON DELETE SET NULL,
+    CONSTRAINT `fkEthernetVfPciDeviceVOHostEO` FOREIGN KEY (`hostDevUuid`) REFERENCES `HostEO` (`uuid`) ON DELETE CASCADE,
+    CONSTRAINT `fkEthernetVfPciDeviceVO` FOREIGN KEY (`uuid`) REFERENCES `PciDeviceVO` (`uuid`) ON DELETE CASCADE,
+    CONSTRAINT `fkEthernetVfPciDeviceVOL3NetworkEO` FOREIGN KEY (`l3NetworkUuid`) REFERENCES `L3NetworkEO` (`uuid`) ON DELETE SET NULL
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+ALTER TABLE `zstack`.`HostNetworkInterfaceVO` ADD COLUMN `virtStatus` VARCHAR(32) DEFAULT NULL AFTER `offloadStatus`;

--- a/conf/springConfigXml/VmInstanceManager.xml
+++ b/conf/springConfigXml/VmInstanceManager.xml
@@ -207,6 +207,7 @@
         <value>e1000</value>
         <value>rtl8139</value>
         <value>pcnet</value>
+        <value>SR-IOV</value>
     </util:list>
 
     <bean id="VmNicManager" class="org.zstack.compute.vm.VmNicManagerImpl">

--- a/header/src/main/java/org/zstack/header/allocator/AllocateHostMsg.java
+++ b/header/src/main/java/org/zstack/header/allocator/AllocateHostMsg.java
@@ -4,6 +4,7 @@ import org.zstack.header.configuration.DiskOfferingInventory;
 import org.zstack.header.image.ImageInventory;
 import org.zstack.header.message.NeedReplyMessage;
 import org.zstack.header.vm.VmInstanceInventory;
+import org.zstack.header.vm.VmNicParam;
 
 import java.util.*;
 
@@ -15,6 +16,7 @@ public class AllocateHostMsg extends NeedReplyMessage {
     private List<String> avoidHostUuids;
     private List<String> softAvoidHostUuids;
     private List<String> l3NetworkUuids;
+    private List<VmNicParam> vmNicParams = new ArrayList<>();
     private VmInstanceInventory vmInstance;
     private ImageInventory image;
     private String vmOperation;
@@ -178,6 +180,14 @@ public class AllocateHostMsg extends NeedReplyMessage {
 
     public void setL3NetworkUuids(List<String> l3NetworkUuids) {
         this.l3NetworkUuids = l3NetworkUuids;
+    }
+
+    public List<VmNicParam> getVmNicParams() {
+        return vmNicParams;
+    }
+
+    public void setVmNicParams(List<VmNicParam> vmNicParams) {
+        this.vmNicParams = vmNicParams;
     }
 
     public VmInstanceInventory getVmInstance() {

--- a/header/src/main/java/org/zstack/header/allocator/HostAllocatorSpec.java
+++ b/header/src/main/java/org/zstack/header/allocator/HostAllocatorSpec.java
@@ -3,6 +3,7 @@ package org.zstack.header.allocator;
 import org.zstack.header.configuration.DiskOfferingInventory;
 import org.zstack.header.image.ImageInventory;
 import org.zstack.header.vm.VmInstanceInventory;
+import org.zstack.header.vm.VmNicParam;
 
 import java.util.*;
 
@@ -14,6 +15,7 @@ public class HostAllocatorSpec {
     private long cpuCapacity;
     private long memoryCapacity;
     private List<String> l3NetworkUuids;
+    private List<VmNicParam> vmNicParams = new ArrayList<>();
     private long diskSize;
     private String hypervisorType;
     private String allocatorStrategy;
@@ -166,6 +168,14 @@ public class HostAllocatorSpec {
         this.l3NetworkUuids = l3NetworkUuids;
     }
 
+    public List<VmNicParam> getVmNicParams() {
+        return vmNicParams;
+    }
+
+    public void setVmNicParams(List<VmNicParam> vmNicParams) {
+        this.vmNicParams = vmNicParams;
+    }
+
     public long getDiskSize() {
         return diskSize;
     }
@@ -241,6 +251,7 @@ public class HostAllocatorSpec {
         spec.setMemoryCapacity(msg.getMemoryCapacity());
         spec.setVmInstance(msg.getVmInstance());
         spec.setL3NetworkUuids(msg.getL3NetworkUuids());
+        spec.setVmNicParams(msg.getVmNicParams());
         spec.setImage(msg.getImage());
         spec.setVmOperation(msg.getVmOperation());
         spec.setDiskOfferings(msg.getDiskOfferings());

--- a/header/src/main/java/org/zstack/header/network/l2/L2NetworkType.java
+++ b/header/src/main/java/org/zstack/header/network/l2/L2NetworkType.java
@@ -6,6 +6,7 @@ public class L2NetworkType {
     private static Map<String, L2NetworkType> types = Collections.synchronizedMap(new HashMap<String, L2NetworkType>());
     private final String typeName;
     private boolean exposed = true;
+    private boolean sriovSupported = false;
 
     public static boolean hasType(String typeName) {
         return types.containsKey(typeName);
@@ -21,12 +22,25 @@ public class L2NetworkType {
         this.exposed = exposed;
     }
 
+    public L2NetworkType(String typeName, boolean exposed, boolean sriovSupported) {
+        this(typeName, exposed);
+        this.sriovSupported = sriovSupported;
+    }
+
     public boolean isExposed() {
         return exposed;
     }
 
     public void setExposed(boolean exposed) {
         this.exposed = exposed;
+    }
+
+    public boolean isSriovSupported() {
+        return sriovSupported;
+    }
+
+    public void setSriovSupported(boolean isSupportSriov) {
+        this.sriovSupported = isSupportSriov;
     }
 
     public static L2NetworkType valueOf(String typeName) {
@@ -65,5 +79,15 @@ public class L2NetworkType {
             }
         }
         return exposedTypes;
+    }
+
+    public static Set<String> getSriovSupportedTypeName() {
+        HashSet<String> supportedTypes = new HashSet<String>();
+        for (L2NetworkType type : types.values()) {
+            if (type.isSriovSupported()) {
+                supportedTypes.add(type.toString());
+            }
+        }
+        return supportedTypes;
     }
 }

--- a/header/src/main/java/org/zstack/header/network/l2/VSwitchType.java
+++ b/header/src/main/java/org/zstack/header/network/l2/VSwitchType.java
@@ -29,10 +29,7 @@ public class VSwitchType {
     public VSwitchType(String typeName, VmNicType nicType) {
         this.typeName = typeName;
         types.put(typeName, this);
-        if (vSwitchSupportNicTypesMap.get(typeName) == null) {
-            vSwitchSupportNicTypesMap.put(typeName, new ArrayList<VmNicType>());
-        }
-        vSwitchSupportNicTypesMap.get(typeName).add(nicType);
+        vSwitchSupportNicTypesMap.computeIfAbsent(typeName, k -> new ArrayList<VmNicType>()).add(nicType);
     }
 
     public boolean isExposed() {

--- a/header/src/main/java/org/zstack/header/vm/APIAttachL3NetworkToVmMsg.java
+++ b/header/src/main/java/org/zstack/header/vm/APIAttachL3NetworkToVmMsg.java
@@ -168,7 +168,7 @@ public class APIAttachL3NetworkToVmMsg extends APIMessage implements VmInstanceM
         APIAttachL3NetworkToVmMsg msg = new APIAttachL3NetworkToVmMsg();
         msg.vmInstanceUuid = uuid();
         msg.l3NetworkUuid = uuid();
-        msg.driverType = "e1000";
+        msg.driverType = VmNicConstant.NIC_DRIVER_TYPE_E1000;
         return msg;
     }
 }

--- a/header/src/main/java/org/zstack/header/vm/APIChangeVmNicNetworkMsg.java
+++ b/header/src/main/java/org/zstack/header/vm/APIChangeVmNicNetworkMsg.java
@@ -25,6 +25,9 @@ public class APIChangeVmNicNetworkMsg extends APIMessage implements VmInstanceMe
     @APIParam(resourceType = L3NetworkVO.class, checkAccount = true)
     private String destL3NetworkUuid;
 
+    @APIParam(required = false)
+    private String vmNicParams;
+
     @APINoSee
     private String vmInstanceUuid;
 
@@ -47,6 +50,14 @@ public class APIChangeVmNicNetworkMsg extends APIMessage implements VmInstanceMe
 
     public void setDestL3NetworkUuid(String destL3NetworkUuid) {
         this.destL3NetworkUuid = destL3NetworkUuid;
+    }
+
+    public String getVmNicParams() {
+        return vmNicParams;
+    }
+
+    public void setVmNicParams(String vmNicParams) {
+        this.vmNicParams = vmNicParams;
     }
 
     public Map<String, List<String>> getRequiredIpMap() {

--- a/header/src/main/java/org/zstack/header/vm/APIChangeVmNicNetworkMsgDoc_zh_cn.groovy
+++ b/header/src/main/java/org/zstack/header/vm/APIChangeVmNicNetworkMsgDoc_zh_cn.groovy
@@ -66,6 +66,15 @@ doc {
 					optional true
 					since "0.6"
 				}
+				column {
+					name "vmNicParams"
+					enclosedIn "params"
+					desc "网卡信息"
+					location "body"
+					type "String"
+					optional true
+					since "4.2.0"
+				}
 			}
         }
 

--- a/header/src/main/java/org/zstack/header/vm/APIUpdateVmNicDriverEvent.java
+++ b/header/src/main/java/org/zstack/header/vm/APIUpdateVmNicDriverEvent.java
@@ -38,7 +38,7 @@ public class APIUpdateVmNicDriverEvent extends APIEvent {
         nic.setMac("00:0c:29:bd:99:fc");
         nic.setUsedIpUuid(uuid());
         nic.setUuid(uuid());
-        nic.setDriverType("e1000");
+        nic.setDriverType(VmNicConstant.NIC_DRIVER_TYPE_E1000);
 
         event.setInventory(nic);
 

--- a/header/src/main/java/org/zstack/header/vm/APIUpdateVmNicDriverMsg.java
+++ b/header/src/main/java/org/zstack/header/vm/APIUpdateVmNicDriverMsg.java
@@ -56,7 +56,7 @@ public class APIUpdateVmNicDriverMsg extends APIMessage implements VmInstanceMes
         APIUpdateVmNicDriverMsg msg = new APIUpdateVmNicDriverMsg();
         msg.vmInstanceUuid = uuid();
         msg.vmNicUuid = uuid();
-        msg.driverType = "e1000";
+        msg.driverType = VmNicConstant.NIC_DRIVER_TYPE_E1000;
         return msg;
     }
 }

--- a/header/src/main/java/org/zstack/header/vm/VmInstanceNicFactory.java
+++ b/header/src/main/java/org/zstack/header/vm/VmInstanceNicFactory.java
@@ -37,4 +37,8 @@ public interface VmInstanceNicFactory {
     default String  getPhysicalNicName(VmNicInventory nic) {
         return null;
     }
+
+    default void releaseVmNic(VmNicInventory nic) {
+        return;
+    }
 }

--- a/header/src/main/java/org/zstack/header/vm/VmInstanceSpec.java
+++ b/header/src/main/java/org/zstack/header/vm/VmInstanceSpec.java
@@ -294,7 +294,7 @@ public class VmInstanceSpec implements Serializable {
     }
 
     private VmInstanceInventory vmInventory;
-    private List<VmNicSpec> l3Networks;
+    private List<VmNicSpec> l3Networks = new ArrayList<>();
     private List<DiskOfferingInventory> dataDiskOfferings;
     private List<String> dataVolumeTemplateUuids;
     private Map<String, List<String>> dataVolumeFromTemplateSystemTags = new HashMap<>();
@@ -712,7 +712,7 @@ public class VmInstanceSpec implements Serializable {
         List<String> nsTypes = new ArrayList<>();
         if (getL3Networks() != null) {
             for (VmNicSpec nicSpec : getL3Networks()) {
-                for (L3NetworkInventory l3: nicSpec.l3Invs) {
+                for (L3NetworkInventory l3: nicSpec.getL3Invs()) {
                     nsTypes.addAll(l3.getNetworkServiceTypes());
                 }
             }

--- a/header/src/main/java/org/zstack/header/vm/VmInstanceType.java
+++ b/header/src/main/java/org/zstack/header/vm/VmInstanceType.java
@@ -9,6 +9,7 @@ public class VmInstanceType {
     private final String typeName;
 
     private boolean supportUpdateOnHypervisor = true;
+    private boolean sriovSupported = false;
 
     public VmInstanceType(String typeName) {
         this.typeName = typeName;
@@ -49,5 +50,13 @@ public class VmInstanceType {
 
     public void setSupportUpdateOnHypervisor(boolean supportUpdateOnHypervisor) {
         this.supportUpdateOnHypervisor = supportUpdateOnHypervisor;
+    }
+
+    public boolean isSriovSupported() {
+        return sriovSupported;
+    }
+
+    public void setSriovSupported(boolean sriovSupported) {
+        this.sriovSupported = sriovSupported;
     }
 }

--- a/header/src/main/java/org/zstack/header/vm/VmNicConstant.java
+++ b/header/src/main/java/org/zstack/header/vm/VmNicConstant.java
@@ -1,0 +1,12 @@
+package org.zstack.header.vm;
+
+import org.zstack.header.configuration.PythonClass;
+
+@PythonClass
+public interface VmNicConstant {
+    public static final String NIC_DRIVER_TYPE_VIRTIO = "virtio";
+    public static final String NIC_DRIVER_TYPE_E1000 = "e1000";
+    public static final String NIC_DRIVER_TYPE_RTL8139 = "rtl8139";
+    public static final String NIC_DRIVER_TYPE_PCNET = "pcnet";
+    public static final String NIC_DRIVER_TYPE_SR_IOV = "SR-IOV";
+}

--- a/header/src/main/java/org/zstack/header/vm/VmNicHelper.java
+++ b/header/src/main/java/org/zstack/header/vm/VmNicHelper.java
@@ -107,4 +107,19 @@ public class VmNicHelper {
     public static String getPrimaryL3Uuid(VmNicInventory nic) {
         return nic.getL3NetworkUuid();
     }
+
+    public static List<VmNicParam> getVmNicParamsWithVfNic(VmInstanceVO vmVo) {
+        List<VmNicParam> ret = new ArrayList<>();
+        for (VmNicVO nic : vmVo.getVmNics()) {
+            VmNicType nicType = VmNicType.valueOf(nic.getType());
+            if (nicType.isUseSRIOV()) {
+                VmNicParam param = new VmNicParam();
+                param.setL3NetworkUuid(nic.getL3NetworkUuid());
+                param.setDriverType(nic.getDriverType());
+                ret.add(param);
+            }
+        }
+
+        return ret;
+    }
 }

--- a/header/src/main/java/org/zstack/header/vm/VmNicParam.java
+++ b/header/src/main/java/org/zstack/header/vm/VmNicParam.java
@@ -2,7 +2,7 @@ package org.zstack.header.vm;
 
 import java.io.Serializable;
 
-public class VmNicParm implements Serializable {
+public class VmNicParam implements Serializable {
     private String l3NetworkUuid;
 
     private String ip;
@@ -26,6 +26,8 @@ public class VmNicParm implements Serializable {
     private Long inboundBandwidth;
 
     private Integer multiQueueNum;
+
+    private String vfParentUuid;
 
     public String getL3NetworkUuid() {
         return l3NetworkUuid;
@@ -121,5 +123,17 @@ public class VmNicParm implements Serializable {
 
     public void setMultiQueueNum(Integer multiQueueNum) {
         this.multiQueueNum = multiQueueNum;
+    }
+
+    public Boolean isSriovEnabled() {
+        return VmNicConstant.NIC_DRIVER_TYPE_SR_IOV.equals(driverType);
+    }
+
+    public String getVfParentUuid() {
+        return vfParentUuid;
+    }
+
+    public void setVfParentUuid(String vfParentUuid) {
+        this.vfParentUuid = vfParentUuid;
     }
 }

--- a/header/src/main/java/org/zstack/header/vm/VmNicSpec.java
+++ b/header/src/main/java/org/zstack/header/vm/VmNicSpec.java
@@ -11,12 +11,12 @@ import static org.zstack.utils.CollectionDSL.list;
 
 public class VmNicSpec implements Serializable {
     /* due to the design changed, single nic will only has 1 l3 network */
-    public List<L3NetworkInventory> l3Invs;
-    public String nicDriverType;
+    private List<L3NetworkInventory> l3Invs;
+    private String nicDriverType;
 
     //from api msg
     /* due to the design changed, single nic will only has 1 l3 network */
-    public List<VmNicParm> vmNicParms;
+    private List<VmNicParam> vmNicParams;
 
     public VmNicSpec(List<L3NetworkInventory> l3Invs) {
         this.l3Invs = l3Invs;
@@ -85,11 +85,29 @@ public class VmNicSpec implements Serializable {
         return res;
     }
 
-    public List<VmNicParm> getVmNicParms() {
-        return vmNicParms;
+    public static List<VmNicParam> getVmNicParamsOfSpec(List<VmNicSpec> specs) {
+        List<VmNicParam> vmNicParams = new ArrayList<>();
+        for (VmNicSpec spec: specs) {
+            if (spec.vmNicParams != null) {
+                vmNicParams.addAll(spec.vmNicParams);
+            }
+        }
+        return vmNicParams;
     }
 
-    public void setVmNicParms(List<VmNicParm> vmNicParms) {
-        this.vmNicParms = vmNicParms;
+    public List<VmNicParam> getVmNicParams() {
+        return vmNicParams;
+    }
+
+    public void setVmNicParams(List<VmNicParam> vmNicParams) {
+        this.vmNicParams = vmNicParams;
+    }
+
+    public VmNicParam getVmNicParam() {
+        if (CollectionUtils.isEmpty(this.vmNicParams)) {
+            return new VmNicParam();
+        }
+
+        return this.vmNicParams.get(0);
     }
 }

--- a/network/src/main/java/org/zstack/network/l2/L2NoVlanL2NetworkFactory.java
+++ b/network/src/main/java/org/zstack/network/l2/L2NoVlanL2NetworkFactory.java
@@ -13,7 +13,7 @@ import org.zstack.utils.data.FieldPrinter;
 import org.zstack.utils.logging.CLogger;
 
 public class L2NoVlanL2NetworkFactory implements L2NetworkFactory, Component, L2NetworkDefaultMtu, L2NetworkGetVniExtensionPoint {
-    private static L2NetworkType type = new L2NetworkType(L2NetworkConstant.L2_NO_VLAN_NETWORK_TYPE);
+    private static L2NetworkType type = new L2NetworkType(L2NetworkConstant.L2_NO_VLAN_NETWORK_TYPE, true, true);
     private static CLogger logger = Utils.getLogger(L2NoVlanL2NetworkFactory.class);
     private static FieldPrinter printer = Utils.getFieldPrinter();
     

--- a/network/src/main/java/org/zstack/network/l2/L2VlanNetworkFactory.java
+++ b/network/src/main/java/org/zstack/network/l2/L2VlanNetworkFactory.java
@@ -23,7 +23,7 @@ import java.util.List;
 
 public class L2VlanNetworkFactory extends AbstractService implements L2NetworkFactory, L2NetworkDefaultMtu, L2NetworkGetVniExtensionPoint {
     private static CLogger logger = Utils.getLogger(L2VlanNetworkFactory.class);
-    static L2NetworkType type = new L2NetworkType(L2NetworkConstant.L2_VLAN_NETWORK_TYPE);
+    static L2NetworkType type = new L2NetworkType(L2NetworkConstant.L2_VLAN_NETWORK_TYPE, true, true);
     
     @Autowired
     private DatabaseFacade dbf;

--- a/plugin/applianceVm/src/main/java/org/zstack/appliancevm/ApplianceVmFactory.java
+++ b/plugin/applianceVm/src/main/java/org/zstack/appliancevm/ApplianceVmFactory.java
@@ -21,6 +21,10 @@ import java.util.Map;
 public class ApplianceVmFactory implements VmInstanceFactory, Component {
     public static VmInstanceType type = new VmInstanceType(ApplianceVmConstant.APPLIANCE_VM_TYPE);
 
+    static {
+        type.setSriovSupported(true);
+    }
+
     @Autowired
     private DatabaseFacade dbf;
     @Autowired

--- a/plugin/hostNetworkInterface/src/main/java/org/zstack/network/hostNetworkInterface/HostNetworkInterfaceInventory.java
+++ b/plugin/hostNetworkInterface/src/main/java/org/zstack/network/hostNetworkInterface/HostNetworkInterfaceInventory.java
@@ -44,6 +44,7 @@ public class HostNetworkInterfaceInventory implements Serializable {
     private String callBackIp;
     private String pciDeviceAddress;
     private String offloadStatus;
+    private String virtStatus;
     private String description;
     private Timestamp createDate;
     private Timestamp lastOpDate;
@@ -224,6 +225,14 @@ public class HostNetworkInterfaceInventory implements Serializable {
         this.offloadStatus = offloadStatus;
     }
 
+    public String getVirtStatus() {
+        return virtStatus;
+    }
+
+    public void setVirtStatus(String virtStatus) {
+        this.virtStatus = virtStatus;
+    }
+
     public String getDescription() {
         return description;
     }
@@ -277,6 +286,7 @@ public class HostNetworkInterfaceInventory implements Serializable {
         this.slaveActive = vo.isSlaveActive();
         this.carrierActive = vo.isCarrierActive();
         this.offloadStatus = vo.getOffloadStatus();
+        this.virtStatus = vo.getVirtStatus();
         this.description = vo.getDescription();
         this.createDate = vo.getCreateDate();
         this.lastOpDate = vo.getLastOpDate();

--- a/plugin/hostNetworkInterface/src/main/java/org/zstack/network/hostNetworkInterface/HostNetworkInterfaceUpdateExtensionPoint.java
+++ b/plugin/hostNetworkInterface/src/main/java/org/zstack/network/hostNetworkInterface/HostNetworkInterfaceUpdateExtensionPoint.java
@@ -1,0 +1,7 @@
+package org.zstack.network.hostNetworkInterface;
+
+import java.util.List;
+
+public interface HostNetworkInterfaceUpdateExtensionPoint {
+    public void afterCreated(String hostUuid, List<HostNetworkInterfaceVO> interfaceVOS, List<HostNetworkBondingVO> bondingVOS);
+}

--- a/plugin/hostNetworkInterface/src/main/java/org/zstack/network/hostNetworkInterface/HostNetworkInterfaceVO.java
+++ b/plugin/hostNetworkInterface/src/main/java/org/zstack/network/hostNetworkInterface/HostNetworkInterfaceVO.java
@@ -86,6 +86,9 @@ public class HostNetworkInterfaceVO extends ResourceVO implements ToInventory, O
     private String offloadStatus;
 
     @Column
+    private String virtStatus;
+
+    @Column
     private String description;
 
     @Column
@@ -263,6 +266,14 @@ public class HostNetworkInterfaceVO extends ResourceVO implements ToInventory, O
 
     public void setOffloadStatus(String offloadStatus) {
         this.offloadStatus = offloadStatus;
+    }
+
+    public String getVirtStatus() {
+        return virtStatus;
+    }
+
+    public void setVirtStatus(String virtStatus) {
+        this.virtStatus = virtStatus;
     }
 
     public String getDescription() {

--- a/plugin/hostNetworkInterface/src/main/java/org/zstack/network/hostNetworkInterface/HostNetworkInterfaceVO_.java
+++ b/plugin/hostNetworkInterface/src/main/java/org/zstack/network/hostNetworkInterface/HostNetworkInterfaceVO_.java
@@ -29,6 +29,7 @@ public class HostNetworkInterfaceVO_ extends ResourceVO_ {
     public static volatile SingularAttribute<HostNetworkInterfaceVO, String> callBackIp;
     public static volatile SingularAttribute<HostNetworkInterfaceVO, String> pciDeviceAddress;
     public static volatile SingularAttribute<HostNetworkInterfaceVO, String> offloadStatus;
+    public static volatile SingularAttribute<HostNetworkInterfaceVO, String> virtStatus;
     public static volatile SingularAttribute<HostNetworkInterfaceVO, Long> speed;
     public static volatile SingularAttribute<HostNetworkInterfaceVO, Boolean> slaveActive;
     public static volatile SingularAttribute<HostNetworkInterfaceVO, Boolean> carrierActive;

--- a/plugin/kvm/src/main/java/org/zstack/kvm/KVMHost.java
+++ b/plugin/kvm/src/main/java/org/zstack/kvm/KVMHost.java
@@ -100,9 +100,6 @@ import org.zstack.utils.tester.ZTester;
 
 import javax.persistence.TypedQuery;
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.*;
@@ -3770,6 +3767,7 @@ public class KVMHost extends HostBase implements Host {
                 msg.setHostUuid(self.getUuid());
                 msg.setFullAllocate(false);
                 msg.setL3NetworkUuids(VmNicHelper.getL3Uuids(VmNicInventory.valueOf(vm.getVmNics())));
+                msg.setVmNicParams(VmNicHelper.getVmNicParamsWithVfNic(vm));
                 msg.setServiceId(bus.makeLocalServiceId(HostAllocatorConstant.SERVICE_ID));
                 bus.send(msg, new CloudBusCallBack(chain) {
                     @Override

--- a/sdk/src/main/java/SourceClassMap.java
+++ b/sdk/src/main/java/SourceClassMap.java
@@ -284,6 +284,8 @@ public class SourceClassMap {
 			put("org.zstack.header.securitymachine.SecretResourcePoolInventory", "org.zstack.sdk.SecretResourcePoolInventory");
 			put("org.zstack.header.securitymachine.SecurityMachineInventory", "org.zstack.sdk.SecurityMachineInventory");
 			put("org.zstack.header.simulator.SimulatorHostInventory", "org.zstack.sdk.SimulatorHostInventory");
+			put("org.zstack.header.sriov.EthernetVfPciDeviceInventory", "org.zstack.sdk.EthernetVfPciDeviceInventory");
+			put("org.zstack.header.sriov.EthernetVfStatus", "org.zstack.sdk.EthernetVfStatus");
 			put("org.zstack.header.sriov.VmVfNicInventory", "org.zstack.sdk.VmVfNicInventory");
 			put("org.zstack.header.sshkeypair.SshKeyPairInventory", "org.zstack.sdk.SshKeyPairInventory");
 			put("org.zstack.header.sshkeypair.SshPrivateKeyPairInventory", "org.zstack.sdk.SshPrivateKeyPairInventory");
@@ -877,6 +879,8 @@ public class SourceClassMap {
 			put("org.zstack.sdk.EmailTriggerActionInventory", "org.zstack.monitoring.actions.EmailTriggerActionInventory");
 			put("org.zstack.sdk.ErrorCode", "org.zstack.header.errorcode.ErrorCode");
 			put("org.zstack.sdk.ErrorCodeList", "org.zstack.header.errorcode.ErrorCodeList");
+			put("org.zstack.sdk.EthernetVfPciDeviceInventory", "org.zstack.header.sriov.EthernetVfPciDeviceInventory");
+			put("org.zstack.sdk.EthernetVfStatus", "org.zstack.header.sriov.EthernetVfStatus");
 			put("org.zstack.sdk.EventLogInventory", "org.zstack.core.eventlog.EventLogInventory");
 			put("org.zstack.sdk.ExternalBackupInventory", "org.zstack.externalbackup.ExternalBackupInventory");
 			put("org.zstack.sdk.ExternalBackupState", "org.zstack.externalbackup.ExternalBackupState");

--- a/sdk/src/main/java/org/zstack/sdk/CreateSlbInstanceAction.java
+++ b/sdk/src/main/java/org/zstack/sdk/CreateSlbInstanceAction.java
@@ -43,6 +43,9 @@ public class CreateSlbInstanceAction extends AbstractAction {
     @Param(required = false, nonempty = false, nullElements = false, emptyString = true, noTrim = false)
     public java.lang.String hostUuid;
 
+    @Param(required = false, nonempty = false, nullElements = false, emptyString = true, noTrim = false)
+    public java.lang.String vmNicParams;
+
     @Param(required = false)
     public java.lang.String resourceUuid;
 

--- a/sdk/src/main/java/org/zstack/sdk/CreateVpcVRouterAction.java
+++ b/sdk/src/main/java/org/zstack/sdk/CreateVpcVRouterAction.java
@@ -49,6 +49,9 @@ public class CreateVpcVRouterAction extends AbstractAction {
     @Param(required = false, nonempty = false, nullElements = false, emptyString = true, noTrim = false)
     public java.util.List rootVolumeSystemTags;
 
+    @Param(required = false, nonempty = false, nullElements = false, emptyString = true, noTrim = false)
+    public java.lang.String vmNicParams;
+
     @Param(required = false)
     public java.lang.String resourceUuid;
 

--- a/sdk/src/main/java/org/zstack/sdk/EthernetVfPciDeviceInventory.java
+++ b/sdk/src/main/java/org/zstack/sdk/EthernetVfPciDeviceInventory.java
@@ -1,0 +1,47 @@
+package org.zstack.sdk;
+
+import org.zstack.sdk.EthernetVfStatus;
+
+public class EthernetVfPciDeviceInventory extends org.zstack.sdk.PciDeviceInventory {
+
+    public java.lang.String hostDevUuid;
+    public void setHostDevUuid(java.lang.String hostDevUuid) {
+        this.hostDevUuid = hostDevUuid;
+    }
+    public java.lang.String getHostDevUuid() {
+        return this.hostDevUuid;
+    }
+
+    public java.lang.String interfaceName;
+    public void setInterfaceName(java.lang.String interfaceName) {
+        this.interfaceName = interfaceName;
+    }
+    public java.lang.String getInterfaceName() {
+        return this.interfaceName;
+    }
+
+    public java.lang.String vmUuid;
+    public void setVmUuid(java.lang.String vmUuid) {
+        this.vmUuid = vmUuid;
+    }
+    public java.lang.String getVmUuid() {
+        return this.vmUuid;
+    }
+
+    public java.lang.String l3NetworkUuid;
+    public void setL3NetworkUuid(java.lang.String l3NetworkUuid) {
+        this.l3NetworkUuid = l3NetworkUuid;
+    }
+    public java.lang.String getL3NetworkUuid() {
+        return this.l3NetworkUuid;
+    }
+
+    public EthernetVfStatus vfStatus;
+    public void setVfStatus(EthernetVfStatus vfStatus) {
+        this.vfStatus = vfStatus;
+    }
+    public EthernetVfStatus getVfStatus() {
+        return this.vfStatus;
+    }
+
+}

--- a/sdk/src/main/java/org/zstack/sdk/EthernetVfStatus.java
+++ b/sdk/src/main/java/org/zstack/sdk/EthernetVfStatus.java
@@ -1,0 +1,8 @@
+package org.zstack.sdk;
+
+public enum EthernetVfStatus {
+	Available,
+	Reserved,
+	Attached,
+	Releasing,
+}

--- a/sdk/src/main/java/org/zstack/sdk/HostNetworkInterfaceInventory.java
+++ b/sdk/src/main/java/org/zstack/sdk/HostNetworkInterfaceInventory.java
@@ -180,6 +180,14 @@ public class HostNetworkInterfaceInventory  {
         return this.offloadStatus;
     }
 
+    public java.lang.String virtStatus;
+    public void setVirtStatus(java.lang.String virtStatus) {
+        this.virtStatus = virtStatus;
+    }
+    public java.lang.String getVirtStatus() {
+        return this.virtStatus;
+    }
+
     public java.lang.String description;
     public void setDescription(java.lang.String description) {
         this.description = description;

--- a/sdk/src/main/java/org/zstack/sdk/QueryEthernetVFAction.java
+++ b/sdk/src/main/java/org/zstack/sdk/QueryEthernetVFAction.java
@@ -4,7 +4,7 @@ import java.util.HashMap;
 import java.util.Map;
 import org.zstack.sdk.*;
 
-public class ChangeVmNicNetworkAction extends AbstractAction {
+public class QueryEthernetVFAction extends QueryAction {
 
     private static final HashMap<String, Parameter> parameterMap = new HashMap<>();
 
@@ -12,7 +12,7 @@ public class ChangeVmNicNetworkAction extends AbstractAction {
 
     public static class Result {
         public ErrorCode error;
-        public org.zstack.sdk.ChangeVmNicNetworkResult value;
+        public org.zstack.sdk.QueryEthernetVFResult value;
 
         public Result throwExceptionIfError() {
             if (error != null) {
@@ -25,41 +25,6 @@ public class ChangeVmNicNetworkAction extends AbstractAction {
         }
     }
 
-    @Param(required = true, nonempty = false, nullElements = false, emptyString = true, noTrim = false)
-    public java.lang.String vmNicUuid;
-
-    @Param(required = true, nonempty = false, nullElements = false, emptyString = true, noTrim = false)
-    public java.lang.String destL3NetworkUuid;
-
-    @Param(required = false, nonempty = false, nullElements = false, emptyString = true, noTrim = false)
-    public java.lang.String vmNicParams;
-
-    @Param(required = false)
-    public java.lang.String staticIp;
-
-    @Param(required = false)
-    public java.util.List systemTags;
-
-    @Param(required = false)
-    public java.util.List userTags;
-
-    @Param(required = false)
-    public String sessionId;
-
-    @Param(required = false)
-    public String accessKeyId;
-
-    @Param(required = false)
-    public String accessKeySecret;
-
-    @Param(required = false)
-    public String requestIp;
-
-    @NonAPIParam
-    public long timeout = -1;
-
-    @NonAPIParam
-    public long pollingInterval = -1;
 
 
     private Result makeResult(ApiResult res) {
@@ -69,8 +34,8 @@ public class ChangeVmNicNetworkAction extends AbstractAction {
             return ret;
         }
         
-        org.zstack.sdk.ChangeVmNicNetworkResult value = res.getResult(org.zstack.sdk.ChangeVmNicNetworkResult.class);
-        ret.value = value == null ? new org.zstack.sdk.ChangeVmNicNetworkResult() : value; 
+        org.zstack.sdk.QueryEthernetVFResult value = res.getResult(org.zstack.sdk.QueryEthernetVFResult.class);
+        ret.value = value == null ? new org.zstack.sdk.QueryEthernetVFResult() : value; 
 
         return ret;
     }
@@ -99,11 +64,11 @@ public class ChangeVmNicNetworkAction extends AbstractAction {
 
     protected RestInfo getRestInfo() {
         RestInfo info = new RestInfo();
-        info.httpMethod = "POST";
-        info.path = "/vm-instances/nics/{vmNicUuid}/l3-networks/{destL3NetworkUuid}";
+        info.httpMethod = "GET";
+        info.path = "/pci-device/ethernet-vfs";
         info.needSession = true;
-        info.needPoll = true;
-        info.parameterName = "params";
+        info.needPoll = false;
+        info.parameterName = "";
         return info;
     }
 

--- a/sdk/src/main/java/org/zstack/sdk/QueryEthernetVFResult.java
+++ b/sdk/src/main/java/org/zstack/sdk/QueryEthernetVFResult.java
@@ -1,0 +1,22 @@
+package org.zstack.sdk;
+
+
+
+public class QueryEthernetVFResult {
+    public java.util.List inventories;
+    public void setInventories(java.util.List inventories) {
+        this.inventories = inventories;
+    }
+    public java.util.List getInventories() {
+        return this.inventories;
+    }
+
+    public java.lang.Long total;
+    public void setTotal(java.lang.Long total) {
+        this.total = total;
+    }
+    public java.lang.Long getTotal() {
+        return this.total;
+    }
+
+}

--- a/test/src/test/groovy/org/zstack/test/integration/kvm/nic/ChangeWindowsVmNicDriverCase.groovy
+++ b/test/src/test/groovy/org/zstack/test/integration/kvm/nic/ChangeWindowsVmNicDriverCase.groovy
@@ -1,15 +1,13 @@
 package org.zstack.test.integration.kvm.nic
 
-import org.springframework.beans.factory.annotation.Autowired
 import org.zstack.compute.vm.VmSystemTags
 import org.zstack.header.image.ImagePlatform
 import org.zstack.header.tag.SystemTagVO
 import org.zstack.header.tag.SystemTagVO_
+import org.zstack.header.vm.VmNicConstant
 import org.zstack.sdk.VmInstanceInventory
 import org.zstack.header.vm.VmNicVO
 import org.zstack.header.vm.VmNicVO_
-import org.zstack.tag.SystemTag
-import org.zstack.tag.TagManager
 import org.zstack.header.vm.VmInstanceState
 import org.zstack.test.integration.kvm.Env
 import org.zstack.test.integration.kvm.KvmTest
@@ -45,7 +43,7 @@ class ChangeWindowsVmNicDriverCase extends SubCase {
     void testChangeWindowsVmNicDriver() {
         VmInstanceInventory vm = env.inventoryByName("vm") as VmInstanceInventory
         assert VmSystemTags.VIRTIO.hasTag(vm.uuid)
-        assert vm.vmNics[0].driverType == "virtio"
+        assert vm.vmNics[0].driverType == VmNicConstant.NIC_DRIVER_TYPE_VIRTIO
 
         updateVmInstance {
             platform = ImagePlatform.Windows.toString()
@@ -59,7 +57,7 @@ class ChangeWindowsVmNicDriverCase extends SubCase {
                     .findValue().toString()
         }
         assert !VmSystemTags.VIRTIO.hasTag(vm.uuid)
-        assert Q.New(VmNicVO.class).eq(VmNicVO_.vmInstanceUuid, vm.uuid).select(VmNicVO_.driverType).findValue() == "e1000"
+        assert Q.New(VmNicVO.class).eq(VmNicVO_.vmInstanceUuid, vm.uuid).select(VmNicVO_.driverType).findValue() == VmNicConstant.NIC_DRIVER_TYPE_E1000
 
         if (vm.state.equals(VmInstanceState.Running.toString())) {
             expect(AssertionError.class) {
@@ -86,6 +84,6 @@ class ChangeWindowsVmNicDriverCase extends SubCase {
         }
 
         assert VmSystemTags.VIRTIO.hasTag(vm.uuid)
-        assert Q.New(VmNicVO.class).eq(VmNicVO_.vmInstanceUuid, vm.uuid).select(VmNicVO_.driverType).findValue().equals("virtio")
+        assert Q.New(VmNicVO.class).eq(VmNicVO_.vmInstanceUuid, vm.uuid).select(VmNicVO_.driverType).findValue() == VmNicConstant.NIC_DRIVER_TYPE_VIRTIO
     }
 }

--- a/test/src/test/groovy/org/zstack/test/integration/networkservice/provider/virtualrouter/VirtualrouterMultiNicCase.groovy
+++ b/test/src/test/groovy/org/zstack/test/integration/networkservice/provider/virtualrouter/VirtualrouterMultiNicCase.groovy
@@ -8,7 +8,7 @@ import org.zstack.core.db.SimpleQuery
 import org.zstack.header.network.service.NetworkServiceProviderVO
 import org.zstack.header.network.service.NetworkServiceProviderVO_
 import org.zstack.header.network.service.NetworkServiceType
-import org.zstack.header.vm.VmNicParm
+import org.zstack.header.vm.VmNicParam
 import org.zstack.kvm.KVMAgentCommands
 import org.zstack.kvm.KVMConstant
 import org.zstack.network.securitygroup.APIAddSecurityGroupRuleMsg
@@ -544,14 +544,14 @@ class VirtualrouterMultiNicCase extends SubCase {
 
         assert vm.vmNics.size() == MAX_NIC_COUNT
 
-        List<VmNicParm> nicParms = new ArrayList<>()
-        VmNicParm nicParm = new VmNicParm()
-        nicParm.setL3NetworkUuid(l3.uuid)
-        nicParm.setDriverType("virtio")
-        nicParm.setMultiQueueNum(4)
-        nicParms.add(nicParm)
-        nicParms.add(nicParm)
-        nicParms.add(nicParm)
+        List<VmNicParam> nicParams = new ArrayList<>()
+        VmNicParam nicParam = new VmNicParam()
+        nicParam.setL3NetworkUuid(l3.uuid)
+        nicParam.setDriverType("virtio")
+        nicParam.setMultiQueueNum(4)
+        nicParams.add(nicParam)
+        nicParams.add(nicParam)
+        nicParams.add(nicParam)
 
         def vm2 = createVmInstance {
             name = "vm2"
@@ -559,7 +559,7 @@ class VirtualrouterMultiNicCase extends SubCase {
             l3NetworkUuids = [l3.uuid, l3.uuid, l3.uuid]
             defaultL3NetworkUuid = l3.uuid
             instanceOfferingUuid = offering.uuid
-            vmNicParams = JSONObjectUtil.toJsonString(nicParms)
+            vmNicParams = JSONObjectUtil.toJsonString(nicParams)
         } as VmInstanceInventory
 
         assert vm2.vmNics.size() == 3

--- a/testlib/src/main/java/org/zstack/testlib/ApiHelper.groovy
+++ b/testlib/src/main/java/org/zstack/testlib/ApiHelper.groovy
@@ -27512,6 +27512,35 @@ abstract class ApiHelper {
     }
 
 
+    def queryEthernetVF(@DelegatesTo(strategy = Closure.OWNER_FIRST, value = org.zstack.sdk.QueryEthernetVFAction.class) Closure c) {
+        def a = new org.zstack.sdk.QueryEthernetVFAction()
+        a.sessionId = Test.currentEnvSpec?.session?.uuid
+        c.resolveStrategy = Closure.OWNER_FIRST
+        c.delegate = a
+        c()
+        
+        a.conditions = a.conditions.collect { it.toString() }
+
+
+        if (System.getProperty("apipath") != null) {
+            if (a.apiId == null) {
+                a.apiId = Platform.uuid
+            }
+    
+            def tracker = new ApiPathTracker(a.apiId)
+            def out = errorOut(a.call())
+            def path = tracker.getApiPath()
+            if (!path.isEmpty()) {
+                Test.apiPaths[a.class.name] = path.join(" --->\n")
+            }
+        
+            return out
+        } else {
+            return errorOut(a.call())
+        }
+    }
+
+
     def queryEventFromResourceStack(@DelegatesTo(strategy = Closure.OWNER_FIRST, value = org.zstack.sdk.QueryEventFromResourceStackAction.class) Closure c) {
         def a = new org.zstack.sdk.QueryEventFromResourceStackAction()
         a.sessionId = Test.currentEnvSpec?.session?.uuid


### PR DESCRIPTION
DBImpact
APIImpact

Resolves: ZSV-5082

Change-Id: I697075646a6e7862747171616e7066786a676469

sync from gitlab !6005

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 增加了对 SR-IOV 的支持，包括虚拟功能（VF）网络接口的处理和查询。
  - 引入了针对不同虚拟机类型和网络设置的新验证逻辑。

- **改进**
  - 优化了虚拟机网络接口（NIC）的参数处理，包括重命名、方法签名更新和逻辑调整。
  - 在多个组件中增加了对虚拟网络接口参数的设置和处理。

- **Bug 修复**
  - 修正了虚拟机网络接口参数在特定流程中的处理逻辑。

- **数据库更新**
  - 创建了新的数据库表和字段来支持 SR-IOV 功能。

- **测试**
  - 更新了测试用例以适应代码变更，保证功能的正确性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->