### PR TITLE
<fix>[expon]: report node healthy for iscsi protocol

### DIFF
--- a/header/src/main/java/org/zstack/header/storage/addon/primary/NodeHealthyCheckProtocolExtensionPoint.java
+++ b/header/src/main/java/org/zstack/header/storage/addon/primary/NodeHealthyCheckProtocolExtensionPoint.java
@@ -1,0 +1,8 @@
+package org.zstack.header.storage.addon.primary;
+
+import org.zstack.header.host.HypervisorType;
+
+public interface NodeHealthyCheckProtocolExtensionPoint {
+    HypervisorType getHypervisorType();
+    String getHealthyProtocol();
+}

--- a/plugin/expon/src/main/java/org/zstack/expon/ExponIscsiHelper.java
+++ b/plugin/expon/src/main/java/org/zstack/expon/ExponIscsiHelper.java
@@ -14,6 +14,8 @@ public class ExponIscsiHelper {
 
     static String iscsiHeartbeatVolumeName = "iscsi_zstack_heartbeat";
 
+    static String iscsiPrefix = "iscsi_zstack";
+
     static String buildIscsiExportClientName(String clientIp) {
         return "iscsi_" + clientIp.replace(".", "_");
     }

--- a/storage/src/main/java/org/zstack/storage/addon/primary/ExternalPrimaryStorage.java
+++ b/storage/src/main/java/org/zstack/storage/addon/primary/ExternalPrimaryStorage.java
@@ -176,7 +176,7 @@ public class ExternalPrimaryStorage extends PrimaryStorageBase {
         } else if (msg instanceof InstantiateMemoryVolumeOnPrimaryStorageMsg) {
             throw new UnsupportedOperationException();
         } else {
-            spec.setName(volume.getName());
+            spec.setName(buildVolumeName(volume.getUuid()));
             createEmptyVolume(msg, spec);
         }
     }


### PR DESCRIPTION
report node healthy for iscsi protocol

Resolves: ZSTAC-63741

Change-Id: I6568687270737961786c6578667579636e66716c

sync from gitlab !6020

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新功能**
    - 在`HostManagerImpl`中增加了一个公共`Map`字段`usedProtocolExtensions`，用于根据虚拟机管理程序类型在扩展填充期间存储`HostUsedProtocolExtensionPoint`实例。
    - 添加了`HostUsedProtocolExtensionPoint.java`文件，定义了一个接口，用于在计算主机上下文中检索与主机相关的虚拟机管理程序类型和主机协议。
    - 在`ExponIscsiHelper.java`文件中，添加了一个新的静态字符串`iscsiPrefix`，值为"iscsi_zstack"，用于存储iSCSI相关操作的通用前缀。
    - 在`ExponStorageController`中，增加了对不同协议（`Vhost`和`iSCSI`）的处理，以及基于主机协议的特定协议健康检查方法。
    - 引入了`KVMUsedProtocolPoint`接口，用于检索与卷协议相关的主机协议和KVM虚拟机管理程序类型。
    - 修改了`ExternalPrimaryStorage.java`中的`handle`方法，改为使用`buildVolumeName`方法通过卷UUID来设置卷名称，而不是直接从卷对象设置名称。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->