### PR TITLE
<fix>[localstorage]: set DEST_HOST_FOR_CREATING_DATA_VOLUME noncloneable

### DIFF
--- a/plugin/localstorage/src/main/java/org/zstack/storage/primary/local/LocalStorageSystemTags.java
+++ b/plugin/localstorage/src/main/java/org/zstack/storage/primary/local/LocalStorageSystemTags.java
@@ -1,5 +1,6 @@
 package org.zstack.storage.primary.local;
 
+import org.zstack.header.core.NonCloneable;
 import org.zstack.header.host.HostVO;
 import org.zstack.header.tag.TagDefinition;
 import org.zstack.header.volume.VolumeVO;
@@ -12,6 +13,7 @@ import org.zstack.tag.PatternedSystemTag;
 @TagDefinition
 public class LocalStorageSystemTags {
     public static final String DEST_HOST_FOR_CREATING_DATA_VOLUME_TOKEN = "hostUuid";
+    @NonCloneable
     public static PatternedSystemTag DEST_HOST_FOR_CREATING_DATA_VOLUME = new PatternedSystemTag(
             String.format("localStorage::hostUuid::{%s}", DEST_HOST_FOR_CREATING_DATA_VOLUME_TOKEN),
             VolumeVO.class


### PR DESCRIPTION
Resolves: ZSTAC-64707

Change-Id: I6a666d6f69776c677771656a637a6161796c636e

sync from gitlab !6090

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 增加了数据卷创建过程中目标主机的非克隆标记。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->