### PR TITLE
<fix>[network]: fix npe

### DIFF
--- a/plugin/flatNetworkProvider/src/main/java/org/zstack/network/service/flat/BridgeVlanIdFinder.java
+++ b/plugin/flatNetworkProvider/src/main/java/org/zstack/network/service/flat/BridgeVlanIdFinder.java
@@ -43,11 +43,14 @@ public class BridgeVlanIdFinder {
 
     @Transactional(readOnly = true)
     public Map<String, String> findByL2Uuids(Collection<String> l2Uuids) {
+        if (l2Uuids == null || l2Uuids.isEmpty()) {
+            return new HashMap<>();
+        }
         Map<String, String> bridgesVlan = new HashMap<>();
         List<L2NetworkVO> l2Vos = Q.New(L2NetworkVO.class).in(L2NetworkVO_.uuid, asList(l2Uuids)).list();
         l2Vos.forEach(l2 -> {
             String bridge = KVMSystemTags.L2_BRIDGE_NAME.getTokenByResourceUuid(l2.getUuid(), KVMSystemTags.L2_BRIDGE_NAME_TOKEN);
-            if (l2.getVirtualNetworkId() != null && !l2.getVirtualNetworkId().equals(0)) {
+            if (bridge != null && l2.getVirtualNetworkId() != null && !l2.getVirtualNetworkId().equals(0)) {
                 // ugly if condition due to history vlan usage which embed in the legacy bridge name
                 if (!bridge.contains(l2.getVirtualNetworkId().toString())) {
                     String vlanId = "";


### PR DESCRIPTION
Resolves: ZSTAC-64969

Change-Id: I6868776c47329c4eba1f49f492d89d8d0b90a0f8

sync from gitlab !6093

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 在处理前增加了对空或空白 `l2Uuids` 集合的检查，确保在这种情况下返回一个新的空映射。
	- 调整了对 `bridge` 和 `l2.getVirtualNetworkId()` 的检查逻辑，以处理嵌入在桥名称中的传统 VLAN 使用。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->