### PR TITLE
<fix>[kvm]: add parameter KvmReportVmShutdownEventMsg.detail

### DIFF
--- a/compute/src/main/java/org/zstack/compute/vm/VmInstanceBase.java
+++ b/compute/src/main/java/org/zstack/compute/vm/VmInstanceBase.java
@@ -542,7 +542,7 @@ public class VmInstanceBase extends AbstractVmInstance {
             public void run(SyncTaskChain chain) {
                 KvmReportVmShutdownEventReply reply = new KvmReportVmShutdownEventReply();
                 for (KvmReportVmShutdownEventExtensionPoint ext : pluginRgty.getExtensionList(KvmReportVmShutdownEventExtensionPoint.class)) {
-                    ext.kvmReportVmShutdownEvent(msg.getVmInstanceUuid());
+                    ext.kvmReportVmShutdownEvent(KvmReportVmShutdownEventExtensionPoint.ShutdownDetail.of(msg));
                 }
                 bus.reply(msg, reply);
                 chain.next();

--- a/header/src/main/java/org/zstack/header/vm/KvmReportVmShutdownEventExtensionPoint.java
+++ b/header/src/main/java/org/zstack/header/vm/KvmReportVmShutdownEventExtensionPoint.java
@@ -1,9 +1,32 @@
 package org.zstack.header.vm;
 
+import static org.zstack.header.vm.VmInstanceConstant.*;
+
 /**
  * @Author: qiuyu.zhang
  * @Date: 2024/3/4 13:14
  */
 public interface KvmReportVmShutdownEventExtensionPoint {
-    void kvmReportVmShutdownEvent(String vmUuid);
+    void kvmReportVmShutdownEvent(ShutdownDetail vmUuid);
+
+    public class ShutdownDetail {
+        public String vmUuid;
+        public String detail;
+        public String opaque;
+
+        public boolean triggerByHost;
+        public boolean triggerByGuest;
+
+        public static ShutdownDetail of(KvmReportVmShutdownEventMsg message) {
+            ShutdownDetail struct = new ShutdownDetail();
+            struct.vmUuid = message.getVmInstanceUuid();
+            struct.detail = message.getDetail();
+            struct.opaque = message.getOpaque();
+
+            struct.triggerByHost = SHUTDOWN_DETAIL_BY_HOST.equals(struct.detail);
+            struct.triggerByGuest = SHUTDOWN_DETAIL_BY_GUEST.equals(struct.detail);
+
+            return struct;
+        }
+    }
 }

--- a/header/src/main/java/org/zstack/header/vm/KvmReportVmShutdownEventMsg.java
+++ b/header/src/main/java/org/zstack/header/vm/KvmReportVmShutdownEventMsg.java
@@ -8,6 +8,8 @@ import org.zstack.header.message.NeedReplyMessage;
  */
 public class KvmReportVmShutdownEventMsg extends NeedReplyMessage implements VmInstanceMessage{
     private String vmInstanceUuid;
+    private String detail;
+    private String opaque;
 
     public void setVmInstanceUuid(String vmInstanceUuid) {
         this.vmInstanceUuid = vmInstanceUuid;
@@ -15,5 +17,21 @@ public class KvmReportVmShutdownEventMsg extends NeedReplyMessage implements VmI
     @Override
     public String getVmInstanceUuid() {
         return vmInstanceUuid;
+    }
+
+    public String getDetail() {
+        return detail;
+    }
+
+    public void setDetail(String detail) {
+        this.detail = detail;
+    }
+
+    public String getOpaque() {
+        return opaque;
+    }
+
+    public void setOpaque(String opaque) {
+        this.opaque = opaque;
     }
 }

--- a/header/src/main/java/org/zstack/header/vm/VmInstanceConstant.java
+++ b/header/src/main/java/org/zstack/header/vm/VmInstanceConstant.java
@@ -21,6 +21,10 @@ public interface VmInstanceConstant {
 
     String TF_VIRTUAL_NIC_TYPE = "TFVNIC";
 
+    String SHUTDOWN_DETAIL_BY_HOST = "by host";
+    String SHUTDOWN_DETAIL_BY_GUEST = "by guest";
+    String SHUTDOWN_DETAIL_FINISHED = "finished";
+
     enum Params {
         VmInstanceSpec,
         AttachingVolumeInventory,

--- a/plugin/kvm/src/main/java/org/zstack/kvm/KVMAgentCommands.java
+++ b/plugin/kvm/src/main/java/org/zstack/kvm/KVMAgentCommands.java
@@ -3944,6 +3944,8 @@ public class KVMAgentCommands {
 
     public static class ReportVmShutdownEventCmd {
         public String vmUuid;
+        public String detail;
+        public String opaque;
     }
 
     public static class ReportVmRebootEventCmd {

--- a/plugin/kvm/src/main/java/org/zstack/kvm/KVMHostFactory.java
+++ b/plugin/kvm/src/main/java/org/zstack/kvm/KVMHostFactory.java
@@ -462,6 +462,8 @@ public class KVMHostFactory extends AbstractService implements HypervisorFactory
         restf.registerSyncHttpCallHandler(KVMConstant.KVM_REPORT_VM_SHUTDOWN_EVENT, KVMAgentCommands.ReportVmShutdownEventCmd.class, cmd -> {
             KvmReportVmShutdownEventMsg msg = new KvmReportVmShutdownEventMsg();
             msg.setVmInstanceUuid(cmd.vmUuid);
+            msg.setDetail(cmd.detail);
+            msg.setOpaque(cmd.opaque);
             bus.makeTargetServiceIdByResourceUuid(msg, VmInstanceConstant.SERVICE_ID, cmd.vmUuid);
             bus.send(msg);
             return null;


### PR DESCRIPTION
KvmReportVmShutdownEventMsg.detail indicates whether
the VM shutdown event was triggered by the host ('by host')
or the guest themselves ('by guest')

KvmReportVmShutdownEventMsg.opaque is the addition
information of the shutdown event.

Resolves: ZSV-5477

Change-Id: I696a72687476696e777671696374676a67717773

sync from gitlab !6107