### PR TITLE
<chore>[utils]: replace zstack.Function by java.util.function

### DIFF
--- a/plugin/eip/src/main/java/org/zstack/network/service/eip/EipExtension.java
+++ b/plugin/eip/src/main/java/org/zstack/network/service/eip/EipExtension.java
@@ -25,12 +25,12 @@ import org.zstack.network.service.vip.VipVO;
 import org.zstack.utils.CollectionUtils;
 import org.zstack.utils.Utils;
 import org.zstack.utils.function.Function;
-import org.zstack.utils.function.FunctionNoArg;
 import org.zstack.utils.logging.CLogger;
 
 import javax.persistence.Query;
 import javax.persistence.TypedQuery;
 import java.util.*;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 /**
@@ -139,17 +139,17 @@ public class EipExtension extends AbstractNetworkServiceExtension implements Com
                     continue;
                 }
 
-                List<EipVO> evos = new FunctionNoArg<List<EipVO>>() {
+                List<EipVO> evos = new Supplier<List<EipVO>>() {
                     @Override
                     @Transactional
-                    public List<EipVO> call() {
+                    public List<EipVO> get() {
                         String sql = "select eip from EipVO eip, VmNicVO nic, UsedIpVO ip where nic.uuid = ip.vmNicUuid and ip.l3NetworkUuid = :l3uuid and nic.uuid = eip.vmNicUuid and nic.uuid = :nicUuid";
                         Query q = dbf.getEntityManager().createQuery(sql);
                         q.setParameter("l3uuid", l3.getUuid());
                         q.setParameter("nicUuid", nic.getUuid());
                         return q.getResultList();
                     }
-                }.call();
+                }.get();
 
                 if (evos.isEmpty()) {
                     continue;

--- a/simulator/simulatorImpl/src/main/java/org/zstack/simulator/SimulatorSecurityGroupBackend.java
+++ b/simulator/simulatorImpl/src/main/java/org/zstack/simulator/SimulatorSecurityGroupBackend.java
@@ -3,7 +3,6 @@ package org.zstack.simulator;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.zstack.core.cloudbus.CloudBus;
 import org.zstack.core.db.DatabaseFacade;
-import org.zstack.core.db.SimpleQuery;
 import org.zstack.core.errorcode.ErrorFacade;
 import org.zstack.header.core.Completion;
 import org.zstack.header.errorcode.ErrorCode;
@@ -11,10 +10,7 @@ import org.zstack.header.host.HypervisorType;
 import org.zstack.header.simulator.SimulatorConstant;
 import org.zstack.header.vm.*;
 import org.zstack.network.securitygroup.*;
-import org.zstack.utils.CollectionUtils;
 import org.zstack.utils.Utils;
-import org.zstack.utils.function.Function;
-import org.zstack.utils.function.ListFunction;
 import org.zstack.utils.gson.JSONObjectUtil;
 import org.zstack.utils.logging.CLogger;
 
@@ -60,33 +56,9 @@ public class SimulatorSecurityGroupBackend implements
 
 	}
 
-	@Override
+    @Override
     public void cleanUpUnusedRuleOnHost(String hostUuid, Completion completion) {
-        SimpleQuery<VmInstanceVO> q = dbf.createQuery(VmInstanceVO.class);
-        q.add(VmInstanceVO_.hostUuid, SimpleQuery.Op.EQ, hostUuid);
-        List<VmInstanceVO> vms = q.list();
-        List<VmNicVO> nics = CollectionUtils.transformToList(vms, new ListFunction<VmNicVO, VmInstanceVO>() {
-            @Override
-            public List<VmNicVO> call(VmInstanceVO arg) {
-                List<VmNicVO> lst = new ArrayList<VmNicVO>();
-                lst.addAll(arg.getVmNics());
-                return lst;
-            }
-        });
-        List<String> nicNames = CollectionUtils.transformToList(nics, new Function<String, VmNicVO>() {
-            @Override
-            public String call(VmNicVO arg) {
-                return arg.getInternalName();
-            }
-        });
-        // Set<SecurityGroupRuleTO> tos = rules.get(hostUuid);
-        Set<SecurityGroupRuleTO> ntos = new HashSet<SecurityGroupRuleTO>();
-        // for (SecurityGroupRuleTO to : tos) {
-        //     if (nicNames.contains(to.getVmNicInternalName())) {
-        //         ntos.add(to);
-        //     }
-        // }
-        rules.put(hostUuid, ntos);
+        rules.put(hostUuid, new HashSet<>());
         completion.success();
     }
 

--- a/test/src/test/groovy/org/zstack/test/integration/networkservice/provider/virtualrouter/eip/VirtualRouterEipCase.groovy
+++ b/test/src/test/groovy/org/zstack/test/integration/networkservice/provider/virtualrouter/eip/VirtualRouterEipCase.groovy
@@ -115,11 +115,8 @@ class VirtualRouterEipCase extends SubCase {
         })
         assert defaultNic != null
 
-        final List<String> l3s = CollectionUtils.transformToList(vm.getVmNics(), new Function<String, VmNicInventory>() {
-            String call(VmNicInventory arg) {
-                return arg.getL3NetworkUuid()
-            }
-        })
+        final List<String> l3s = CollectionUtils.transformAndRemoveNull(vm.getVmNics(),
+                { VmNicInventory nic -> nic.getL3NetworkUuid() })
         long count = Q.New(NetworkServiceL3NetworkRefVO.class).select()
                 .eq(NetworkServiceL3NetworkRefVO_.networkServiceType, "DHCP")
                 .in(NetworkServiceL3NetworkRefVO_.l3NetworkUuid, l3s).count()

--- a/utils/src/main/java/org/zstack/utils/CollectionUtils.java
+++ b/utils/src/main/java/org/zstack/utils/CollectionUtils.java
@@ -2,7 +2,6 @@ package org.zstack.utils;
 
 import org.zstack.utils.function.ForEachFunction;
 import org.zstack.utils.function.Function;
-import org.zstack.utils.function.ListFunction;
 import org.zstack.utils.logging.CLogger;
 
 import java.lang.reflect.Method;
@@ -17,19 +16,6 @@ import java.util.stream.Stream;
 public class CollectionUtils {
     private static final CLogger logger = Utils.getLogger(CollectionUtils.class);
 
-    public static <K, V> List<K> transformToList(Collection<V> from, ListFunction<K, V> func) {
-        List<K> ret = new ArrayList<K>();
-        for (V v : from) {
-            List<K> k = func.call(v);
-            if (k == null) {
-                continue;
-            }
-            ret.addAll(k);
-        }
-
-        return ret;
-    }
-
     public static <T> List<T> getDuplicateElementsOfList(List<T> list) {
         List<T> result = new ArrayList<T>();
         Set<T> set = new HashSet<T>();
@@ -41,6 +27,10 @@ public class CollectionUtils {
         return result;
     }
 
+    /**
+     * use {@link #transformAndRemoveNull(Collection, java.util.function.Function)}
+     */
+    @Deprecated
     public static <K, V> List<K> transformToList(Collection<V> from, Function<K, V> func) {
         List<K> ret = new ArrayList<K>();
         for (V v : from) {
@@ -56,6 +46,10 @@ public class CollectionUtils {
 
     public static <FROM, TO> List<TO> transform(Collection<FROM> from, java.util.function.Function<FROM, TO> mapper) {
         return from.stream().map(mapper).collect(Collectors.toList());
+    }
+
+    public static <FROM, TO> List<TO> transformAndRemoveNull(Collection<FROM> from, java.util.function.Function<FROM, TO> mapper) {
+        return from.stream().map(mapper).filter(Objects::nonNull).collect(Collectors.toList());
     }
 
     public static <T> List<T> filter(Collection<T> from, Predicate<T> tester) {
@@ -85,6 +79,10 @@ public class CollectionUtils {
         return ret;
     }
 
+    /**
+     * use {@link #findOneOrNull}
+     */
+    @Deprecated
     public static <K, V> K find(Collection<V> from, Function<K, V> func) {
         for (V v : from) {
             K k = func.call(v);

--- a/utils/src/main/java/org/zstack/utils/function/FunctionNoArg.java
+++ b/utils/src/main/java/org/zstack/utils/function/FunctionNoArg.java
@@ -1,7 +1,0 @@
-package org.zstack.utils.function;
-
-/**
-*/
-public interface FunctionNoArg<K> {
-    K call();
-}

--- a/utils/src/main/java/org/zstack/utils/function/ListFunction.java
+++ b/utils/src/main/java/org/zstack/utils/function/ListFunction.java
@@ -1,9 +1,0 @@
-package org.zstack.utils.function;
-
-import java.util.List;
-
-/**
-*/
-public interface ListFunction<K, V> {
-    List<K> call(V arg);
-}


### PR DESCRIPTION
At the beginning, our program was based on JDK 1.5
and there were no streaming programming tools available,
so we added our own defined Function interface;

Now that we have used JDK 1.8, we can replace
the original interface with Java's Function tool

Change-Id: I7473626a6d746c6c76716963647774696b717962

sync from gitlab !6116