### PR TITLE
<fix>[mevoco]: check capacity before snapshot revert

### DIFF
--- a/testlib/src/main/java/org/zstack/testlib/CephPrimaryStorageSpec.groovy
+++ b/testlib/src/main/java/org/zstack/testlib/CephPrimaryStorageSpec.groovy
@@ -461,6 +461,8 @@ class CephPrimaryStorageSpec extends PrimaryStorageSpec {
             }
 
             simulator(CephPrimaryStorageBase.ROLLBACK_SNAPSHOT_PATH) { HttpEntity<String> e, EnvSpec spec ->
+                def cmd = JSONObjectUtil.toObject(e.body, CephPrimaryStorageBase.RollbackSnapshotCmd.class)
+                assert cmd.capacityThreshold > 0
                 return new CephPrimaryStorageBase.RollbackSnapshotRsp()
             }
 


### PR DESCRIPTION
use physical capacity threshold

Resolves: ZSTAC-65247

Change-Id: I77677475636770677168657977646f646c6c7364

sync from gitlab !6151

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 在Ceph主存储中增加了容量阈值管理功能，优化了快照回滚操作的容量管理。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->