### PR TITLE
<fix>[header]: add TemplatedVmInstanceCacheInventory

### DIFF
--- a/header/src/main/java/org/zstack/header/vm/TemplatedVmInstanceCacheInventory.java
+++ b/header/src/main/java/org/zstack/header/vm/TemplatedVmInstanceCacheInventory.java
@@ -1,0 +1,57 @@
+package org.zstack.header.vm;
+
+import org.zstack.header.configuration.PythonClassInventory;
+import org.zstack.header.search.Inventory;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+@PythonClassInventory
+@Inventory(mappingVOClass = TemplatedVmInstanceVO.class)
+public class TemplatedVmInstanceCacheInventory implements Serializable {
+    private long id;
+    private String templatedVmInstanceUuid;
+    private String cacheVmInstanceUuid;
+
+    public static TemplatedVmInstanceCacheInventory valueOf(TemplatedVmInstanceCacheVO vo) {
+        TemplatedVmInstanceCacheInventory inv = new TemplatedVmInstanceCacheInventory();
+        inv.setId(vo.getId());
+        inv.setTemplatedVmInstanceUuid(vo.getTemplatedVmInstanceUuid());
+        inv.setCacheVmInstanceUuid(vo.getCacheVmInstanceUuid());
+        return inv;
+    }
+
+    public static List<TemplatedVmInstanceCacheInventory> valueOf(Collection<TemplatedVmInstanceCacheVO> vos) {
+        List<TemplatedVmInstanceCacheInventory> invs = new ArrayList<TemplatedVmInstanceCacheInventory>();
+        for (TemplatedVmInstanceCacheVO vo : vos) {
+            invs.add(valueOf(vo));
+        }
+        return invs;
+    }
+
+    public long getId() {
+        return id;
+    }
+
+    public void setId(long id) {
+        this.id = id;
+    }
+
+    public String getTemplatedVmInstanceUuid() {
+        return templatedVmInstanceUuid;
+    }
+
+    public void setTemplatedVmInstanceUuid(String templatedVmInstanceUuid) {
+        this.templatedVmInstanceUuid = templatedVmInstanceUuid;
+    }
+
+    public String getCacheVmInstanceUuid() {
+        return cacheVmInstanceUuid;
+    }
+
+    public void setCacheVmInstanceUuid(String cacheVmInstanceUuid) {
+        this.cacheVmInstanceUuid = cacheVmInstanceUuid;
+    }
+}


### PR DESCRIPTION
Related: ZSV-4992

Change-Id: I6974786568706c6c6a716c726b61617874717773

sync from gitlab !6167

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 新增了虚拟机实例模板缓存的库存表示功能。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->