### PR TITLE
<fix>[expon]: add get lun detail in expon api helper

### DIFF
--- a/plugin/expon/src/main/java/org/zstack/expon/ExponApiHelper.java
+++ b/plugin/expon/src/main/java/org/zstack/expon/ExponApiHelper.java
@@ -863,4 +863,13 @@ public class ExponApiHelper {
 
         return queryVolumeSnapshot(name);
     }
+
+    public VolumeLunModule getVolumeLunDetail(String volId) {
+        GetVolumeLunDetailRequest req = new GetVolumeLunDetailRequest();
+        req.setSessionId(sessionId);
+        req.setVolId(volId);
+        GetVolumeLunDetailResponse rsp = callErrorOut(req, GetVolumeLunDetailResponse.class);
+
+        return rsp.getLunDetails().get(0);
+    }
 }

--- a/plugin/expon/src/main/java/org/zstack/expon/ExponStorageController.java
+++ b/plugin/expon/src/main/java/org/zstack/expon/ExponStorageController.java
@@ -758,7 +758,7 @@ public class ExponStorageController implements PrimaryStorageControllerSvc, Prim
             return;
         }
 
-        apiHelper.removeHostFromIscsiClient(iqn, client.getId());
+        retry(() -> apiHelper.removeHostFromIscsiClient(iqn, client.getId()));
     }
 
     private synchronized void unexportIscsi(String source, String clientIp) {

--- a/plugin/expon/src/main/java/org/zstack/expon/sdk/volume/GetVolumeLunDetailRequest.java
+++ b/plugin/expon/src/main/java/org/zstack/expon/sdk/volume/GetVolumeLunDetailRequest.java
@@ -1,0 +1,34 @@
+package org.zstack.expon.sdk.volume;
+
+import org.springframework.http.HttpMethod;
+import org.zstack.expon.sdk.ExponRequest;
+import org.zstack.expon.sdk.ExponRestRequest;
+import org.zstack.expon.sdk.Param;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@ExponRestRequest(
+        path = "/block/volumes/{volId}/lun_detail",
+        method = HttpMethod.GET,
+        responseClass = GetVolumeLunDetailResponse.class
+)
+public class GetVolumeLunDetailRequest extends ExponRequest {
+    private static final HashMap<String, Parameter> parameterMap = new HashMap<>();
+
+    @Param
+    private String volId;
+
+    public String getVolId() {
+        return volId;
+    }
+
+    public void setVolId(String volId) {
+        this.volId = volId;
+    }
+
+    @Override
+    public Map<String, Parameter> getParameterMap() {
+        return parameterMap;
+    }
+}

--- a/plugin/expon/src/main/java/org/zstack/expon/sdk/volume/GetVolumeLunDetailResponse.java
+++ b/plugin/expon/src/main/java/org/zstack/expon/sdk/volume/GetVolumeLunDetailResponse.java
@@ -1,0 +1,17 @@
+package org.zstack.expon.sdk.volume;
+
+import org.zstack.expon.sdk.ExponResponse;
+
+import java.util.List;
+
+public class GetVolumeLunDetailResponse extends ExponResponse {
+    private List<VolumeLunModule> lunDetails;
+
+    public List<VolumeLunModule> getLunDetails() {
+        return lunDetails;
+    }
+
+    public void setLunDetails(List<VolumeLunModule> lunDetails) {
+        this.lunDetails = lunDetails;
+    }
+}

--- a/plugin/expon/src/main/java/org/zstack/expon/sdk/volume/VolumeLunModule.java
+++ b/plugin/expon/src/main/java/org/zstack/expon/sdk/volume/VolumeLunModule.java
@@ -1,0 +1,109 @@
+package org.zstack.expon.sdk.volume;
+
+/**
+ * @example
+ * {
+ *     "VolumeNamespace": "ussns",
+ *     "blkSize": 512,
+ *     "lun_id": "19",
+ *     "poolId": 1,
+ *     "size": 28991029248,
+ *     "target": "iqn.2024-04.com.sds.wds:100bbf2da6e1",
+ *     "treeId": 43,
+ *     "uuid": "5550f3ec-af9a-4d9e-8638-ba4cf76293e0",
+ *     "volId": 51,
+ *     "volName": "volume-0462cfeb-98f9-4f70-b5cc-2a42feeec376"
+ * }
+ */
+public class VolumeLunModule {
+    private String volumeNamespace;
+    private int blockSize;
+    private String lunId;
+    private int poolId;
+    private long size;
+    private String target;
+    private int treeId;
+    private String uuid;
+    private int volId;
+    private String volName;
+
+    public String getVolumeNamespace() {
+        return volumeNamespace;
+    }
+
+    public void setVolumeNamespace(String volumeNamespace) {
+        this.volumeNamespace = volumeNamespace;
+    }
+
+    public int getBlockSize() {
+        return blockSize;
+    }
+
+    public void setBlockSize(int blockSize) {
+        this.blockSize = blockSize;
+    }
+
+    public String getLunId() {
+        return lunId;
+    }
+
+    public void setLunId(String lunId) {
+        this.lunId = lunId;
+    }
+
+    public int getPoolId() {
+        return poolId;
+    }
+
+    public void setPoolId(int poolId) {
+        this.poolId = poolId;
+    }
+
+    public long getSize() {
+        return size;
+    }
+
+    public void setSize(long size) {
+        this.size = size;
+    }
+
+    public String getTarget() {
+        return target;
+    }
+
+    public void setTarget(String target) {
+        this.target = target;
+    }
+
+    public int getTreeId() {
+        return treeId;
+    }
+
+    public void setTreeId(int treeId) {
+        this.treeId = treeId;
+    }
+
+    public String getUuid() {
+        return uuid;
+    }
+
+    public void setUuid(String uuid) {
+        this.uuid = uuid;
+    }
+
+    public int getVolId() {
+        return volId;
+    }
+
+    public void setVolId(int volId) {
+        this.volId = volId;
+    }
+
+    public String getVolName() {
+        return volName;
+    }
+
+    public void setVolName(String volName) {
+        this.volName = volName;
+    }
+}

--- a/storage/src/main/java/org/zstack/storage/addon/primary/BlockExternalPrimaryStorageFactory.java
+++ b/storage/src/main/java/org/zstack/storage/addon/primary/BlockExternalPrimaryStorageFactory.java
@@ -1,9 +1,19 @@
 package org.zstack.storage.addon.primary;
 
+import org.zstack.header.host.HostInventory;
+import org.zstack.header.storage.addon.primary.BaseVolumeInfo;
 import org.zstack.header.storage.primary.PrimaryStorageVO;
+
+import java.util.Map;
 
 public interface BlockExternalPrimaryStorageFactory {
     String getType();
 
     BlockExternalPrimaryStorageBackend getBlockExternalPrimaryStorageBackend(PrimaryStorageVO vo);
+
+    void activeIscsiVolume(String clientIqn, BaseVolumeInfo vol, boolean shareable);
+
+    Map<String, String> getVolumeIscsiInfo(String volInstallPath, HostInventory host);
+
+    String getVolumeLunId(String volInstallPath);
 }


### PR DESCRIPTION
add get lun detail in expon api helper for get
lun id

Resolves: ZSTAC-64980

Change-Id: I75697468646967626a6a6b6962626d63666f7961
(cherry picked from commit b3a400ae4bfad02f165c166df55db2e5f8375b62)

sync from gitlab !6170

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 新增了一个公共方法用于根据卷ID检索卷LUN（逻辑单元号）详细信息。
	- 增加了对iSCSI卷的处理和检索卷信息的新方法签名。
- **改进**
	- 在 `deactivateIscsi` 功能中添加了重试机制，用于从iSCSI客户端中移除主机的操作。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->