### PR TITLE
<fix>[compute]: allow duplicated static ip in simple l3

### DIFF
--- a/compute/src/main/java/org/zstack/compute/vm/VmInstanceApiInterceptor.java
+++ b/compute/src/main/java/org/zstack/compute/vm/VmInstanceApiInterceptor.java
@@ -651,9 +651,6 @@ public class VmInstanceApiInterceptor implements ApiMessageInterceptor {
             if (msg.getGateway() == null) {
                 msg.setGateway("");
             }
-            if (Q.New(UsedIpVO.class).eq(UsedIpVO_.ip, msg.getIp()).eq(UsedIpVO_.l3NetworkUuid, msg.getL3NetworkUuid()).isExists()) {
-                throw new ApiMessageInterceptionException(argerr("ip address [%s] already set to vmNic", msg.getIp()));
-            }
         }
         if (msg.getIp6() != null && !l3NetworkVO.getEnableIPAM()) {
             l3Found = true;
@@ -662,9 +659,6 @@ public class VmInstanceApiInterceptor implements ApiMessageInterceptor {
             }
             if (msg.getIpv6Gateway() == null) {
                 msg.setIpv6Gateway("");
-            }
-            if (Q.New(UsedIpVO.class).eq(UsedIpVO_.ip, msg.getIp6()).eq(UsedIpVO_.l3NetworkUuid, msg.getL3NetworkUuid()).isExists()) {
-                throw new ApiMessageInterceptionException(argerr("ip address [%s] already set to vmNic", msg.getIp6()));
             }
         }
         if (!l3Found) {


### PR DESCRIPTION
1. modify logic in APISetVmStaticIp

Resolves: ZSV-5744

Change-Id: I76626664666a68726a717465656a656d6e766c6f

sync from gitlab !6213