### PR TITLE
<improve>[compute]: improve guesttools

### DIFF
--- a/compute/src/main/java/org/zstack/compute/vm/CustomNicOperator.java
+++ b/compute/src/main/java/org/zstack/compute/vm/CustomNicOperator.java
@@ -40,34 +40,42 @@ public class CustomNicOperator {
     }
 
     public void updateNicTags(String mac ,String ip,String nicUuid){
-        this.deleteNicTags();
         // set the results to system tag
         // because MacOperator doesn't provide a set mac method , so we set it here using SystemTagCreator
         SystemTagCreator macCreator = VmSystemTags.CUSTOM_MAC.newSystemTagCreator(vmUuid);
         macCreator.ignoreIfExisting = false;
         macCreator.inherent = false;
+        macCreator.recreate = true;
         macCreator.setTagByTokens(map(
                 e(VmSystemTags.STATIC_IP_L3_UUID_TOKEN, l3Uuid),
                 e(VmSystemTags.MAC_TOKEN, mac)
         ));
-        macCreator.create();
+        if (mac != null) {
+            macCreator.create();
+        }
 
         SystemTagCreator ipTagCreator = VmSystemTags.STATIC_IP.newSystemTagCreator(vmUuid);
         ipTagCreator.ignoreIfExisting = false;
         ipTagCreator.inherent = false;
+        ipTagCreator.recreate = true;
         ipTagCreator.setTagByTokens(map(
                 e(VmSystemTags.STATIC_IP_L3_UUID_TOKEN, l3Uuid),
                 e(VmSystemTags.STATIC_IP_TOKEN, ip)
         ));
-        ipTagCreator.create();
+        if (ip != null) {
+            ipTagCreator.create();
+        }
 
         SystemTagCreator nicIdCreator = VmSystemTags.CUSTOM_NIC_UUID.newSystemTagCreator(vmUuid);
         nicIdCreator.ignoreIfExisting = false;
         nicIdCreator.inherent = false;
+        nicIdCreator.recreate = true;
         nicIdCreator.setTagByTokens(map(
                 e(VmSystemTags.STATIC_IP_L3_UUID_TOKEN, l3Uuid),
                 e(VmSystemTags.NIC_UUID_TOKEN, nicUuid)
         ));
-        nicIdCreator.create();
+        if (nicUuid != null) {
+            nicIdCreator.create();
+        }
     }
 }

--- a/compute/src/main/java/org/zstack/compute/vm/StaticIpOperator.java
+++ b/compute/src/main/java/org/zstack/compute/vm/StaticIpOperator.java
@@ -34,7 +34,7 @@ public class StaticIpOperator {
     @Autowired
     private DatabaseFacade dbf;
 
-    public Map<String, List<String>> getStaticIpbyVmUuid(String vmUuid) {
+    public Map<String, List<String>> getStaticIpByVmUuid(String vmUuid) {
         Map<String, List<String>> ret = new HashMap<String, List<String>>();
 
         List<Map<String, String>> tokenList = VmSystemTags.STATIC_IP.getTokensOfTagsByResourceUuid(vmUuid);
@@ -63,11 +63,8 @@ public class StaticIpOperator {
             if(VmSystemTags.STATIC_IP.isMatch(sysTag)) {
                 Map<String, String> token = TagUtils.parse(VmSystemTags.STATIC_IP.getTagFormat(), sysTag);
                 String l3Uuid = token.get(VmSystemTags.STATIC_IP_L3_UUID_TOKEN);
-                NicIpAddressInfo nicIpAddressInfo = ret.get(l3Uuid);
-                if (nicIpAddressInfo == null) {
-                    ret.put(l3Uuid, new NicIpAddressInfo("", "", "",
-                            "", "", ""));
-                }
+                ret.computeIfAbsent(l3Uuid, k -> new NicIpAddressInfo("", "", "",
+                        "", "", ""));
                 String ip = token.get(VmSystemTags.STATIC_IP_TOKEN);
                 ip = IPv6NetworkUtils.ipv6TagValueToAddress(ip);
                 if (NetworkUtils.isIpv4Address(ip)) {
@@ -120,7 +117,7 @@ public class StaticIpOperator {
         return ret;
     }
 
-    public Map<String, List<String>> getStaticIpbySystemTag(List<String> systemTags) {
+    public Map<String, List<String>> getStaticIpBySystemTag(List<String> systemTags) {
         Map<String, List<String>> ret = new HashMap<>();
 
         if (systemTags == null) {
@@ -167,7 +164,7 @@ public class StaticIpOperator {
             }
         }
 
-        /* '::' is token used by systemtag, replace with "--" */
+        /* '::' is token used by systemTag, replace with "--" */
         ip = IPv6NetworkUtils.ipv6AddessToTagValue(ip);
         if (tagUuid == null) {
             SystemTagCreator creator = VmSystemTags.STATIC_IP.newSystemTagCreator(vmUuid);

--- a/compute/src/main/java/org/zstack/compute/vm/VmAllocateNicFlow.java
+++ b/compute/src/main/java/org/zstack/compute/vm/VmAllocateNicFlow.java
@@ -155,6 +155,7 @@ public class VmAllocateNicFlow implements Flow {
                             UsedIpVO vo = new UsedIpVO();
                             vo.setUuid(Platform.getUuid());
                             vo.setIp(IPv6NetworkUtils.getIpv6AddressCanonicalString(nicNicIpAddressInfo.ipv6Address));
+                            vo.setIpInLong(IPv6NetworkUtils.ipv6AddressToBigInteger(nicNicIpAddressInfo.ipv6Address).longValue());
                             vo.setNetmask(IPv6NetworkUtils.getFormalNetmaskOfNetworkCidr(nicNicIpAddressInfo.ipv6Address+"/"+ nicNicIpAddressInfo.ipv6Prefix));
                             vo.setGateway(nicNicIpAddressInfo.ipv6Gateway.isEmpty() ? "" : IPv6NetworkUtils.getIpv6AddressCanonicalString(nicNicIpAddressInfo.ipv6Gateway));
                             vo.setIpVersion(IPv6Constants.IPv6);
@@ -165,6 +166,7 @@ public class VmAllocateNicFlow implements Flow {
                                 nicVO.setUsedIpUuid(vo.getUuid());
                             }
                             nicVO.setIp(vo.getIp());
+                            nicVO.setIpVersion(vo.getIpVersion());
                             nicVO.setNetmask(vo.getNetmask());
                             nicVO.setGateway(vo.getGateway());
                             dbf.persist(vo);
@@ -173,6 +175,7 @@ public class VmAllocateNicFlow implements Flow {
                             UsedIpVO vo = new UsedIpVO();
                             vo.setUuid(Platform.getUuid());
                             vo.setIp(nicNicIpAddressInfo.ipv4Address);
+                            vo.setIpInLong(NetworkUtils.ipv4StringToLong(nicNicIpAddressInfo.ipv4Address));
                             vo.setGateway(nicNicIpAddressInfo.ipv4Gateway);
                             vo.setNetmask(nicNicIpAddressInfo.ipv4Netmask);
                             vo.setIpVersion(IPv6Constants.IPv4);
@@ -183,6 +186,7 @@ public class VmAllocateNicFlow implements Flow {
                                 nicVO.setUsedIpUuid(vo.getUuid());
                             }
                             nicVO.setIp(vo.getIp());
+                            nicVO.setIpVersion(vo.getIpVersion());
                             nicVO.setNetmask(vo.getNetmask());
                             nicVO.setGateway(vo.getGateway());
                             dbf.persist(vo);

--- a/compute/src/main/java/org/zstack/compute/vm/VmAllocateNicForStartingVmFlow.java
+++ b/compute/src/main/java/org/zstack/compute/vm/VmAllocateNicForStartingVmFlow.java
@@ -79,7 +79,7 @@ public class VmAllocateNicForStartingVmFlow implements Flow {
             return;
         }
 
-        final Map<String, List<String>> vmStaticIps = new StaticIpOperator().getStaticIpbyVmUuid(vm.getUuid());
+        final Map<String, List<String>> vmStaticIps = new StaticIpOperator().getStaticIpByVmUuid(vm.getUuid());
         List<AllocateIpMsg> amsgs = new ArrayList<>();
         for (VmNicInventory nic : nicsNeedNewIp) {
             L3NetworkInventory l3Inv = L3NetworkInventory.valueOf(dbf.findByUuid(nic.getL3NetworkUuid(), L3NetworkVO.class));

--- a/compute/src/main/java/org/zstack/compute/vm/VmAllocateNicIpFlow.java
+++ b/compute/src/main/java/org/zstack/compute/vm/VmAllocateNicIpFlow.java
@@ -54,7 +54,7 @@ public class VmAllocateNicIpFlow implements Flow {
         final VmInstanceSpec spec = (VmInstanceSpec) data.get(VmInstanceConstant.Params.VmInstanceSpec.toString());
         final List<VmNicInventory> nics = (List<VmNicInventory>) data.get(VmInstanceConstant.Params.VmAllocateNicFlow_nics.toString());
         Boolean allowDuplicatedAddress = (Boolean) data.get(VmInstanceConstant.Params.VmAllocateNicFlow_allowDuplicatedAddress.toString());
-        Map<String, List<String>> vmStaticIps = new StaticIpOperator().getStaticIpbyVmUuid(spec.getVmInventory().getUuid());
+        Map<String, List<String>> vmStaticIps = new StaticIpOperator().getStaticIpByVmUuid(spec.getVmInventory().getUuid());
         List<ErrorCode> errs = new ArrayList<>();
         Set<UsedIpVO> ipVOS = new HashSet<>();
         List<VmNicVO> nicsWithIp = new ArrayList<>();

--- a/compute/src/main/java/org/zstack/compute/vm/VmInstanceApiInterceptor.java
+++ b/compute/src/main/java/org/zstack/compute/vm/VmInstanceApiInterceptor.java
@@ -18,6 +18,7 @@ import org.zstack.header.cluster.ClusterState;
 import org.zstack.header.cluster.ClusterVO;
 import org.zstack.header.cluster.ClusterVO_;
 import org.zstack.header.configuration.*;
+import org.zstack.header.errorcode.ErrorCode;
 import org.zstack.header.errorcode.OperationFailureException;
 import org.zstack.header.host.HostState;
 import org.zstack.header.host.HostStatus;
@@ -51,7 +52,6 @@ import org.zstack.utils.logging.CLogger;
 import org.zstack.utils.network.IPv6Constants;
 import org.zstack.utils.network.IPv6NetworkUtils;
 import org.zstack.utils.network.NetworkUtils;
-import org.zstack.utils.network.NicIpAddressInfo;
 
 import javax.persistence.Tuple;
 import javax.persistence.TypedQuery;
@@ -60,7 +60,8 @@ import java.util.stream.Collectors;
 
 import static org.zstack.core.Platform.argerr;
 import static org.zstack.core.Platform.operr;
-import static org.zstack.utils.CollectionDSL.list;
+import static org.zstack.utils.CollectionDSL.*;
+import static org.zstack.utils.CollectionDSL.e;
 import static org.zstack.utils.CollectionUtils.getDuplicateElementsOfList;
 
 /**
@@ -293,38 +294,16 @@ public class VmInstanceApiInterceptor implements ApiMessageInterceptor {
             }
         }
 
-        Map<String, List<String>> staticIps = new StaticIpOperator().getStaticIpbySystemTag(msg.getSystemTags());
-        if (msg.getRequiredIpMap() != null) {
+        Map<String, List<String>> staticIps = new StaticIpOperator().getStaticIpBySystemTag(msg.getSystemTags());
+        if (msg.getStaticIp() != null) {
             staticIps.computeIfAbsent(msg.getDestL3NetworkUuid(), k -> new ArrayList<>()).add(msg.getStaticIp());
-            SimpleQuery<NormalIpRangeVO> iprq = dbf.createQuery(NormalIpRangeVO.class);
-            iprq.add(NormalIpRangeVO_.l3NetworkUuid, Op.EQ, msg.getDestL3NetworkUuid());
-            List<NormalIpRangeVO> iprs = iprq.list();
-
-            boolean found = false;
-            for (NormalIpRangeVO ipr : iprs) {
-                if (!ipr.getIpVersion().equals(NetworkUtils.getIpversion(msg.getStaticIp()))) {
-                    continue;
-                }
-
-                if (NetworkUtils.isInRange(msg.getStaticIp(), ipr.getStartIp(), ipr.getEndIp())) {
-                    found = true;
-                    break;
-                }
-            }
-
-            if (!l3NetworkVO.getEnableIPAM()) {
-                found = true;
-            }
-
-            if (!found) {
-                throw new ApiMessageInterceptionException(argerr("the static IP[%s] is not in any IP range of the L3 network[uuid:%s]", msg.getStaticIp(), msg.getDestL3NetworkUuid()));
-            }
-
-            SimpleQuery<UsedIpVO> uq = dbf.createQuery(UsedIpVO.class);
-            uq.add(UsedIpVO_.l3NetworkUuid, Op.EQ, msg.getDestL3NetworkUuid());
-            uq.add(UsedIpVO_.ip, Op.EQ, msg.getStaticIp());
-            if (uq.isExists()) {
-                throw new ApiMessageInterceptionException(operr("the static IP[%s] has been occupied on the L3 network[uuid:%s]", msg.getStaticIp(), msg.getDestL3NetworkUuid()));
+            String staticIpTag = VmSystemTags.STATIC_IP.instantiateTag(map(
+                    e(VmSystemTags.STATIC_IP_L3_UUID_TOKEN, msg.getDestL3NetworkUuid()),
+                    e(VmSystemTags.STATIC_IP_TOKEN, msg.getStaticIp())));
+            if (msg.getSystemTags() == null) {
+                msg.setSystemTags(Collections.singletonList(staticIpTag));
+            } else {
+                msg.getSystemTags().add(staticIpTag);
             }
         }
 
@@ -339,36 +318,9 @@ public class VmInstanceApiInterceptor implements ApiMessageInterceptor {
             iprq.add(NormalIpRangeVO_.l3NetworkUuid, Op.EQ, l3Uuid);
             List<NormalIpRangeVO> iprs = iprq.list();
 
-            boolean found = false;
             for (String staticIp : ips) {
-                int ipVersion = IPv6Constants.IPv4;
-                if (IPv6NetworkUtils.isIpv6Address(staticIp)) {
-                    ipVersion = IPv6Constants.IPv6;
-                }
-                for (NormalIpRangeVO ipr : iprs) {
-                    if (ipVersion != ipr.getIpVersion()) {
-                        continue;
-                    }
-                    if (NetworkUtils.isInRange(staticIp, ipr.getStartIp(), ipr.getEndIp())) {
-                        found = true;
-                        break;
-                    }
-                }
-
-                if (!l3NetworkVO.getEnableIPAM()) {
-                    found = true;
-                }
-
-                if (!found) {
-                    throw new ApiMessageInterceptionException(argerr("the static IP[%s] is not in any IP range of the L3 network[uuid:%s]", staticIp, l3Uuid));
-                }
-
-                SimpleQuery<UsedIpVO> uq = dbf.createQuery(UsedIpVO.class);
-                uq.add(UsedIpVO_.l3NetworkUuid, Op.EQ, msg.getDestL3NetworkUuid());
-                uq.add(UsedIpVO_.ip, Op.EQ, msg.getStaticIp());
-                if (uq.isExists()) {
-                    throw new ApiMessageInterceptionException(operr("the static IP[%s] has been occupied on the L3 network[uuid:%s]", staticIp, l3Uuid));
-                }
+                checkIfIpInRange(staticIp, iprs, l3Uuid, l3NetworkVO.getEnableIPAM());
+                checkIfIpOccupied(staticIp, l3Uuid, l3NetworkVO.getEnableIPAM());
             }
         }
 
@@ -377,16 +329,40 @@ public class VmInstanceApiInterceptor implements ApiMessageInterceptor {
         for (Map.Entry<String, List<String>> e : staticIps.entrySet()) {
             msg.getRequiredIpMap().put(e.getKey(), e.getValue());
         }
+    }
 
-        final Map<String, NicIpAddressInfo> nicNetworkInfo = new StaticIpOperator().getNicNetworkInfoBySystemTag(msg.getSystemTags());
-        NicIpAddressInfo nicIpAddressInfo = nicNetworkInfo.get(msg.getDestL3NetworkUuid());
-        if (nicIpAddressInfo != null) {
-            if (!nicIpAddressInfo.ipv4Address.isEmpty() && Q.New(UsedIpVO.class).eq(UsedIpVO_.ip, nicIpAddressInfo.ipv4Address).eq(UsedIpVO_.l3NetworkUuid, msg.getDestL3NetworkUuid()).isExists()) {
-                throw new ApiMessageInterceptionException(argerr("the static IP[%s] has been occupied on the L3 network[uuid:%s]", nicIpAddressInfo.ipv4Address, msg.getDestL3NetworkUuid()));
+    private void checkIfIpInRange(String ip, List<NormalIpRangeVO> ipRanges, String l3Uuid, boolean enableIPAM) {
+        boolean found = false;
+        for (NormalIpRangeVO ipr : ipRanges) {
+            if (!NetworkUtils.getIpversion(ip).equals(ipr.getIpVersion())) {
+                continue;
             }
-            if (!nicIpAddressInfo.ipv6Address.isEmpty() && Q.New(UsedIpVO.class).eq(UsedIpVO_.ip, IPv6NetworkUtils.getIpv6AddressCanonicalString(nicIpAddressInfo.ipv6Address)).eq(UsedIpVO_.l3NetworkUuid, msg.getDestL3NetworkUuid()).isExists()) {
-                throw new ApiMessageInterceptionException(argerr("the static IP[%s] has been occupied on the L3 network[uuid:%s]", nicIpAddressInfo.ipv6Address, msg.getDestL3NetworkUuid()));
+            if (NetworkUtils.isInRange(ip, ipr.getStartIp(), ipr.getEndIp())) {
+                found = true;
+                break;
             }
+        }
+
+        if (!enableIPAM) {
+            found = true;
+        }
+
+        if (!found) {
+            throw new ApiMessageInterceptionException(argerr("the static IP[%s] is not in any IP range of the L3 network[uuid:%s]", ip, l3Uuid));
+        }
+    }
+
+    private void checkIfIpOccupied(String ip, String l3Uuid, boolean enableIPAM) {
+        boolean isIpOccupied = Q.New(UsedIpVO.class)
+                .eq(UsedIpVO_.l3NetworkUuid, l3Uuid)
+                .eq(UsedIpVO_.ip, ip)
+                .isExists();
+        ErrorCode err = argerr("the static IP[%s] has been occupied on the L3 network[uuid:%s]", ip, l3Uuid);
+        if (isIpOccupied) {
+            if (enableIPAM) {
+                throw new ApiMessageInterceptionException(err);
+            }
+            logger.warn(err.getDetails());
         }
     }
 
@@ -675,9 +651,6 @@ public class VmInstanceApiInterceptor implements ApiMessageInterceptor {
             if (msg.getGateway() == null) {
                 msg.setGateway("");
             }
-            if (Q.New(UsedIpVO.class).eq(UsedIpVO_.ip, msg.getIp()).eq(UsedIpVO_.l3NetworkUuid, msg.getL3NetworkUuid()).isExists()) {
-                throw new ApiMessageInterceptionException(argerr("ip address [%s] already set to vmNic", msg.getIp()));
-            }
         }
         if (msg.getIp6() != null && !l3NetworkVO.getEnableIPAM()) {
             l3Found = true;
@@ -686,9 +659,6 @@ public class VmInstanceApiInterceptor implements ApiMessageInterceptor {
             }
             if (msg.getIpv6Gateway() == null) {
                 msg.setIpv6Gateway("");
-            }
-            if (Q.New(UsedIpVO.class).eq(UsedIpVO_.ip, msg.getIp6()).eq(UsedIpVO_.l3NetworkUuid, msg.getL3NetworkUuid()).isExists()) {
-                throw new ApiMessageInterceptionException(argerr("ip address [%s] already set to vmNic", msg.getIp6()));
             }
         }
         if (!l3Found) {
@@ -827,28 +797,8 @@ public class VmInstanceApiInterceptor implements ApiMessageInterceptor {
             iprq.add(NormalIpRangeVO_.l3NetworkUuid, Op.EQ, msg.getL3NetworkUuid());
             List<NormalIpRangeVO> iprs = iprq.list();
 
-            boolean found = false;
-            for (NormalIpRangeVO ipr : iprs) {
-                if (NetworkUtils.isInRange(msg.getIp(), ipr.getStartIp(), ipr.getEndIp())) {
-                    found = true;
-                    break;
-                }
-            }
-
-            if (!t.get(4, Boolean.class)) {
-                found = true;
-            }
-
-            if (!found) {
-                throw new ApiMessageInterceptionException(argerr("the static IP[%s] is not in any IP range of the L3 network[uuid:%s]", msg.getIp(), msg.getL3NetworkUuid()));
-            }
-
-            SimpleQuery<UsedIpVO> uq = dbf.createQuery(UsedIpVO.class);
-            uq.add(UsedIpVO_.l3NetworkUuid, Op.EQ, msg.getL3NetworkUuid());
-            uq.add(UsedIpVO_.ip, Op.EQ, msg.getIp());
-            if (uq.isExists()) {
-                throw new ApiMessageInterceptionException(operr("the static IP[%s] has been occupied on the L3 network[uuid:%s]", msg.getIp(), msg.getL3NetworkUuid()));
-            }
+            checkIfIpInRange(msg.getIp(), iprs, msg.getL3NetworkUuid(), t.get(4, Boolean.class));
+            checkIfIpOccupied(msg.getIp(), msg.getL3NetworkUuid(), t.get(4, Boolean.class));
         }
     }
 
@@ -919,44 +869,22 @@ public class VmInstanceApiInterceptor implements ApiMessageInterceptor {
             }
         }
 
-        Map<String, List<String>> staticIps = new StaticIpOperator().getStaticIpbySystemTag(msg.getSystemTags());
+        Map<String, List<String>> staticIps = new StaticIpOperator().getStaticIpBySystemTag(msg.getSystemTags());
+        if (msg.getStaticIp() != null) {
+            staticIps.computeIfAbsent(msg.getL3NetworkUuid(), k -> new ArrayList<>()).add(msg.getStaticIp());
+            String staticIpTag = VmSystemTags.STATIC_IP.instantiateTag(map(
+                    e(VmSystemTags.STATIC_IP_L3_UUID_TOKEN, msg.getL3NetworkUuid()),
+                    e(VmSystemTags.STATIC_IP_TOKEN, msg.getStaticIp())));
+            if (msg.getSystemTags() == null) {
+                msg.setSystemTags(Collections.singletonList(staticIpTag));
+            } else {
+                msg.getSystemTags().add(staticIpTag);
+            }
+        }
         msg.setNicNetworkInfo(new StaticIpOperator().getNicNetworkInfoBySystemTag(msg.getSystemTags()).entrySet()
                 .stream()
                 .filter(entry -> Q.New(L3NetworkVO.class).eq(L3NetworkVO_.uuid, entry.getKey()).eq(L3NetworkVO_.enableIPAM, Boolean.FALSE).isExists())
                 .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
-        if (msg.getStaticIp() != null) {
-            staticIps.computeIfAbsent(msg.getL3NetworkUuid(), k -> new ArrayList<>()).add(msg.getStaticIp());
-            SimpleQuery<NormalIpRangeVO> iprq = dbf.createQuery(NormalIpRangeVO.class);
-            iprq.add(NormalIpRangeVO_.l3NetworkUuid, Op.EQ, msg.getL3NetworkUuid());
-            List<NormalIpRangeVO> iprs = iprq.list();
-
-            boolean found = false;
-            for (NormalIpRangeVO ipr : iprs) {
-                if (!ipr.getIpVersion().equals(NetworkUtils.getIpversion(msg.getStaticIp()))) {
-                    continue;
-                }
-
-                if (NetworkUtils.isInRange(msg.getStaticIp(), ipr.getStartIp(), ipr.getEndIp())) {
-                    found = true;
-                    break;
-                }
-            }
-
-            if (!l3NetworkVO.getEnableIPAM()) {
-                found = true;
-            }
-
-            if (!found) {
-                throw new ApiMessageInterceptionException(argerr("the static IP[%s] is not in any IP range of the L3 network[uuid:%s]", msg.getStaticIp(), msg.getL3NetworkUuid()));
-            }
-
-            SimpleQuery<UsedIpVO> uq = dbf.createQuery(UsedIpVO.class);
-            uq.add(UsedIpVO_.l3NetworkUuid, Op.EQ, msg.getL3NetworkUuid());
-            uq.add(UsedIpVO_.ip, Op.EQ, msg.getStaticIp());
-            if (uq.isExists()) {
-                throw new ApiMessageInterceptionException(operr("the static IP[%s] has been occupied on the L3 network[uuid:%s]", msg.getStaticIp(), msg.getL3NetworkUuid()));
-            }
-        }
 
         for (Map.Entry<String, List<String>> e : staticIps.entrySet()) {
             if (!newAddedL3Uuids.contains(e.getKey())) {
@@ -969,36 +897,9 @@ public class VmInstanceApiInterceptor implements ApiMessageInterceptor {
             iprq.add(NormalIpRangeVO_.l3NetworkUuid, Op.EQ, l3Uuid);
             List<NormalIpRangeVO> iprs = iprq.list();
 
-            boolean found = false;
             for (String staticIp : ips) {
-                int ipVersion = IPv6Constants.IPv4;
-                if (IPv6NetworkUtils.isIpv6Address(staticIp)) {
-                    ipVersion = IPv6Constants.IPv6;
-                }
-                for (NormalIpRangeVO ipr : iprs) {
-                    if (ipVersion != ipr.getIpVersion()) {
-                        continue;
-                    }
-                    if (NetworkUtils.isInRange(staticIp, ipr.getStartIp(), ipr.getEndIp())) {
-                        found = true;
-                        break;
-                    }
-                }
-
-                if (!l3NetworkVO.getEnableIPAM()) {
-                    found = true;
-                }
-
-                if (!found) {
-                    throw new ApiMessageInterceptionException(argerr("the static IP[%s] is not in any IP range of the L3 network[uuid:%s]", staticIp, l3Uuid));
-                }
-
-                SimpleQuery<UsedIpVO> uq = dbf.createQuery(UsedIpVO.class);
-                uq.add(UsedIpVO_.l3NetworkUuid, Op.EQ, msg.getL3NetworkUuid());
-                uq.add(UsedIpVO_.ip, Op.EQ, staticIp);
-                if (uq.isExists()) {
-                    throw new ApiMessageInterceptionException(operr("the static IP[%s] has been occupied on the L3 network[uuid:%s]", staticIp, l3Uuid));
-                }
+                checkIfIpInRange(staticIp, iprs, l3Uuid, l3NetworkVO.getEnableIPAM());
+                checkIfIpOccupied(staticIp, l3Uuid, l3NetworkVO.getEnableIPAM());
             }
         }
 

--- a/compute/src/main/java/org/zstack/compute/vm/VmInstanceManagerImpl.java
+++ b/compute/src/main/java/org/zstack/compute/vm/VmInstanceManagerImpl.java
@@ -62,7 +62,6 @@ import org.zstack.header.tag.SystemTagValidator;
 import org.zstack.header.vm.*;
 import org.zstack.header.vm.VmInstanceConstant.VmOperation;
 import org.zstack.header.vm.VmInstanceDeletionPolicyManager.VmInstanceDeletionPolicy;
-import org.zstack.header.vm.cdrom.VmCdRomInventory;
 import org.zstack.header.vm.cdrom.VmCdRomVO;
 import org.zstack.header.vm.cdrom.VmCdRomVO_;
 import org.zstack.header.volume.*;
@@ -76,6 +75,7 @@ import org.zstack.tag.*;
 import org.zstack.utils.*;
 import org.zstack.utils.function.Function;
 import org.zstack.utils.logging.CLogger;
+import org.zstack.utils.network.IPv6Constants;
 import org.zstack.utils.network.IPv6NetworkUtils;
 import org.zstack.utils.network.NetworkUtils;
 
@@ -90,8 +90,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
-import static java.lang.Integer.parseInt;
-import static java.lang.Integer.valueOf;
 import static java.util.Arrays.asList;
 import static org.zstack.core.Platform.*;
 import static org.zstack.utils.CollectionDSL.*;
@@ -1736,47 +1734,7 @@ public class VmInstanceManagerImpl extends AbstractService implements
                         String hostname = VmSystemTags.HOSTNAME.getTokenByTag(sysTag, VmSystemTags.HOSTNAME_TOKEN);
 
                         validateHostname(sysTag, hostname);
-                    } else if (VmSystemTags.STATIC_IP.isMatch(sysTag)) {
-                        validateStaticIp(sysTag);
-                    } 
-                }
-            }
-
-            private void validateStaticIp(String sysTag) {
-                Map<String, String> token = TagUtils.parse(VmSystemTags.STATIC_IP.getTagFormat(), sysTag);
-                String l3Uuid = token.get(VmSystemTags.STATIC_IP_L3_UUID_TOKEN);
-                if (!dbf.isExist(l3Uuid, L3NetworkVO.class)) {
-                    throw new ApiMessageInterceptionException(argerr("L3 network[uuid:%s] not found. Please correct your system tag[%s] of static IP",
-                            l3Uuid, sysTag));
-                }
-
-                String ip = token.get(VmSystemTags.STATIC_IP_TOKEN);
-                ip = IPv6NetworkUtils.ipv6TagValueToAddress(ip);
-                if (!NetworkUtils.isIpv4Address(ip) && !IPv6NetworkUtils.isIpv6Address(ip)) {
-                    throw new ApiMessageInterceptionException(argerr("%s is not a valid ip address. Please correct your system tag[%s] of static IP",
-                            ip, sysTag));
-                }
-
-                if (Q.New(L3NetworkVO.class).eq(L3NetworkVO_.uuid, l3Uuid).eq(L3NetworkVO_.enableIPAM, Boolean.FALSE).isExists()) {
-                    if (Q.New(UsedIpVO.class).eq(UsedIpVO_.ip, ip).eq(UsedIpVO_.l3NetworkUuid, l3Uuid).isExists()) {
-                        throw new ApiMessageInterceptionException(argerr("IP[%s] is already used on the L3 network[uuid:%s]. Please correct your system tag[%s] of static IP",
-                                ip, l3Uuid, sysTag));
                     }
-                    return;
-                }
-
-                CheckIpAvailabilityMsg cmsg = new CheckIpAvailabilityMsg();
-                cmsg.setIp(ip);
-                cmsg.setL3NetworkUuid(l3Uuid);
-                bus.makeLocalServiceId(cmsg, L3NetworkConstant.SERVICE_ID);
-                MessageReply r = bus.call(cmsg);
-                if (!r.isSuccess()) {
-                    throw new ApiMessageInterceptionException(inerr(r.getError().getDetails()));
-                }
-
-                CheckIpAvailabilityReply cr = r.castReply();
-                if (!cr.isAvailable()) {
-                    throw new ApiMessageInterceptionException(operr("IP[%s] is not available on the L3 network[uuid:%s] because: %s", ip, l3Uuid, cr.getReason()));
                 }
             }
 
@@ -1815,8 +1773,6 @@ public class VmInstanceManagerImpl extends AbstractService implements
                     q.select(VmInstanceVO_.defaultL3NetworkUuid);
                     q.add(VmInstanceVO_.uuid, Op.EQ, resourceUuid);
                     String defaultL3Uuid = q.findValue();
-                } else if (VmSystemTags.STATIC_IP.isMatch(systemTag)) {
-                    validateStaticIp(systemTag);
                 } else if (VmSystemTags.BOOT_ORDER.isMatch(systemTag)) {
                     validateBootOrder(systemTag);
                 }
@@ -1865,6 +1821,152 @@ public class VmInstanceManagerImpl extends AbstractService implements
                 throw new ApiMessageInterceptionException(argerr("cpuThreads must be an integer"));
             }
         });
+    }
+
+    private void installStaticIpValidator() {
+        class StaticIpValidator implements SystemTagCreateMessageValidator, SystemTagValidator {
+            @Override
+            public void validateSystemTagInCreateMessage(APICreateMessage cmsg) {
+                for (String sysTag : cmsg.getSystemTags()) {
+                    if (VmSystemTags.STATIC_IP.isMatch(sysTag)) {
+                        validateStaticIp(sysTag, true);
+                    } else if (VmSystemTags.IPV4_GATEWAY.isMatch(sysTag)) {
+                        validateIpv4Gateway(sysTag);
+                    } else if (VmSystemTags.IPV6_GATEWAY.isMatch(sysTag)) {
+                        validateIpv6Gateway(sysTag);
+                    } else if (VmSystemTags.IPV4_NETMASK.isMatch(sysTag)) {
+                        validateIpv4NetMask(sysTag);
+                    } else if (VmSystemTags.IPV6_PREFIX.isMatch(sysTag)) {
+                        validateIpv6Prefix(sysTag);
+                    }
+                }
+            }
+
+            @Override
+            public void validateSystemTag(String resourceUuid, Class resourceType, String systemTag) {
+                if (VmSystemTags.STATIC_IP.isMatch(systemTag)) {
+                    validateStaticIp(systemTag, false);
+                } else if (VmSystemTags.IPV4_GATEWAY.isMatch(systemTag)) {
+                    validateIpv4Gateway(systemTag);
+                } else if (VmSystemTags.IPV6_GATEWAY.isMatch(systemTag)) {
+                    validateIpv6Gateway(systemTag);
+                } else if (VmSystemTags.IPV4_NETMASK.isMatch(systemTag)) {
+                    validateIpv4NetMask(systemTag);
+                } else if (VmSystemTags.IPV6_PREFIX.isMatch(systemTag)) {
+                    validateIpv6Prefix(systemTag);
+                }
+            }
+
+            private void validateStaticIp(String sysTag, boolean checkAvailability) {
+                String tagUsage = VmSystemTags.STATIC_IP_TOKEN;
+                Map<String, String> token = TagUtils.parse(VmSystemTags.STATIC_IP.getTagFormat(), sysTag);
+                String l3Uuid = token.get(VmSystemTags.STATIC_IP_L3_UUID_TOKEN);
+                if (!dbf.isExist(l3Uuid, L3NetworkVO.class)) {
+                    throw new ApiMessageInterceptionException(argerr("L3 network[uuid:%s] not found. Please correct your system tag[%s] of %s",
+                            l3Uuid, sysTag, tagUsage));
+                }
+
+                String ip = token.get(VmSystemTags.STATIC_IP_TOKEN);
+                ip = IPv6NetworkUtils.ipv6TagValueToAddress(ip);
+                if (!NetworkUtils.isIpv4Address(ip) && !IPv6NetworkUtils.isIpv6Address(ip)) {
+                    throw new ApiMessageInterceptionException(argerr("%s is not a valid %s. Please correct your system tag[%s] of %s",
+                            ip, tagUsage, sysTag, tagUsage));
+                }
+
+                if (Q.New(L3NetworkVO.class).eq(L3NetworkVO_.uuid, l3Uuid).eq(L3NetworkVO_.enableIPAM, Boolean.FALSE).isExists()) {
+                    if (Q.New(UsedIpVO.class).eq(UsedIpVO_.ip, ip).eq(UsedIpVO_.l3NetworkUuid, l3Uuid).isExists()) {
+                        logger.warn(String.format("IP[%s] is already used on the L3 network[uuid:%s]", ip, l3Uuid));
+                    }
+                    return;
+                }
+
+                if (!checkAvailability) {
+                    return;
+                }
+
+                CheckIpAvailabilityMsg cmsg = new CheckIpAvailabilityMsg();
+                cmsg.setIp(ip);
+                cmsg.setL3NetworkUuid(l3Uuid);
+                bus.makeLocalServiceId(cmsg, L3NetworkConstant.SERVICE_ID);
+                MessageReply r = bus.call(cmsg);
+                if (!r.isSuccess()) {
+                    throw new ApiMessageInterceptionException(inerr(r.getError().getDetails()));
+                }
+
+                CheckIpAvailabilityReply cr = r.castReply();
+                if (!cr.isAvailable()) {
+                    throw new ApiMessageInterceptionException(operr("IP[%s] is not available on the L3 network[uuid:%s] because: %s", ip, l3Uuid, cr.getReason()));
+                }
+            }
+
+            private void validateIpv4Gateway(String sysTag) {
+                String tagUsage = VmSystemTags.IPV4_GATEWAY_TOKEN;
+                Map<String, String> token = TagUtils.parse(VmSystemTags.IPV4_GATEWAY.getTagFormat(), sysTag);
+                String l3Uuid = token.get(VmSystemTags.IPV4_GATEWAY_L3_UUID_TOKEN);
+                if (!dbf.isExist(l3Uuid, L3NetworkVO.class)) {
+                    throw new ApiMessageInterceptionException(argerr("L3 network[uuid:%s] not found. Please correct your system tag[%s] of %s",
+                            l3Uuid, sysTag, tagUsage));
+                }
+
+                String ip = token.get(VmSystemTags.IPV4_GATEWAY_TOKEN);
+                if (!NetworkUtils.isIpv4Address(ip)) {
+                    throw new ApiMessageInterceptionException(argerr("%s is not a valid %s. Please correct your system tag[%s] of %s",
+                            ip, tagUsage, sysTag, tagUsage));
+                }
+            }
+
+            private void validateIpv6Gateway(String sysTag) {
+                String tagUsage = VmSystemTags.IPV6_GATEWAY_TOKEN;
+                Map<String, String> token = TagUtils.parse(VmSystemTags.IPV6_GATEWAY.getTagFormat(), sysTag);
+                String l3Uuid = token.get(VmSystemTags.IPV6_GATEWAY_L3_UUID_TOKEN);
+                if (!dbf.isExist(l3Uuid, L3NetworkVO.class)) {
+                    throw new ApiMessageInterceptionException(argerr("L3 network[uuid:%s] not found. Please correct your system tag[%s] of %s",
+                            l3Uuid, sysTag, tagUsage));
+                }
+
+                String ip = IPv6NetworkUtils.ipv6TagValueToAddress(token.get(VmSystemTags.IPV6_GATEWAY_TOKEN));
+                if (!IPv6NetworkUtils.isIpv6Address(ip)) {
+                    throw new ApiMessageInterceptionException(argerr("%s is not a valid %s. Please correct your system tag[%s] of %s",
+                            ip, tagUsage, sysTag, tagUsage));
+                }
+            }
+
+            private void validateIpv4NetMask(String sysTag) {
+                String tagUsage = VmSystemTags.IPV4_NETMASK_TOKEN;
+                Map<String, String> token = TagUtils.parse(VmSystemTags.IPV4_NETMASK.getTagFormat(), sysTag);
+                String l3Uuid = token.get(VmSystemTags.IPV4_NETMASK_L3_UUID_TOKEN);
+                if (!dbf.isExist(l3Uuid, L3NetworkVO.class)) {
+                    throw new ApiMessageInterceptionException(argerr("L3 network[uuid:%s] not found. Please correct your system tag[%s] of %s",
+                            l3Uuid, sysTag, tagUsage));
+                }
+
+                String netMask = token.get(VmSystemTags.IPV4_NETMASK_TOKEN);
+                if (!NetworkUtils.isNetmask(netMask)) {
+                    throw new ApiMessageInterceptionException(argerr("%s is not a valid %s. Please correct your system tag[%s] of %s",
+                            netMask, tagUsage, sysTag, tagUsage));
+                }
+            }
+
+            private void validateIpv6Prefix(String sysTag) {
+                String tagUsage = VmSystemTags.IPV6_PREFIX_TOKEN;
+                Map<String, String> token = TagUtils.parse(VmSystemTags.IPV6_PREFIX.getTagFormat(), sysTag);
+                String l3Uuid = token.get(VmSystemTags.IPV6_PREFIX_L3_UUID_TOKEN);
+                if (!dbf.isExist(l3Uuid, L3NetworkVO.class)) {
+                    throw new ApiMessageInterceptionException(argerr("L3 network[uuid:%s] not found. Please correct your system tag[%s] of %s",
+                            l3Uuid, sysTag, tagUsage));
+                }
+
+                int prefixLen = Integer.parseInt(token.get(VmSystemTags.IPV6_PREFIX_TOKEN));
+                if (prefixLen > IPv6Constants.IPV6_PREFIX_LEN_MAX || prefixLen < IPv6Constants.IPV6_PREFIX_LEN_MIN) {
+                    throw new ApiMessageInterceptionException(argerr("ip range prefix length[%d] is out of range [%d - %d]. Please correct your system tag[%s] of %s",
+                            prefixLen, IPv6Constants.IPV6_PREFIX_LEN_MIN, IPv6Constants.IPV6_PREFIX_LEN_MAX, sysTag, tagUsage));
+                }
+            }
+        }
+
+        StaticIpValidator staticIpValidator = new StaticIpValidator();
+        tagMgr.installCreateMessageValidator(VmInstanceVO.class.getSimpleName(), staticIpValidator);
+        VmSystemTags.STATIC_IP.installValidator(staticIpValidator);
     }
 
     private void installUserdataValidator() {
@@ -2097,6 +2199,7 @@ public class VmInstanceManagerImpl extends AbstractService implements
 
     private void installSystemTagValidator() {
         installHostnameValidator();
+        installStaticIpValidator();
         installUserdataValidator();
         installBootModeValidator();
         installCleanTrafficValidator();

--- a/conf/globalConfig/vm.xml
+++ b/conf/globalConfig/vm.xml
@@ -307,7 +307,7 @@
 		<name>enable.vm.internal.ip.overwrite</name>
 		<description>enable vm internal ip address overwrite db record</description>
 		<type>java.lang.Boolean</type>
-		<defaultValue>false</defaultValue>
+		<defaultValue>true</defaultValue>
 	</config>
 
 	<config>

--- a/header/src/main/java/org/zstack/header/network/l3/UsedIpInventory.java
+++ b/header/src/main/java/org/zstack/header/network/l3/UsedIpInventory.java
@@ -34,7 +34,7 @@ public class UsedIpInventory implements Serializable {
     private String usedFor;
     @APINoSee
     private String metaData;
-    private long ipInLong;
+    private Long ipInLong;
     private String vmNicUuid;
     private Timestamp createDate;
     private Timestamp lastOpDate;
@@ -109,7 +109,7 @@ public class UsedIpInventory implements Serializable {
         this.ip = ip;
     }
 
-    public long getIpInLong() {
+    public Long getIpInLong() {
         return ipInLong;
     }
 

--- a/header/src/main/java/org/zstack/header/vm/VmNicInventory.java
+++ b/header/src/main/java/org/zstack/header/vm/VmNicInventory.java
@@ -36,6 +36,7 @@ public class VmNicInventory implements Serializable {
     private String gateway;
     private String metaData;
     @Deprecated
+    @APINoSee
     private Integer ipVersion;
     private String driverType;
     private List<UsedIpInventory> usedIps;

--- a/plugin/flatNetworkProvider/src/main/java/org/zstack/network/service/flat/FlatDhcpBackend.java
+++ b/plugin/flatNetworkProvider/src/main/java/org/zstack/network/service/flat/FlatDhcpBackend.java
@@ -1337,7 +1337,7 @@ public class FlatDhcpBackend extends AbstractService implements NetworkServiceDh
     public void beforeStartNewCreatedVm(VmInstanceSpec spec) {
         String providerUuid = new NetworkServiceProviderLookup().lookupUuidByType(FlatNetworkServiceConstant.FLAT_NETWORK_SERVICE_TYPE_STRING);
 
-        Map<String, List<String>> vmStaticIps = new StaticIpOperator().getStaticIpbyVmUuid(spec.getVmInventory().getUuid());
+        Map<String, List<String>> vmStaticIps = new StaticIpOperator().getStaticIpByVmUuid(spec.getVmInventory().getUuid());
         // make sure the Flat DHCP acquired DHCP server IP before starting VMs,
         // otherwise it may not be able to get IP when lots of VMs start concurrently
         // because the logic of VM acquiring IP is ahead flat DHCP acquiring IP

--- a/plugin/sugonSdnController/src/main/java/org/zstack/sugonSdnController/network/TfPortService.java
+++ b/plugin/sugonSdnController/src/main/java/org/zstack/sugonSdnController/network/TfPortService.java
@@ -8,7 +8,6 @@ import org.zstack.header.network.l3.L3NetworkInventory;
 import org.zstack.header.vm.VmInstanceInventory;
 import org.zstack.identity.AccountManager;
 import org.zstack.sugonSdnController.controller.api.Status;
-import org.zstack.sugonSdnController.controller.api.types.KeyValuePair;
 import org.zstack.sugonSdnController.controller.api.types.KeyValuePairs;
 import org.zstack.sugonSdnController.controller.api.types.VirtualMachineInterface;
 import org.zstack.sugonSdnController.controller.neutronClient.TfPortClient;
@@ -50,7 +49,7 @@ public class TfPortService {
     public TfPortResponse createTfPort(String tfPortUUid, VmInstanceInventory vm, L3NetworkInventory l3) {
         MacOperator mo = new MacOperator();
         String customMac = mo.getMac(vm.getUuid(), l3.getUuid());
-        Map<String, List<String>> vmStaticIps = new StaticIpOperator().getStaticIpbyVmUuid(vm.getUuid());
+        Map<String, List<String>> vmStaticIps = new StaticIpOperator().getStaticIpByVmUuid(vm.getUuid());
         Map<Integer, String> nicStaticIpMap = new StaticIpOperator().getNicStaticIpMap(vmStaticIps.get(l3.getUuid()));
 
         // ignoring ipv6 now , so if the user didn't assign ip on the webpage,then useTf Ip;

--- a/sdk/src/main/java/org/zstack/sdk/UsedIpInventory.java
+++ b/sdk/src/main/java/org/zstack/sdk/UsedIpInventory.java
@@ -68,11 +68,11 @@ public class UsedIpInventory  {
         return this.usedFor;
     }
 
-    public long ipInLong;
-    public void setIpInLong(long ipInLong) {
+    public java.lang.Long ipInLong;
+    public void setIpInLong(java.lang.Long ipInLong) {
         this.ipInLong = ipInLong;
     }
-    public long getIpInLong() {
+    public java.lang.Long getIpInLong() {
         return this.ipInLong;
     }
 

--- a/sdk/src/main/java/org/zstack/sdk/VmNicInventory.java
+++ b/sdk/src/main/java/org/zstack/sdk/VmNicInventory.java
@@ -76,14 +76,6 @@ public class VmNicInventory  {
         return this.metaData;
     }
 
-    public java.lang.Integer ipVersion;
-    public void setIpVersion(java.lang.Integer ipVersion) {
-        this.ipVersion = ipVersion;
-    }
-    public java.lang.Integer getIpVersion() {
-        return this.ipVersion;
-    }
-
     public java.lang.String driverType;
     public void setDriverType(java.lang.String driverType) {
         this.driverType = driverType;

--- a/test/src/test/groovy/org/zstack/test/integration/network/l3network/ipv6/SetStaticIpv6AddressCase.groovy
+++ b/test/src/test/groovy/org/zstack/test/integration/network/l3network/ipv6/SetStaticIpv6AddressCase.groovy
@@ -2,7 +2,6 @@ package org.zstack.test.integration.network.l3network.ipv6
 
 import com.googlecode.ipv6.IPv6Address
 import org.zstack.compute.vm.StaticIpOperator
-import org.zstack.network.service.flat.FlatNetworkSystemTags
 import org.zstack.sdk.GetL3NetworkDhcpIpAddressResult
 import org.zstack.sdk.ImageInventory
 import org.zstack.sdk.InstanceOfferingInventory
@@ -17,8 +16,6 @@ import org.zstack.testlib.EnvSpec
 import org.zstack.testlib.SubCase
 import org.zstack.utils.network.IPv6Constants
 import org.zstack.utils.network.IPv6NetworkUtils
-
-import java.util.stream.Collectors
 
 /**
  * Created by shixin on 2018/09/10.
@@ -155,7 +152,7 @@ class SetStaticIpv6AddressCase extends SubCase {
             }
         }
 
-        Map<String, List<String>> staticIpMap = new StaticIpOperator().getStaticIpbyVmUuid(vm.uuid)
+        Map<String, List<String>> staticIpMap = new StaticIpOperator().getStaticIpByVmUuid(vm.uuid)
         assert staticIpMap.get(l3_statefull.uuid) != null
         assert staticIpMap.get(l3_statefull.uuid).size() == 2
         assert staticIpMap.get(l3_statefull.uuid).contains(ip4Str)
@@ -165,7 +162,7 @@ class SetStaticIpv6AddressCase extends SubCase {
             vmInstanceUuid = vm.uuid
             l3NetworkUuid = l3_statefull.uuid
         }
-        staticIpMap = new StaticIpOperator().getStaticIpbyVmUuid(vm.uuid)
+        staticIpMap = new StaticIpOperator().getStaticIpByVmUuid(vm.uuid)
         assert staticIpMap.get(l3_statefull.uuid) == null
 
         ip4Str = ip4s.get(1)
@@ -182,7 +179,7 @@ class SetStaticIpv6AddressCase extends SubCase {
             l3NetworkUuid = l3_statefull.uuid
             staticIp = ip4Str
         }
-        staticIpMap = new StaticIpOperator().getStaticIpbyVmUuid(vm.uuid)
+        staticIpMap = new StaticIpOperator().getStaticIpByVmUuid(vm.uuid)
         assert staticIpMap.get(l3_statefull.uuid) != null
         assert staticIpMap.get(l3_statefull.uuid).size() == 1
         assert staticIpMap.get(l3_statefull.uuid).contains(ip6Str)
@@ -192,7 +189,7 @@ class SetStaticIpv6AddressCase extends SubCase {
             l3NetworkUuid = l3_statefull.uuid
             staticIp = ip6Str
         }
-        staticIpMap = new StaticIpOperator().getStaticIpbyVmUuid(vm.uuid)
+        staticIpMap = new StaticIpOperator().getStaticIpByVmUuid(vm.uuid)
         assert staticIpMap.get(l3_statefull.uuid) == null
 
         destroyVmInstance {
@@ -248,7 +245,7 @@ class SetStaticIpv6AddressCase extends SubCase {
                 assert ip.ip == ip6Str
             }
         }
-        Map<String, List<String>> staticIpMap = new StaticIpOperator().getStaticIpbyVmUuid(vm.uuid)
+        Map<String, List<String>> staticIpMap = new StaticIpOperator().getStaticIpByVmUuid(vm.uuid)
         assert staticIpMap.get(l3_statefull.uuid) != null
         assert staticIpMap.get(l3_statefull.uuid).size() == 2
         assert staticIpMap.get(l3_statefull.uuid).contains(ip4Str)
@@ -266,7 +263,7 @@ class SetStaticIpv6AddressCase extends SubCase {
             l3NetworkUuid = l3_statefull.uuid
             staticIp = ip6Str
         }
-        staticIpMap = new StaticIpOperator().getStaticIpbyVmUuid(vm.uuid)
+        staticIpMap = new StaticIpOperator().getStaticIpByVmUuid(vm.uuid)
         assert staticIpMap.get(l3_statefull.uuid) != null
         assert staticIpMap.get(l3_statefull.uuid).size() == 1
         assert staticIpMap.get(l3_statefull.uuid).contains(ip4Str)
@@ -334,7 +331,7 @@ class SetStaticIpv6AddressCase extends SubCase {
             }
         }
 
-        Map<String, List<String>> staticIpMap = new StaticIpOperator().getStaticIpbyVmUuid(vm.uuid)
+        Map<String, List<String>> staticIpMap = new StaticIpOperator().getStaticIpByVmUuid(vm.uuid)
         assert staticIpMap.get(l3_statefull.uuid) != null
         assert staticIpMap.get(l3_statefull.uuid).size() == 2
         assert staticIpMap.get(l3_statefull.uuid).contains(ip4Str)
@@ -351,7 +348,7 @@ class SetStaticIpv6AddressCase extends SubCase {
             delegate.ip = ip4Str
             delegate.ip6 = ip6Str
         }
-        staticIpMap = new StaticIpOperator().getStaticIpbyVmUuid(vm.uuid)
+        staticIpMap = new StaticIpOperator().getStaticIpByVmUuid(vm.uuid)
         assert staticIpMap.get(l3_statefull.uuid) != null
         assert staticIpMap.get(l3_statefull.uuid).size() == 2
         assert staticIpMap.get(l3_statefull.uuid).contains(ip4Str)

--- a/testlib/src/main/java/org/zstack/testlib/tool/TermsGenerator.groovy
+++ b/testlib/src/main/java/org/zstack/testlib/tool/TermsGenerator.groovy
@@ -8,6 +8,7 @@ import org.zstack.utils.path.PathUtil
 
 import javax.persistence.Entity
 import java.nio.charset.Charset
+import java.nio.charset.StandardCharsets
 
 class TermsGenerator {
     static String termFileFormat = "terms_%s.yaml"
@@ -111,11 +112,14 @@ class TermsGenerator {
             }
         }
 
-        File f = new File(PathUtil.
-                join(workDir, destDir, destFileName))
-        for (String line : outputLines) {
-            f.append(line, Charset.forName("UTF-8").toString())
-        }
+        File f = new File(PathUtil.join(workDir, destDir, destFileName));
+        f.withOutputStream({ os ->
+            os.withWriter(StandardCharsets.UTF_8.toString()) { writer ->
+                outputLines.each { line ->
+                    writer.write(line)
+                }
+            }
+        })
     }
 
     static List<TermTranslatePropertyLine> loadFileFromResource(String fileName) {

--- a/utils/src/main/java/org/zstack/utils/network/NetworkUtils.java
+++ b/utils/src/main/java/org/zstack/utils/network/NetworkUtils.java
@@ -956,7 +956,7 @@ public class NetworkUtils {
         }
     }
 
-    public static Boolean isValidInternalAddress(String ip) {
+    public static Boolean isInternalAddress(String ip) {
         if (isIpv4Address(ip)) {
             return isAutomaticPrivateIpAddr(ip);
         } else if (IPv6NetworkUtils.isIpv6Address(ip)) {


### PR DESCRIPTION
1. change ipInLong field type from long to Long to fix the bug of
returning multiple fields when querying specific filed in zql

2. allow duplicated static ip in simple l3

3. add validator for system tags of ip gateway and netmask

Resolves: ZSV-5459

Change-Id: I6c6a7561726b786b6d6f6a646a76786f687a6a76

sync from gitlab !6230