### PR TITLE
<fix>[identity]: Change the sharing logic of shareable volume

### DIFF
--- a/identity/src/main/java/org/zstack/identity/AccountManagerImpl.java
+++ b/identity/src/main/java/org/zstack/identity/AccountManagerImpl.java
@@ -41,6 +41,7 @@ import org.zstack.header.rest.RestAuthenticationBackend;
 import org.zstack.header.rest.RestAuthenticationParams;
 import org.zstack.header.rest.RestAuthenticationType;
 import org.zstack.header.vo.*;
+import org.zstack.header.volume.VolumeVO;
 import org.zstack.identity.rbac.PolicyUtils;
 import org.zstack.utils.*;
 import org.zstack.utils.function.ForEachFunction;
@@ -1071,7 +1072,7 @@ public class AccountManagerImpl extends AbstractService implements AccountManage
         }
 
         AccountType atype = types.get(0);
-        if (AccountType.SystemAdmin == atype) {
+        if (AccountType.SystemAdmin == atype && resourceType != VolumeVO.class) {
             return null;
         }
 


### PR DESCRIPTION
Change the logic of sharedable volume to "enable sharing between
different virtual machines of the same user". The original situation
was that administrator users could see shareable volume of normal
users. Now, shareable volume created by administrator users can only
be seen by administrator users, and shareable volume created by
ordinary users can only be seen by the current user.

Resolves: ZSV-5132

Change-Id: I657a6b746e7a6b6869657461706d6e6d6f686867

sync from gitlab !6253