### PR TITLE
<fix>[kvm]: fix callWithException() usage in KVMHost

### DIFF
--- a/plugin/kvm/src/main/java/org/zstack/kvm/KVMHost.java
+++ b/plugin/kvm/src/main/java/org/zstack/kvm/KVMHost.java
@@ -940,15 +940,14 @@ public class KVMHost extends HostBase implements Host {
         KVMHostVO host = dbf.findByUuid(msg.getHostUuid(), KVMHostVO.class);
         HTTP.Builder hb = HTTP.post();
         hb.body("");
-        try {
-            hb.url(String.format("http://localhost:%s?username=%s&&hostname=%s&&port=%s&&password=%s",
-                    KVMGlobalConfig.HOST_WEBSSH_PORT.value(),
-                    msg.getUserName(),
-                    host.getManagementIp(),
-                    host.getPort().toString(),
-                    msg.getPassword()));
+        hb.url(String.format("http://localhost:%s?username=%s&&hostname=%s&&port=%s&&password=%s",
+                KVMGlobalConfig.HOST_WEBSSH_PORT.value(),
+                msg.getUserName(),
+                host.getManagementIp(),
+                host.getPort().toString(),
+                msg.getPassword()));
 
-            Response r = hb.callWithException();
+        try (Response r = hb.callWithException()) {
             // 1. webssh maybe is not running
             if (!r.isSuccessful()) {
                 reply.setError(inerr("webssh server is unreachable for %s", r.message()));


### PR DESCRIPTION
Use try with resource to avoid memory leak

Related: ZSTAC-17091

Change-Id: I746e7164796f77786b72656277777377616b746a
Signed-off-by: AlanJager <ye.zou@zstack.io>

sync from gitlab !6314