### PR TITLE
<fix>[compute]: set host sync level to connect-host task

### DIFF
--- a/compute/src/main/java/org/zstack/compute/host/HostBase.java
+++ b/compute/src/main/java/org/zstack/compute/host/HostBase.java
@@ -1267,6 +1267,11 @@ public abstract class HostBase extends AbstractHost {
             }
 
             @Override
+            public int getSyncLevel() {
+                return getHostSyncLevel();
+            }
+
+            @Override
             public void run(SyncTaskChain chain) {
                 checkState();
                 


### PR DESCRIPTION
ConnectHostMsg message uses two level HostBase queue.
First one is connect-host-%s-single-flight and second
one is connect-host-%s. Single flight is used to deduplicate
task during one connection, but now without host sync
level, connect-host task will be executed without limitation.

Especially, in large scale environment with a lot of hosts
reconnection may run out of management node's thread.

Resolves: ZSTAC-62184

Change-Id: I7177646c6f71646c6b6b767a6d736f6377656469

sync from gitlab !6327