### PR TITLE
<fix>[conf]: create vm from backup

### DIFF
--- a/sdk/src/main/java/org/zstack/heder/storage/volume/backup/CreateVmFromVmBackupAction.java
+++ b/sdk/src/main/java/org/zstack/heder/storage/volume/backup/CreateVmFromVmBackupAction.java
@@ -34,7 +34,7 @@ public class CreateVmFromVmBackupAction extends AbstractAction {
     @Param(required = false, nonempty = false, nullElements = false, emptyString = true, noTrim = false)
     public java.lang.String backupStorageUuid;
 
-    @Param(required = true, nonempty = false, nullElements = false, emptyString = true, noTrim = false)
+    @Param(required = false, nonempty = false, nullElements = false, emptyString = true, noTrim = false)
     public java.lang.String instanceOfferingUuid;
 
     @Param(required = false, nonempty = false, nullElements = false, emptyString = true, noTrim = false)
@@ -69,6 +69,15 @@ public class CreateVmFromVmBackupAction extends AbstractAction {
 
     @Param(required = false, nonempty = false, nullElements = false, emptyString = true, noTrim = false)
     public java.util.List dataVolumeSystemTags;
+
+    @Param(required = false, nonempty = false, nullElements = false, emptyString = true, noTrim = false)
+    public java.lang.Integer cpuNum;
+
+    @Param(required = false, nonempty = false, nullElements = false, emptyString = true, noTrim = false)
+    public java.lang.Long memorySize;
+
+    @Param(required = false, validValues = {"InstantStart","CreateStopped"}, nonempty = false, nullElements = false, emptyString = true, noTrim = false)
+    public java.lang.String strategy = "InstantStart";
 
     @Param(required = false)
     public java.lang.String defaultL3NetworkUuid;

--- a/sdk/src/main/java/org/zstack/heder/storage/volume/backup/RevertVmFromVmBackupAction.java
+++ b/sdk/src/main/java/org/zstack/heder/storage/volume/backup/RevertVmFromVmBackupAction.java
@@ -31,6 +31,9 @@ public class RevertVmFromVmBackupAction extends AbstractAction {
     @Param(required = false, nonempty = false, nullElements = false, emptyString = true, noTrim = false)
     public java.lang.String backupStorageUuid;
 
+    @Param(required = false, nonempty = false, nullElements = false, emptyString = true, noTrim = false)
+    public boolean instantStart = false;
+
     @Param(required = false)
     public java.util.List systemTags;
 


### PR DESCRIPTION
1 add params to APICreateVmFromVmBackupMsg

1) Set up the InstanceOffering using cpuNum and memorySize

2)strategy Select whether to start or stop the vm after creation

2 add instantStart to APIRevertVmFromVmBackupMsg

1) APIRevertVmFromVmBackupMsg adds a parameter instantStart.

instantStart=true means after restoration, start the vm

Resolves: ZSV-766

Change-Id: I756f6f6a746268617679646178797567706d6864

sync from gitlab !4989