### PR TITLE
<fix>[host]: remove @NoLogging from webssh url

### DIFF
--- a/header/src/main/java/org/zstack/header/host/APIGetHostWebSshUrlEvent.java
+++ b/header/src/main/java/org/zstack/header/host/APIGetHostWebSshUrlEvent.java
@@ -17,7 +17,6 @@ public class APIGetHostWebSshUrlEvent extends APIEvent {
         super(apiId);
     }
 
-    @NoLogging
     private String url;
 
     public String getUrl() {


### PR DESCRIPTION
webssh connection url could not be used again
after connection connected, so no need to mask
the url in api result

Resolves: ZSTAC-65384

Change-Id: I666c707177686a7368706174796a726a776c7a66
Signed-off-by: AlanJager <ye.zou@zstack.io>

sync from gitlab !6346