### PR TITLE
<type>[sblk]: update sblk default preallocation to none

### DIFF
--- a/conf/db/upgrade/V4.8.11__schema.sql
+++ b/conf/db/upgrade/V4.8.11__schema.sql
@@ -1,0 +1,1 @@
+UPDATE `zstack`.`GlobalConfigVO` SET `value`='none', `defaultValue`='none' WHERE `category`='sharedblock' AND `name`='qcow2.allocation';


### PR DESCRIPTION
1、update sblk default preallocation to none
2、disable discard on metadata

Resolves/Related: ZSTAC-66340

Change-Id: 81a07e23790c4785953c8aee676103a9

sync from gitlab !6351