### PR TITLE
<fix>[storage]: support memory snapshot before 4.6.11

### DIFF
--- a/storage/src/main/java/org/zstack/storage/snapshot/group/VolumeSnapshotGroupBase.java
+++ b/storage/src/main/java/org/zstack/storage/snapshot/group/VolumeSnapshotGroupBase.java
@@ -280,9 +280,10 @@ public class VolumeSnapshotGroupBase implements VolumeSnapshotGroup {
                 new While<>(pluginRgty.getExtensionList(MemorySnapshotGroupExtensionPoint.class)).each((ext, compl) -> {
                     List<VmInstanceDeviceAddressArchiveVO> archiveVmInfos = vidm.getAddressArchiveInfoFromArchiveForResourceUuid(getSelfInventory().getVmInstanceUuid(), getSelfInventory().getUuid(), ext.getArchiveBundleCanonicalName());
                     List<Object> bundles = archiveVmInfos.stream().map(archiveVmInfo -> (Object) JSONObjectUtil.toObject(archiveVmInfo.getMetadata(), ext.getArchiveBundleClass())).collect(Collectors.toList());
+                    // keep-backward-compatibility for old version since
                     if (bundles.isEmpty()) {
-                        compl.addError(operr("no bundle found for type:%s", ext.getArchiveBundleCanonicalName()));
-                        compl.allDone();
+                        logger.warn(String.format("no bundle found for type: %s", ext.getArchiveBundleCanonicalName()));
+                        compl.done();
                         return;
                     }
                     ext.beforeRevertMemorySnapshotGroup(getSelfInventory(), bundles, new Completion(compl) {


### PR DESCRIPTION
Since 4.6.11 archive build class is introduced to
memory snapshot metadata to help save/restore snapshot
metadata in resource level, but the memory snapshot
taken before 4.6.11 has missing some of the archive
type so ignore errors if no archive bundle could be found

Related: ZSTAC-66290

Change-Id: I616e7478756a6c697a636668786a6b6467727462
Signed-off-by: AlanJager <ye.zou@zstack.io>

sync from gitlab !6355