### PR TITLE
<fix>[conf]: reset sharedblock qcow2 allocation

### DIFF
--- a/conf/db/upgrade/V5.1.8__schema.sql
+++ b/conf/db/upgrade/V5.1.8__schema.sql
@@ -131,3 +131,5 @@ CREATE TABLE IF NOT EXISTS `zstack`.`ReservedIpRangeVO` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 ALTER TABLE `zstack`.`PciDeviceVO` ADD `rev` varchar(32) DEFAULT '';
+
+DELETE FROM `zstack`.`ResourceConfigVO` WHERE `category`='sharedblock' AND `name`='qcow2.allocation';


### PR DESCRIPTION
metadata is slow on volume backup.
none is fast on volume backup.
subcluster can resolve write amplification on empty volume.

so set allocation to default config: none.

DBImpact

Resolves: ZSTAC-66340

Change-Id: I61646877736e676768627562627476686d79636d

sync from gitlab !6403