### PR TITLE
<fix>[host]: use host free disk

### DIFF
--- a/header/src/main/java/org/zstack/header/host/APIGetPhysicalMachineBlockDevicesMsg.java
+++ b/header/src/main/java/org/zstack/header/host/APIGetPhysicalMachineBlockDevicesMsg.java
@@ -6,6 +6,8 @@ import org.zstack.header.message.APIParam;
 import org.zstack.header.message.APISyncCallMessage;
 import org.zstack.header.rest.RestRequest;
 
+import java.util.List;
+
 @RestRequest(
         path = "/host/get-block-devices",
         method = HttpMethod.GET,
@@ -21,6 +23,8 @@ import org.zstack.header.rest.RestRequest;
     private Integer sshPort;
     @APIParam(maxLength = 255)
     private String hostName;
+    @APIParam(required = false)
+    List<String> excludedTypes;
 
     public String getUsername() {
         return username;
@@ -52,6 +56,14 @@ import org.zstack.header.rest.RestRequest;
 
     public void setHostName(String hostName) {
         this.hostName = hostName;
+    }
+
+    public List<String> getExcludedTypes() {
+        return excludedTypes;
+    }
+
+    public void setExcludedTypes(List<String> excludedTypes) {
+        this.excludedTypes = excludedTypes;
     }
 
     public static APIGetPhysicalMachineBlockDevicesMsg __example__() {

--- a/header/src/main/java/org/zstack/header/host/APIGetPhysicalMachineBlockDevicesMsgDoc_zh_cn.groovy
+++ b/header/src/main/java/org/zstack/header/host/APIGetPhysicalMachineBlockDevicesMsgDoc_zh_cn.groovy
@@ -58,6 +58,15 @@ doc {
 					since "zsv 4.3.0"
 				}
 				column {
+					name "excludedBlockDevicesType"
+					enclosedIn ""
+					desc "指定排除的磁盘类型"
+					location "query"
+					type "List"
+					optional true
+					since "zsv 4.3.0"
+				}
+				column {
 					name "systemTags"
 					enclosedIn ""
 					desc "系统标签"

--- a/header/src/main/java/org/zstack/header/host/APIGetPhysicalMachineBlockDevicesReply.java
+++ b/header/src/main/java/org/zstack/header/host/APIGetPhysicalMachineBlockDevicesReply.java
@@ -5,6 +5,7 @@ import org.zstack.header.rest.RestResponse;
 import org.zstack.utils.CollectionUtils;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import static org.zstack.header.host.BlockDevicesParser.blockDevicesExample;
@@ -44,6 +45,15 @@ public class APIGetPhysicalMachineBlockDevicesReply extends APIReply {
             return blockDevices;
         }
 
+        public void filter(List<String> excludedBlockDevicesType) {
+            if (CollectionUtils.isEmpty(excludedBlockDevicesType)) {
+                return;
+            }
+
+            unusedBlockDevices.removeIf(blockDevice -> excludedBlockDevicesType.contains(blockDevice.getType()));
+            usedBlockDevices.removeIf(blockDevice -> excludedBlockDevicesType.contains(blockDevice.getType()));
+        }
+
         public static class BlockDevice {
             private String name;
             private String type;
@@ -66,7 +76,7 @@ public class APIGetPhysicalMachineBlockDevicesReply extends APIReply {
                 device.physicalSector = blockDevice.getPhysicalSector();
                 device.logicalSector = blockDevice.getLogicalSector();
                 device.mountPoint = blockDevice.getMountPoint();
-                device.partitionTable = blockDevice.getPartitionTable();
+                device.partitionTable = blockDevice.getPartitionTable() != null ? blockDevice.getPartitionTable() : "unknown";
                 if (!CollectionUtils.isEmpty(blockDevice.getChildren())) {
                     device.children = new ArrayList<>();
                     for (BlockDevicesParser.BlockDevice child : blockDevice.getChildren()) {
@@ -159,7 +169,9 @@ public class APIGetPhysicalMachineBlockDevicesReply extends APIReply {
 
     public static APIGetPhysicalMachineBlockDevicesReply __example__() {
         APIGetPhysicalMachineBlockDevicesReply reply = new APIGetPhysicalMachineBlockDevicesReply();
-        reply.setBlockDevices(BlockDevices.valueOf(BlockDevicesParser.parse(blockDevicesExample)));
+        BlockDevices blockDevices = BlockDevices.valueOf(BlockDevicesParser.parse(blockDevicesExample));
+        blockDevices.filter(Collections.singletonList("rom"));
+        reply.setBlockDevices(blockDevices);
         return reply;
     }
 }

--- a/header/src/main/java/org/zstack/header/host/APIMountBlockDeviceMsg.java
+++ b/header/src/main/java/org/zstack/header/host/APIMountBlockDeviceMsg.java
@@ -4,7 +4,10 @@ import org.springframework.http.HttpMethod;
 import org.zstack.header.log.NoLogging;
 import org.zstack.header.message.APIMessage;
 import org.zstack.header.message.APIParam;
+import org.zstack.header.message.DefaultTimeout;
 import org.zstack.header.rest.RestRequest;
+
+import java.util.concurrent.TimeUnit;
 
 @RestRequest(
         path = "/host/mount-block-device",
@@ -26,8 +29,19 @@ public class APIMountBlockDeviceMsg extends APIMessage {
     private String blockDevicePath;
     @APIParam(maxLength = 2048)
     private String mountPoint;
-    @APIParam(required = false, maxLength = 255, validValues = {"btrfs", "cramfs", "ext2", "ext3", "ext4", "fat", "minix", "msdos", "ntfs", "vfat", "xfs"})
+    @APIParam(required = false, maxLength = 255, validValues = {"ext4", "xfs"})
     private String filesystemType = "xfs";
+
+    public static class mkfsCommd {
+        public static String buildMkfsCommd(String filesystemType, String blockDevicePath) {
+            if (filesystemType.equals("ext4")) {
+                return "mkfs.ext4 -F " + blockDevicePath;
+            } else if (filesystemType.equals("xfs")) {
+                return "mkfs.xfs -f " + blockDevicePath;
+            }
+            throw new IllegalArgumentException("unsupported filesystem type: " + filesystemType);
+        }
+    }
 
     public String getUsername() {
         return username;

--- a/header/src/main/java/org/zstack/header/host/APIMountBlockDeviceMsgDoc_zh_cn.groovy
+++ b/header/src/main/java/org/zstack/header/host/APIMountBlockDeviceMsgDoc_zh_cn.groovy
@@ -83,7 +83,7 @@ doc {
 					type "String"
 					optional true
 					since "zsv 4.3.0"
-					values ("btrfs","cramfs","ext2","ext3","ext4","fat","minix","msdos","ntfs","vfat","xfs")
+					values ("ext4","xfs")
 				}
 				column {
 					name "systemTags"

--- a/sdk/src/main/java/org/zstack/sdk/GetPhysicalMachineBlockDevicesAction.java
+++ b/sdk/src/main/java/org/zstack/sdk/GetPhysicalMachineBlockDevicesAction.java
@@ -37,6 +37,9 @@ public class GetPhysicalMachineBlockDevicesAction extends AbstractAction {
     @Param(required = true, maxLength = 255, nonempty = false, nullElements = false, emptyString = true, noTrim = false)
     public java.lang.String hostName;
 
+    @Param(required = false, nonempty = false, nullElements = false, emptyString = true, noTrim = false)
+    public java.util.List excludedTypes;
+
     @Param(required = false)
     public java.util.List systemTags;
 

--- a/sdk/src/main/java/org/zstack/sdk/MountBlockDeviceAction.java
+++ b/sdk/src/main/java/org/zstack/sdk/MountBlockDeviceAction.java
@@ -43,7 +43,7 @@ public class MountBlockDeviceAction extends AbstractAction {
     @Param(required = true, maxLength = 2048, nonempty = false, nullElements = false, emptyString = true, noTrim = false)
     public java.lang.String mountPoint;
 
-    @Param(required = false, validValues = {"btrfs","cramfs","ext2","ext3","ext4","fat","minix","msdos","ntfs","vfat","xfs"}, maxLength = 255, nonempty = false, nullElements = false, emptyString = true, noTrim = false)
+    @Param(required = false, validValues = {"ext4","xfs"}, maxLength = 255, nonempty = false, nullElements = false, emptyString = true, noTrim = false)
     public java.lang.String filesystemType = "xfs";
 
     @Param(required = false)


### PR DESCRIPTION
1 add '-s' to parted to skip the command confirmation

2 add excludedBlockDevicesType  to APIGetPhysicalMachineBlockDevicesMsg,
used to represent the default filtering disk type

3 grep uses -w to match the specified string.

4 failed to obtain disk partition, set default value "unknown".

Resolves: ZSV-5764

Change-Id: I6e6376696470687a6b6a677271736c616c777464

sync from gitlab !6481