### PR TITLE
<fix>[account-import]: sync ldap user after management mode ready

### DIFF
--- a/conf/springConfigXml/accountImport.xml
+++ b/conf/springConfigXml/accountImport.xml
@@ -23,6 +23,7 @@
         <zstack:plugin>
             <zstack:extension interface="org.zstack.header.Component"/>
             <zstack:extension interface="org.zstack.identity.imports.source.CreateAccountSourceExtensionPoint"/>
+            <zstack:extension interface="org.zstack.header.managementnode.ManagementNodeReadyExtensionPoint"/>
         </zstack:plugin>
     </bean>
 </beans>

--- a/plugin/ldap/src/main/java/org/zstack/ldap/LdapConstant.java
+++ b/plugin/ldap/src/main/java/org/zstack/ldap/LdapConstant.java
@@ -29,6 +29,8 @@ public interface LdapConstant {
     }
 
     String[] QUERY_LDAP_ENTRY_MUST_RETURN_ATTRIBUTES = {"cn","name","distinguishedname","displayname","userprincipalname","objectclass","entryDN","distinguishedName"};
+    String[] QUERY_WINDOWS_AD_ENTRY_MUST_RETURN_ATTRIBUTES = {"UserAccountControl"};
+    String[] QUERY_OPEN_LDAP_ENTRY_MUST_RETURN_ATTRIBUTES = {};
 
     String QUERY_LDAP_ENTRY_RETURN_ATTRIBUTE_SEPARATOR = ",";
 

--- a/plugin/ldap/src/main/java/org/zstack/ldap/compute/LdapSyncHelper.java
+++ b/plugin/ldap/src/main/java/org/zstack/ldap/compute/LdapSyncHelper.java
@@ -254,10 +254,10 @@ public class LdapSyncHelper {
             private void printUnbindingList(Map<String, String> credentialsAccountMapNeedDelete) {
                 StringBuilder builder = new StringBuilder(128 + credentialsAccountMapNeedDelete.size() << 7);
                 builder.append(String.format(
-                        "LDAP[uuid=%s, deleteStrategy=%s] unbinding account list below:\n",
+                        "LDAP[uuid=%s, deleteStrategy=%s] unbinding account list below:%n",
                         importSpec.getSourceUuid(), taskSpec.getDeleteAccountStrategy()));
                 for (Map.Entry<String, String> entry : credentialsAccountMapNeedDelete.entrySet()) {
-                    builder.append(String.format("\taccountUuid=%s, credentials=%s\n", entry.getValue(), entry.getKey()));
+                    builder.append(String.format("\taccountUuid=%s, credentials=%s%n", entry.getValue(), entry.getKey()));
                 }
                 logger.info(builder.toString());
             }

--- a/plugin/ldap/src/main/java/org/zstack/ldap/driver/LdapUtil.java
+++ b/plugin/ldap/src/main/java/org/zstack/ldap/driver/LdapUtil.java
@@ -438,8 +438,16 @@ public class LdapUtil {
         }
 
         returnedAttSet.addAll(Arrays.asList(LdapConstant.QUERY_LDAP_ENTRY_MUST_RETURN_ATTRIBUTES));
-
         returnedAttSet.add(ldap.getUsernameProperty());
+
+        switch (ldap.getServerType()) {
+        case OpenLdap:
+            returnedAttSet.addAll(Arrays.asList(LdapConstant.QUERY_OPEN_LDAP_ENTRY_MUST_RETURN_ATTRIBUTES));
+            break;
+        case WindowsAD: default:
+            returnedAttSet.addAll(Arrays.asList(LdapConstant.QUERY_WINDOWS_AD_ENTRY_MUST_RETURN_ATTRIBUTES));
+            break;
+        }
 
         return returnedAttSet.toArray(new String[]{});
     }

--- a/plugin/ldap/src/main/java/org/zstack/ldap/entity/LdapEntryInventory.java
+++ b/plugin/ldap/src/main/java/org/zstack/ldap/entity/LdapEntryInventory.java
@@ -7,6 +7,7 @@ import java.util.List;
 @PythonClassInventory
 public class LdapEntryInventory {
     private String dn;
+    private boolean enable;
     private List<LdapEntryAttributeInventory> attributes;
 
     public String getDn() {
@@ -15,6 +16,14 @@ public class LdapEntryInventory {
 
     public void setDn(String dn) {
         this.dn = dn;
+    }
+
+    public boolean isEnable() {
+        return enable;
+    }
+
+    public void setEnable(boolean enable) {
+        this.enable = enable;
     }
 
     public List<LdapEntryAttributeInventory> getAttributes() {

--- a/sdk/src/main/java/org/zstack/sdk/identity/ldap/entity/LdapEntryInventory.java
+++ b/sdk/src/main/java/org/zstack/sdk/identity/ldap/entity/LdapEntryInventory.java
@@ -12,6 +12,14 @@ public class LdapEntryInventory  {
         return this.dn;
     }
 
+    public boolean enable;
+    public void setEnable(boolean enable) {
+        this.enable = enable;
+    }
+    public boolean getEnable() {
+        return this.enable;
+    }
+
     public java.util.List attributes;
     public void setAttributes(java.util.List attributes) {
         this.attributes = attributes;


### PR DESCRIPTION
The sync message will be sent when
the management mode is ready.

When the component is first started, the management node
has not yet joined the "Circle". If a sync message is sent
at this time, it will inform ResourceDestinationMaker
that the startup has not been completed and
an error will be reported.

Related: ZSV-5531

Change-Id: I6c6a6478717471667063616c6c72737a69637379

sync from gitlab !6487