### PR TITLE
<fix>[build]: template path support @

### DIFF
--- a/testlib/src/main/java/org/zstack/testlib/BeanConstructor.groovy
+++ b/testlib/src/main/java/org/zstack/testlib/BeanConstructor.groovy
@@ -57,7 +57,7 @@ class BeanConstructor {
     protected void generateSpringConfig() {
         try {
             //URL templatePath = this.getClass().getClassLoader().getResource("zstack-template.xml")
-            URL templatePath = this.getClass().getClassLoader().getResource("zstack-template.xml")
+            URI templatePath = this.getClass().getClassLoader().getResource("zstack-template.xml").toURI()
             File template = new File(templatePath.getPath())
             List<String> contents = template.readLines()
 


### PR DESCRIPTION
docker are used in kunpeng-native cicd environment, where
workspace path contains @, which is not supported by URL.

Resolves: ZSV-6180

Change-Id: I6a77726c64726b6c726279627175796268696f6b

sync from gitlab !6514