### PR TITLE
<fix>[conf]: remove schema of grayscale upgrade

### DIFF
--- a/conf/db/upgrade/V4.8.13__schema.sql
+++ b/conf/db/upgrade/V4.8.13__schema.sql
@@ -1,1 +1,0 @@
-CALL ADD_CONSTRAINT('AgentVersionVO', 'fkAgentVersionVOResourceVO', 'uuid', 'ResourceVO', 'uuid', 'CASCADE');

--- a/core/src/main/java/org/zstack/core/upgrade/AgentVersionVO.java
+++ b/core/src/main/java/org/zstack/core/upgrade/AgentVersionVO.java
@@ -15,7 +15,6 @@ import java.sql.Timestamp;
 public class AgentVersionVO {
     @Id
     @Column
-    @ForeignKey(parentEntityClass = ResourceVO.class, onDeleteAction = ForeignKey.ReferenceOption.CASCADE)
     private String uuid;
 
     @Column


### PR DESCRIPTION
alter sql could not be used during upgrade

DBImpact

Resolves: ZSTAC-67166

Change-Id: I69636f646c796d70756261636c6167757a746e6f

sync from gitlab !6536