### PR TITLE
<fix>[network]: reformat L2NetworkHostRefVO

### DIFF
--- a/conf/db/upgrade/V4.8.0.5__schema.sql
+++ b/conf/db/upgrade/V4.8.0.5__schema.sql
@@ -1,18 +1,15 @@
 ALTER TABLE `zstack`.`L2VirtualSwitchNetworkVO` ADD COLUMN `vSwitchIndex` INT unsigned DEFAULT NULL AFTER `uuid`;
+DELETE FROM `zstack`.`L2NetworkHostRefVO` WHERE `attachStatus` = 'Detached';
+ALTER TABLE `zstack`.`L2NetworkHostRefVO` DROP COLUMN `attachStatus`;
+ALTER TABLE `zstack`.`L2NetworkHostRefVO` ADD COLUMN `bridgeName` varchar(16) DEFAULT NULL AFTER `l2ProviderType`;
 
 CREATE TABLE IF NOT EXISTS `zstack`.`UplinkGroupVO` (
-    `id` bigint unsigned NOT NULL UNIQUE AUTO_INCREMENT,
+    `id` bigint unsigned NOT NULL UNIQUE,
     `interfaceName` varchar(32) NOT NULL,
-    `vSwitchUuid` varchar(32) NOT NULL,
-    `hostUuid` varchar(32) NOT NULL,
     `type` varchar(32) NOT NULL,
     `bondingUuid` varchar(32) DEFAULT NULL,
     `interfaceUuid` varchar(32) DEFAULT NULL,
-    `lastOpDate` timestamp ON UPDATE CURRENT_TIMESTAMP,
-    `createDate` timestamp,
     PRIMARY KEY  (`id`),
-    CONSTRAINT `fkUplinkGroupVOL2VirtualSwitchNetworkVO` FOREIGN KEY (`vSwitchUuid`) REFERENCES L2VirtualSwitchNetworkVO (`uuid`) ON DELETE CASCADE,
-    CONSTRAINT `fkUplinkGroupVOHostEO` FOREIGN KEY (`hostUuid`) REFERENCES `HostEO` (`uuid`) ON DELETE CASCADE,
     CONSTRAINT `fkUplinkGroupVOHostNetworkBondingVO` FOREIGN KEY (`bondingUuid`) REFERENCES HostNetworkBondingVO (`uuid`) ON DELETE SET NULL,
     CONSTRAINT `fkUplinkGroupVOHostNetworkInterfaceVO` FOREIGN KEY (`interfaceUuid`) REFERENCES HostNetworkInterfaceVO (`uuid`) ON DELETE SET NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;

--- a/header/src/main/java/org/zstack/header/host/HostParam.java
+++ b/header/src/main/java/org/zstack/header/host/HostParam.java
@@ -4,8 +4,8 @@ import java.io.Serializable;
 
 public class HostParam implements Serializable {
     private String hostUuid;
-
     private String physicalInterface;
+    private String l2ProviderType;
 
     public String getHostUuid() {
         return hostUuid;
@@ -21,5 +21,13 @@ public class HostParam implements Serializable {
 
     public void setPhysicalInterface(String physicalInterface) {
         this.physicalInterface = physicalInterface;
+    }
+
+    public String getL2ProviderType() {
+        return l2ProviderType;
+    }
+
+    public void setL2ProviderType(String l2ProviderType) {
+        this.l2ProviderType = l2ProviderType;
     }
 }

--- a/header/src/main/java/org/zstack/header/network/l2/L2NetworkAttachStatus.java
+++ b/header/src/main/java/org/zstack/header/network/l2/L2NetworkAttachStatus.java
@@ -1,6 +1,0 @@
-package org.zstack.header.network.l2;
-
-public enum L2NetworkAttachStatus {
-    Detached,
-    Attached,
-}

--- a/header/src/main/java/org/zstack/header/network/l2/L2NetworkHostRefInventory.java
+++ b/header/src/main/java/org/zstack/header/network/l2/L2NetworkHostRefInventory.java
@@ -21,19 +21,24 @@ public class L2NetworkHostRefInventory {
     private String hostUuid;
     private String l2NetworkUuid;
     private String l2ProviderType;
-    private L2NetworkAttachStatus attachStatus;
+    private String bridgeName;
     private Timestamp createDate;
     private Timestamp lastOpDate;
 
+    public L2NetworkHostRefInventory() {
+    }
+
+    public L2NetworkHostRefInventory(L2NetworkHostRefVO vo) {
+        this.setHostUuid(vo.getHostUuid());
+        this.setL2NetworkUuid(vo.getL2NetworkUuid());
+        this.setL2ProviderType(vo.getL2ProviderType());
+        this.setBridgeName(vo.getBridgeName());
+        this.setCreateDate(vo.getCreateDate());
+        this.setLastOpDate(vo.getLastOpDate());
+    }
+
     public static L2NetworkHostRefInventory valueOf(L2NetworkHostRefVO vo) {
-        L2NetworkHostRefInventory inv = new L2NetworkHostRefInventory();
-        inv.setHostUuid(vo.getHostUuid());
-        inv.setL2NetworkUuid(vo.getL2NetworkUuid());
-        inv.setL2ProviderType(vo.getL2ProviderType());
-        inv.setAttachStatus(vo.getAttachStatus());
-        inv.setCreateDate(vo.getCreateDate());
-        inv.setLastOpDate(vo.getLastOpDate());
-        return inv;
+        return new L2NetworkHostRefInventory(vo);
     }
 
     public static List<L2NetworkHostRefInventory> valueOf(Collection<L2NetworkHostRefVO> vos) {
@@ -68,6 +73,13 @@ public class L2NetworkHostRefInventory {
         this.l2NetworkUuid = l2NetworkUuid;
     }
 
+    public String getBridgeName() {
+        return bridgeName;
+    }
+
+    public void setBridgeName(String bridgeName) {
+        this.bridgeName = bridgeName;
+    }
     public Timestamp getCreateDate() {
         return createDate;
     }
@@ -82,13 +94,5 @@ public class L2NetworkHostRefInventory {
 
     public void setLastOpDate(Timestamp lastOpDate) {
         this.lastOpDate = lastOpDate;
-    }
-
-    public L2NetworkAttachStatus getAttachStatus() {
-        return attachStatus;
-    }
-
-    public void setAttachStatus(L2NetworkAttachStatus attachStatus) {
-        this.attachStatus = attachStatus;
     }
 }

--- a/header/src/main/java/org/zstack/header/network/l2/L2NetworkHostRefVO.java
+++ b/header/src/main/java/org/zstack/header/network/l2/L2NetworkHostRefVO.java
@@ -4,11 +4,10 @@ import org.zstack.header.host.HostEO;
 import org.zstack.header.host.HostVO;
 import org.zstack.header.search.SqlTrigger;
 import org.zstack.header.search.TriggerIndex;
+import org.zstack.header.vo.*;
 import org.zstack.header.vo.EntityGraph;
 import org.zstack.header.vo.ForeignKey;
 import org.zstack.header.vo.ForeignKey.ReferenceOption;
-import org.zstack.header.vo.SoftDeletionCascade;
-import org.zstack.header.vo.SoftDeletionCascades;
 
 import javax.persistence.*;
 import java.sql.Timestamp;
@@ -27,7 +26,8 @@ import java.sql.Timestamp;
                 @EntityGraph.Neighbour(type = HostVO.class, myField = "hostUuid", targetField = "uuid"),
         }
 )
-public class L2NetworkHostRefVO {
+@Inheritance(strategy = InheritanceType.JOINED)
+public class L2NetworkHostRefVO implements ToInventory {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column
@@ -45,8 +45,7 @@ public class L2NetworkHostRefVO {
     private String l2ProviderType;
 
     @Column
-    @Enumerated(EnumType.STRING)
-    private L2NetworkAttachStatus attachStatus;
+    private String bridgeName;
 
     @Column
     private Timestamp createDate;
@@ -83,12 +82,12 @@ public class L2NetworkHostRefVO {
         this.hostUuid = hostUuid;
     }
 
-    public L2NetworkAttachStatus getAttachStatus() {
-        return attachStatus;
+    public String getBridgeName() {
+        return bridgeName;
     }
 
-    public void setAttachStatus(L2NetworkAttachStatus attachStatus) {
-        this.attachStatus = attachStatus;
+    public void setBridgeName(String bridgeName) {
+        this.bridgeName = bridgeName;
     }
 
     public String getL2NetworkUuid() {
@@ -115,4 +114,9 @@ public class L2NetworkHostRefVO {
         this.lastOpDate = lastOpDate;
     }
 
+    @Override
+    public String toString() {
+        return String.format("L2NetworkHostRefVO[hostUuid:%s, l2NetworkUuid:%s, l2ProviderType:%s, bridgeName:%s]",
+                hostUuid, l2NetworkUuid, l2ProviderType, bridgeName);
+    }
 }

--- a/header/src/main/java/org/zstack/header/network/l2/L2NetworkHostRefVO_.java
+++ b/header/src/main/java/org/zstack/header/network/l2/L2NetworkHostRefVO_.java
@@ -10,7 +10,7 @@ public class L2NetworkHostRefVO_ {
     public static volatile SingularAttribute<L2NetworkHostRefVO, String> hostUuid;
     public static volatile SingularAttribute<L2NetworkHostRefVO, String> l2NetworkUuid;
     public static volatile SingularAttribute<L2NetworkHostRefVO, String> l2ProviderType;
-    public static volatile SingularAttribute<L2NetworkHostRefVO, L2NetworkAttachStatus> attachStatus;
+    public static volatile SingularAttribute<L2NetworkHostRefVO, String> bridgeName;
     public static volatile SingularAttribute<L2NetworkHostRefVO, Timestamp> createDate;
     public static volatile SingularAttribute<L2NetworkHostRefVO, Timestamp> lastOpDate;
 }

--- a/network/src/main/java/org/zstack/network/l2/L2NetworkApiInterceptor.java
+++ b/network/src/main/java/org/zstack/network/l2/L2NetworkApiInterceptor.java
@@ -95,8 +95,12 @@ public class L2NetworkApiInterceptor implements ApiMessageInterceptor {
         }
 
         //TODO: UI for ovs and macVlan has not use l2ProviderType yet, set to value of vSwitchType
-        if (msg.getL2ProviderType() == null && !L2NetworkConstant.VSWITCH_TYPE_LINUX_BRIDGE.equals(l2.getvSwitchType())) {
+        if (msg.getL2ProviderType() == null) {
             msg.setL2ProviderType(l2.getvSwitchType());
+        }
+
+        if (!L2ProviderType.hasType(msg.getL2ProviderType())) {
+            throw new ApiMessageInterceptionException(argerr("unsupported l2Network provider type[%s]", msg.getL2ProviderType()));
         }
 
         if (!StringUtils.isEmpty(msg.getHostParams())) {
@@ -137,8 +141,9 @@ public class L2NetworkApiInterceptor implements ApiMessageInterceptor {
             throw new ApiMessageInterceptionException(operr("l2Network[uuid:%s] has not attached to cluster of host[uuid:%s]", msg.getL2NetworkUuid(), msg.getHostUuid()));
         }
 
-        if (L2NetworkHostUtils.checkIfL2NetworkHostRefNotExist(msg.getL2NetworkUuid(), msg.getHostUuid())) {
-            throw new ApiMessageInterceptionException(operr("l2Network[uuid:%s] does not supported to attach to host[uuid:%s]", msg.getL2NetworkUuid(), msg.getHostUuid()));
+        String l2Type = Q.New(L2NetworkVO.class).eq(L2NetworkVO_.uuid, msg.getL2NetworkUuid()).select(L2NetworkVO_.type).findValue();
+        if (L2NetworkType.valueOf(l2Type).isAttachToAllHosts()) {
+            throw new ApiMessageInterceptionException(operr("type[%s] should be attached to all host", l2Type));
         }
 
         HostVO host = dbf.findByUuid(msg.getHostUuid(), HostVO.class);

--- a/network/src/main/java/org/zstack/network/l2/L2NetworkHostUtils.java
+++ b/network/src/main/java/org/zstack/network/l2/L2NetworkHostUtils.java
@@ -7,73 +7,79 @@ import org.zstack.header.errorcode.ErrorCode;
 import org.zstack.header.host.HostParam;
 import org.zstack.header.host.HostVO;
 import org.zstack.header.host.HostVO_;
-import org.zstack.header.network.l2.L2NetworkAttachStatus;
 import org.zstack.header.network.l2.L2NetworkHostRefVO;
 import org.zstack.header.network.l2.L2NetworkHostRefVO_;
+import org.zstack.header.network.l2.L2ProviderType;
 import org.zstack.utils.CollectionUtils;
 import org.zstack.utils.Utils;
 import org.zstack.utils.logging.CLogger;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static org.zstack.core.Platform.argerr;
 
 public class L2NetworkHostUtils {
     private static final CLogger logger = Utils.getLogger(L2NetworkHostUtils.class);
 
-    public static void deleteL2NetworkHostRef(String l2NetworkUuid, List<String> hostUuids) {
-        logger.debug(String.format("del L2NetworkHostRefVO, l2NetworkUuid:%s, hostUuids:%s",
-                l2NetworkUuid, hostUuids));
+    public static void deleteL2NetworkHostRef(String l2Uuid, List<String> hostUuids) {
+        if (CollectionUtils.isEmpty(hostUuids)) {
+            return;
+        }
+
+        logger.debug(String.format("del L2NetworkHostRefVO, l2NetworkUuid: %s, hostUuids: %s",
+                l2Uuid, hostUuids));
         SQL.New(L2NetworkHostRefVO.class)
-                .eq(L2NetworkHostRefVO_.l2NetworkUuid, l2NetworkUuid)
+                .eq(L2NetworkHostRefVO_.l2NetworkUuid, l2Uuid)
                 .in(L2NetworkHostRefVO_.hostUuid, hostUuids)
                 .delete();
     }
 
-    public static void changeL2NetworkToHostRefDetached(String l2NetworkUuid, String hostUuid) {
-        if (checkIfL2NetworkHostRefNotExist(l2NetworkUuid, hostUuid)) {
-            logger.warn(String.format("can not find host l2 network ref[l2NetworkUuid: %s, hostUuid: %s]",
-                    l2NetworkUuid, hostUuid));
+    public static void deleteL2NetworkHostRef(String l2Uuid, String hostUuid) {
+        deleteL2NetworkHostRef(l2Uuid, Collections.singletonList(hostUuid));
+    }
+
+    public static void deleteL2NetworkHostRef(List<String> l2Uuids, String hostUuid) {
+        if (CollectionUtils.isEmpty(l2Uuids)) {
             return;
         }
 
-        logger.debug(String.format("change L2NetworkHostRefVO to Detached, l2NetworkUuid:%s, hostUuid:%s",
-                l2NetworkUuid, hostUuid));
+        logger.debug(String.format("del L2NetworkHostRefVO, l2NetworkUuids: %s, hostUuid: %s",
+                l2Uuids, hostUuid));
         SQL.New(L2NetworkHostRefVO.class)
+                .in(L2NetworkHostRefVO_.l2NetworkUuid, l2Uuids)
                 .eq(L2NetworkHostRefVO_.hostUuid, hostUuid)
-                .eq(L2NetworkHostRefVO_.l2NetworkUuid, l2NetworkUuid)
-                .set(L2NetworkHostRefVO_.attachStatus, L2NetworkAttachStatus.Detached).update();
+                .delete();
     }
 
-    public static void changeL2NetworkToHostRefAttached(String l2NetworkUuid, String hostUuid) {
-        if (checkIfL2NetworkHostRefNotExist(l2NetworkUuid, hostUuid)) {
-            logger.warn(String.format("can not find host l2 network ref[l2NetworkUuid: %s, hostUuid: %s]",
-                    l2NetworkUuid, hostUuid));
-            return;
-        }
-
-        logger.debug(String.format("change L2NetworkHostRefVO to Attached, l2NetworkUuid:%s, hostUuid:%s",
-                l2NetworkUuid, hostUuid));
-        SQL.New(L2NetworkHostRefVO.class)
-                .eq(L2NetworkHostRefVO_.hostUuid, hostUuid)
-                .eq(L2NetworkHostRefVO_.l2NetworkUuid, l2NetworkUuid)
-                .set(L2NetworkHostRefVO_.attachStatus, L2NetworkAttachStatus.Attached).update();
-    }
-
-    public static boolean checkIfL2NetworkHostRefNotExist(String l2NetworkUuid, String hostUuid) {
-        return !Q.New(L2NetworkHostRefVO.class)
-                .eq(L2NetworkHostRefVO_.l2NetworkUuid, l2NetworkUuid)
-                .eq(L2NetworkHostRefVO_.hostUuid, hostUuid)
-                .isExists();
-    }
-
-    public static boolean checkIfL2AttachedToHost(String l2NetworkUuid, String hostUuid) {
+    public static String getBridgeNameFromL2NetworkHostRef(String l2Uuid, String hostUuid) {
         return Q.New(L2NetworkHostRefVO.class)
-                .eq(L2NetworkHostRefVO_.l2NetworkUuid, l2NetworkUuid)
+                .select(L2NetworkHostRefVO_.bridgeName)
+                .eq(L2NetworkHostRefVO_.l2NetworkUuid, l2Uuid)
                 .eq(L2NetworkHostRefVO_.hostUuid, hostUuid)
-                .eq(L2NetworkHostRefVO_.attachStatus, L2NetworkAttachStatus.Attached)
+                .findValue();
+    }
+
+    public static boolean checkIfL2AttachedToHost(String l2Uuid, String hostUuid) {
+        return Q.New(L2NetworkHostRefVO.class)
+                .eq(L2NetworkHostRefVO_.l2NetworkUuid, l2Uuid)
+                .eq(L2NetworkHostRefVO_.hostUuid, hostUuid)
                 .isExists();
+    }
+
+    public static List<String> getExcludeHostUuids(List<String> l2Uuids, List<String> hostUuids) {
+        if (CollectionUtils.isEmpty(l2Uuids) || CollectionUtils.isEmpty(hostUuids)) {
+            return new ArrayList<>();
+        }
+
+        List<String> hostsWithRef = Q.New(L2NetworkHostRefVO.class)
+                .select(L2NetworkHostRefVO_.hostUuid)
+                .in(L2NetworkHostRefVO_.l2NetworkUuid, l2Uuids)
+                .in(L2NetworkHostRefVO_.hostUuid, hostUuids)
+                .listValues();
+        return hostUuids.stream().filter(it -> !hostsWithRef.contains(it)).collect(Collectors.toList());
     }
 
     public static ErrorCode validateHostParams(List<HostParam> hostParams, String clusterUuid, String hostUuid) {
@@ -107,6 +113,11 @@ public class L2NetworkHostUtils {
 
             if (StringUtils.isEmpty(hostParam.getPhysicalInterface())) {
                 return argerr("physical interface can not be null in HostParam");
+            }
+
+            if (!StringUtils.isEmpty(hostParam.getL2ProviderType())
+                    && !L2ProviderType.hasType(hostParam.getL2ProviderType())) {
+                return argerr("unsupported l2Network provider type[%s]", hostParam.getL2ProviderType());
             }
         }
 

--- a/network/src/main/java/org/zstack/network/l2/L2NoVlanL2NetworkFactory.java
+++ b/network/src/main/java/org/zstack/network/l2/L2NoVlanL2NetworkFactory.java
@@ -12,8 +12,13 @@ import org.zstack.utils.Utils;
 import org.zstack.utils.data.FieldPrinter;
 import org.zstack.utils.logging.CLogger;
 
+import static org.zstack.header.network.l2.L2NetworkType.L2NetworkTypeBuilder;
+
 public class L2NoVlanL2NetworkFactory implements L2NetworkFactory, Component, L2NetworkDefaultMtu, L2NetworkGetVniExtensionPoint {
-    private static L2NetworkType type = new L2NetworkType(L2NetworkConstant.L2_NO_VLAN_NETWORK_TYPE, true, true);
+    private static L2NetworkType type = new L2NetworkTypeBuilder()
+            .typeName(L2NetworkConstant.L2_NO_VLAN_NETWORK_TYPE)
+            .sriovSupported(true)
+            .build();
     private static CLogger logger = Utils.getLogger(L2NoVlanL2NetworkFactory.class);
     private static FieldPrinter printer = Utils.getFieldPrinter();
     

--- a/network/src/main/java/org/zstack/network/l2/L2NoVlanNetwork.java
+++ b/network/src/main/java/org/zstack/network/l2/L2NoVlanNetwork.java
@@ -53,6 +53,7 @@ import static org.zstack.core.Platform.*;
 @Configurable(preConstruction = true, autowire = Autowire.BY_TYPE)
 public class L2NoVlanNetwork implements L2Network {
     private static final CLogger logger = Utils.getLogger(L2NoVlanNetwork.class);
+    private static final L2NetworkHostHelper l2NetworkHostHelper = new L2NetworkHostHelper();
 
     @Autowired
     protected L2NetworkExtensionPointEmitter extpEmitter;
@@ -303,6 +304,12 @@ public class L2NoVlanNetwork implements L2Network {
                 .eq(L2NetworkClusterRefVO_.clusterUuid, msg.getClusterUuid())
                 .eq(L2NetworkClusterRefVO_.l2NetworkUuid, msg.getL2NetworkUuid())
                 .delete();
+
+        if (!L2NetworkType.valueOf(self.getType()).isAttachToAllHosts()) {
+            List<String> hostUuids = Q.New(HostVO.class).select(HostVO_.uuid)
+                    .eq(HostVO_.clusterUuid, msg.getClusterUuid()).listValues();
+            L2NetworkHostUtils.deleteL2NetworkHostRef(msg.getL2NetworkUuid(), hostUuids);
+        }
     }
 
     private void handle(DetachL2NetworkFromClusterMsg msg) {
@@ -364,13 +371,15 @@ public class L2NoVlanNetwork implements L2Network {
     }
 
     protected void afterDetachL2NetworkFromHost(final DetachL2NetworkFromHostMsg msg) {
+        if (!L2NetworkType.valueOf(self.getType()).isAttachToAllHosts()) {
+            L2NetworkHostUtils.deleteL2NetworkHostRef(msg.getL2NetworkUuid(), msg.getHostUuid());
+        }
     }
 
     private void handle(DetachL2NetworkFromHostMsg msg) {
         DetachL2NetworkFromHostReply reply = new DetachL2NetworkFromHostReply();
 
         if (!L2NetworkGlobalConfig.DeleteL2BridgePhysically.value(Boolean.class)) {
-            L2NetworkHostUtils.changeL2NetworkToHostRefDetached(msg.getL2NetworkUuid(), msg.getHostUuid());
             afterDetachL2NetworkFromHost(msg);
             bus.reply(msg, reply);
         } else {
@@ -900,10 +909,24 @@ public class L2NoVlanNetwork implements L2Network {
         return HostInventory.valueOf(hosts);
     }
 
+    protected String makeBridgeName() {
+        return null;
+    }
+
     protected void beforeAttachL2NetworkToCluster(final AttachL2NetworkToClusterMsg msg, final List<HostInventory> hosts) {
+        if (!L2NetworkType.valueOf(self.getType()).isAttachToAllHosts()) {
+            List<String> attachableHosts = hosts.stream().map(HostInventory::getUuid).collect(Collectors.toList());
+            l2NetworkHostHelper.initL2NetworkHostRef(msg.getL2NetworkUuid(), attachableHosts,
+                    msg.getL2ProviderType(), makeBridgeName());
+        }
     }
 
     protected void afterAttachL2NetworkToClusterFailed(final AttachL2NetworkToClusterMsg msg) {
+        if (!L2NetworkType.valueOf(self.getType()).isAttachToAllHosts()) {
+            List<String> hostUuids = Q.New(HostVO.class).select(HostVO_.uuid)
+                    .eq(HostVO_.clusterUuid, msg.getClusterUuid()).listValues();
+            L2NetworkHostUtils.deleteL2NetworkHostRef(msg.getL2NetworkUuid(), hostUuids);
+        }
     }
 
     @SuppressWarnings("unchecked")
@@ -1008,9 +1031,16 @@ public class L2NoVlanNetwork implements L2Network {
     }
 
     protected void beforeAttachL2NetworkToHost(final AttachL2NetworkToHostMsg msg) {
+        if (!L2NetworkType.valueOf(self.getType()).isAttachToAllHosts()) {
+            l2NetworkHostHelper.initL2NetworkHostRef(msg.getL2NetworkUuid(), msg.getHostUuid(),
+                    msg.getL2ProviderType(), makeBridgeName());
+        }
     }
 
     protected void afterAttachL2NetworkToHostFailed(final AttachL2NetworkToHostMsg msg) {
+        if (!L2NetworkType.valueOf(self.getType()).isAttachToAllHosts()) {
+            L2NetworkHostUtils.deleteL2NetworkHostRef(msg.getL2NetworkUuid(), msg.getHostUuid());
+        }
     }
 
     private void attachL2NetworkToHost(final AttachL2NetworkToHostMsg msg, final Completion completion) {

--- a/network/src/main/java/org/zstack/network/l2/L2VlanNetworkFactory.java
+++ b/network/src/main/java/org/zstack/network/l2/L2VlanNetworkFactory.java
@@ -6,12 +6,10 @@ import org.zstack.core.cloudbus.MessageSafe;
 import org.zstack.core.db.DatabaseFacade;
 import org.zstack.core.db.Q;
 import org.zstack.header.AbstractService;
-import org.zstack.header.core.Completion;
 import org.zstack.header.core.ReturnValueCompletion;
 import org.zstack.header.message.APIMessage;
 import org.zstack.header.message.Message;
 import org.zstack.header.network.l2.*;
-import org.zstack.network.service.MtuGetter;
 import org.zstack.network.service.NetworkServiceGlobalConfig;
 import org.zstack.query.QueryFacade;
 import org.zstack.resourceconfig.ResourceConfigFacade;
@@ -19,12 +17,15 @@ import org.zstack.utils.Utils;
 import org.zstack.utils.gson.JSONObjectUtil;
 import org.zstack.utils.logging.CLogger;
 
-import java.util.List;
+import static org.zstack.header.network.l2.L2NetworkType.L2NetworkTypeBuilder;
 
 public class L2VlanNetworkFactory extends AbstractService implements L2NetworkFactory, L2NetworkDefaultMtu, L2NetworkGetVniExtensionPoint {
     private static CLogger logger = Utils.getLogger(L2VlanNetworkFactory.class);
-    static L2NetworkType type = new L2NetworkType(L2NetworkConstant.L2_VLAN_NETWORK_TYPE, true, true);
-    
+    static L2NetworkType type = new L2NetworkTypeBuilder()
+            .typeName(L2NetworkConstant.L2_VLAN_NETWORK_TYPE)
+            .sriovSupported(true)
+            .build();
+
     @Autowired
     private DatabaseFacade dbf;
     @Autowired

--- a/plugin/hostNetworkInterface/src/main/java/org/zstack/network/hostNetworkInterface/HostKernelInterfaceTO.java
+++ b/plugin/hostNetworkInterface/src/main/java/org/zstack/network/hostNetworkInterface/HostKernelInterfaceTO.java
@@ -10,6 +10,7 @@ import org.zstack.header.network.l3.UsedIpTO;
 public class HostKernelInterfaceTO {
     private String interfaceName;
     private int vlanId;
+    private String bridgeName;
     private List<UsedIpTO> ips;
 
     public HostKernelInterfaceTO() {
@@ -30,6 +31,14 @@ public class HostKernelInterfaceTO {
 
     public void setVlanId(int vlanId) {
         this.vlanId = vlanId;
+    }
+
+    public String getBridgeName() {
+        return bridgeName;
+    }
+
+    public void setBridgeName(String bridgeName) {
+        this.bridgeName = bridgeName;
     }
 
     public List<UsedIpTO> getIps() {

--- a/sdk/src/main/java/SourceClassMap.java
+++ b/sdk/src/main/java/SourceClassMap.java
@@ -243,7 +243,6 @@ public class SourceClassMap {
 			put("org.zstack.header.longjob.LongJobInventory", "org.zstack.sdk.LongJobInventory");
 			put("org.zstack.header.longjob.LongJobState", "org.zstack.sdk.LongJobState");
 			put("org.zstack.header.managementnode.ManagementNodeInventory", "org.zstack.sdk.ManagementNodeInventory");
-			put("org.zstack.header.network.l2.L2NetworkAttachStatus", "org.zstack.sdk.L2NetworkAttachStatus");
 			put("org.zstack.header.network.l2.L2NetworkData", "org.zstack.sdk.L2NetworkData");
 			put("org.zstack.header.network.l2.L2NetworkHostRefInventory", "org.zstack.sdk.L2NetworkHostRefInventory");
 			put("org.zstack.header.network.l2.L2NetworkInventory", "org.zstack.sdk.L2NetworkInventory");
@@ -961,7 +960,6 @@ public class SourceClassMap {
 			put("org.zstack.sdk.KVMIsoTO", "org.zstack.kvm.KVMIsoTO");
 			put("org.zstack.sdk.KvmHostHypervisorMetadataInventory", "org.zstack.kvm.hypervisor.datatype.KvmHostHypervisorMetadataInventory");
 			put("org.zstack.sdk.KvmHypervisorInfoInventory", "org.zstack.kvm.hypervisor.datatype.KvmHypervisorInfoInventory");
-			put("org.zstack.sdk.L2NetworkAttachStatus", "org.zstack.header.network.l2.L2NetworkAttachStatus");
 			put("org.zstack.sdk.L2NetworkData", "org.zstack.header.network.l2.L2NetworkData");
 			put("org.zstack.sdk.L2NetworkHostRefInventory", "org.zstack.header.network.l2.L2NetworkHostRefInventory");
 			put("org.zstack.sdk.L2NetworkInventory", "org.zstack.header.network.l2.L2NetworkInventory");

--- a/sdk/src/main/java/org/zstack/sdk/L2NetworkAttachStatus.java
+++ b/sdk/src/main/java/org/zstack/sdk/L2NetworkAttachStatus.java
@@ -1,6 +1,0 @@
-package org.zstack.sdk;
-
-public enum L2NetworkAttachStatus {
-	Detached,
-	Attached,
-}

--- a/sdk/src/main/java/org/zstack/sdk/L2NetworkHostRefInventory.java
+++ b/sdk/src/main/java/org/zstack/sdk/L2NetworkHostRefInventory.java
@@ -1,6 +1,6 @@
 package org.zstack.sdk;
 
-import org.zstack.sdk.L2NetworkAttachStatus;
+
 
 public class L2NetworkHostRefInventory  {
 
@@ -28,12 +28,12 @@ public class L2NetworkHostRefInventory  {
         return this.l2ProviderType;
     }
 
-    public L2NetworkAttachStatus attachStatus;
-    public void setAttachStatus(L2NetworkAttachStatus attachStatus) {
-        this.attachStatus = attachStatus;
+    public java.lang.String bridgeName;
+    public void setBridgeName(java.lang.String bridgeName) {
+        this.bridgeName = bridgeName;
     }
-    public L2NetworkAttachStatus getAttachStatus() {
-        return this.attachStatus;
+    public java.lang.String getBridgeName() {
+        return this.bridgeName;
     }
 
     public java.sql.Timestamp createDate;

--- a/sdk/src/main/java/org/zstack/sdk/UplinkGroupInventory.java
+++ b/sdk/src/main/java/org/zstack/sdk/UplinkGroupInventory.java
@@ -2,15 +2,7 @@ package org.zstack.sdk;
 
 import org.zstack.sdk.UplinkGroupType;
 
-public class UplinkGroupInventory  {
-
-    public long id;
-    public void setId(long id) {
-        this.id = id;
-    }
-    public long getId() {
-        return this.id;
-    }
+public class UplinkGroupInventory extends org.zstack.sdk.L2NetworkHostRefInventory {
 
     public java.lang.String interfaceName;
     public void setInterfaceName(java.lang.String interfaceName) {
@@ -18,22 +10,6 @@ public class UplinkGroupInventory  {
     }
     public java.lang.String getInterfaceName() {
         return this.interfaceName;
-    }
-
-    public java.lang.String vSwitchUuid;
-    public void setVSwitchUuid(java.lang.String vSwitchUuid) {
-        this.vSwitchUuid = vSwitchUuid;
-    }
-    public java.lang.String getVSwitchUuid() {
-        return this.vSwitchUuid;
-    }
-
-    public java.lang.String hostUuid;
-    public void setHostUuid(java.lang.String hostUuid) {
-        this.hostUuid = hostUuid;
-    }
-    public java.lang.String getHostUuid() {
-        return this.hostUuid;
     }
 
     public UplinkGroupType type;
@@ -58,22 +34,6 @@ public class UplinkGroupInventory  {
     }
     public java.lang.String getInterfaceUuid() {
         return this.interfaceUuid;
-    }
-
-    public java.sql.Timestamp createDate;
-    public void setCreateDate(java.sql.Timestamp createDate) {
-        this.createDate = createDate;
-    }
-    public java.sql.Timestamp getCreateDate() {
-        return this.createDate;
-    }
-
-    public java.sql.Timestamp lastOpDate;
-    public void setLastOpDate(java.sql.Timestamp lastOpDate) {
-        this.lastOpDate = lastOpDate;
-    }
-    public java.sql.Timestamp getLastOpDate() {
-        return this.lastOpDate;
     }
 
 }


### PR DESCRIPTION
1. add bridgeName field to L2NetworkHostRefVO to support different
bridges when realizing l2 on different hosts;
2. remove the attachStatus field from L2NetworkHostRefVO and keep the
logic consistent with UplinkGroupVO;

DBImpact

Resolves: ZSV-6396

Change-Id: I637a746b7876616a69796f667476776575786b72

sync from gitlab !6624