### PR TITLE
<fix>[migration]: fix offline migration trash incorrect

### DIFF
--- a/compute/src/main/java/org/zstack/compute/vm/VmAfterInstantiateVolumeInAttachingVolumeFlow.java
+++ b/compute/src/main/java/org/zstack/compute/vm/VmAfterInstantiateVolumeInAttachingVolumeFlow.java
@@ -34,7 +34,7 @@ import static org.zstack.core.Platform.err;
 
 @Configurable(preConstruction = true, autowire = Autowire.BY_TYPE)
 public class VmAfterInstantiateVolumeInAttachingVolumeFlow implements Flow {
-    CLogger logger = Utils.getLogger(VmAfterInstantiateVolumeInAttachingVolumeFlow.class);
+    private static final CLogger logger = Utils.getLogger(VmAfterInstantiateVolumeInAttachingVolumeFlow.class);
     @Autowired
     private DatabaseFacade dbf;
     @Autowired

--- a/compute/src/main/java/org/zstack/compute/vm/VmAllocatePrimaryStorageForAttachingDiskFlow.java
+++ b/compute/src/main/java/org/zstack/compute/vm/VmAllocatePrimaryStorageForAttachingDiskFlow.java
@@ -38,7 +38,7 @@ public class VmAllocatePrimaryStorageForAttachingDiskFlow implements Flow {
     @Autowired
     protected ErrorFacade errf;
 
-    private String allocatedInstallUrl;
+    private final String ALLOCATED_INSTALL_URL = "allocated_install_url";
 
     @Override
     public void run(final FlowTrigger chain, final Map data) {
@@ -91,9 +91,9 @@ public class VmAllocatePrimaryStorageForAttachingDiskFlow implements Flow {
             public void run(MessageReply reply) {
                 if (reply.isSuccess()) {
                     AllocatePrimaryStorageSpaceReply ar = (AllocatePrimaryStorageSpaceReply) reply;
-                    allocatedInstallUrl = ar.getAllocatedInstallUrl();
+                    data.put(ALLOCATED_INSTALL_URL, ar.getAllocatedInstallUrl());
                     data.put(VmInstanceConstant.Params.DestPrimaryStorageInventoryForAttachingVolume.toString(), ar.getPrimaryStorageInventory());
-                    data.put(VmInstanceConstant.Params.AllocatedUrlForAttachingVolume.toString(), allocatedInstallUrl);
+                    data.put(VmInstanceConstant.Params.AllocatedUrlForAttachingVolume.toString(), ar.getAllocatedInstallUrl());
                     data.put(VmAllocatePrimaryStorageForAttachingDiskFlow.class, ar.getSize());
                     chain.next();
                 } else {
@@ -109,7 +109,7 @@ public class VmAllocatePrimaryStorageForAttachingDiskFlow implements Flow {
         if (size != null) {
             PrimaryStorageInventory pri = (PrimaryStorageInventory) data.get(VmInstanceConstant.Params.DestPrimaryStorageInventoryForAttachingVolume.toString());
             ReleasePrimaryStorageSpaceMsg rmsg = new ReleasePrimaryStorageSpaceMsg();
-            rmsg.setAllocatedInstallUrl(allocatedInstallUrl);
+            rmsg.setAllocatedInstallUrl((String)data.get(ALLOCATED_INSTALL_URL));
             rmsg.setPrimaryStorageUuid(pri.getUuid());
             rmsg.setDiskSize(size);
             bus.makeTargetServiceIdByResourceUuid(rmsg, PrimaryStorageConstant.SERVICE_ID, pri.getUuid());

--- a/compute/src/main/java/org/zstack/compute/vm/VmAssignDeviceIdToAttachingVolumeFlow.java
+++ b/compute/src/main/java/org/zstack/compute/vm/VmAssignDeviceIdToAttachingVolumeFlow.java
@@ -31,7 +31,7 @@ import java.util.Map;
 
 @Configurable(preConstruction = true, autowire = Autowire.BY_TYPE)
 public class VmAssignDeviceIdToAttachingVolumeFlow implements Flow {
-    CLogger logger = Utils.getLogger(VmAssignDeviceIdToAttachingVolumeFlow.class);
+    private static final CLogger logger = Utils.getLogger(VmAssignDeviceIdToAttachingVolumeFlow.class);
     @Autowired
     private DatabaseFacade dbf;
     @Autowired

--- a/compute/src/main/java/org/zstack/compute/vm/VmCreateOnHypervisorFlow.java
+++ b/compute/src/main/java/org/zstack/compute/vm/VmCreateOnHypervisorFlow.java
@@ -33,11 +33,7 @@ public class VmCreateOnHypervisorFlow implements Flow {
     @Autowired
     private EventFacade evtf;
 
-    private List<VmBeforeCreateOnHypervisorExtensionPoint> exts;
-
-    public VmCreateOnHypervisorFlow() {
-        exts = pluginRgty.getExtensionList(VmBeforeCreateOnHypervisorExtensionPoint.class);
-    }
+    private final List<VmBeforeCreateOnHypervisorExtensionPoint> exts = pluginRgty.getExtensionList(VmBeforeCreateOnHypervisorExtensionPoint.class);
 
     private void fireExtensions(VmInstanceSpec spec) {
         for (VmBeforeCreateOnHypervisorExtensionPoint ext : exts) {

--- a/compute/src/main/java/org/zstack/compute/vm/VmInstantiateResourceForChangeImageFlow.java
+++ b/compute/src/main/java/org/zstack/compute/vm/VmInstantiateResourceForChangeImageFlow.java
@@ -25,14 +25,9 @@ public class VmInstantiateResourceForChangeImageFlow implements Flow {
     @Autowired
     private PluginRegistry pluginRgty;
 
-    private static List<ChangeVmImageExtensionPoint> extensions = null;
+    private final List<ChangeVmImageExtensionPoint> extensions = pluginRgty.getExtensionList(ChangeVmImageExtensionPoint.class);
 
-    public VmInstantiateResourceForChangeImageFlow() {
-        if (extensions == null) {
-            extensions = pluginRgty.getExtensionList(ChangeVmImageExtensionPoint.class);
-        }
-    }
-    
+
     private void runExtensions(final Iterator<ChangeVmImageExtensionPoint> it, final VmInstanceSpec spec, final FlowTrigger chain) {
         if (!it.hasNext()) {
             chain.next();

--- a/compute/src/main/java/org/zstack/compute/vm/VmInstantiateResourcePostFlow.java
+++ b/compute/src/main/java/org/zstack/compute/vm/VmInstantiateResourcePostFlow.java
@@ -28,13 +28,8 @@ public class VmInstantiateResourcePostFlow implements Flow {
     @Autowired
     private PluginRegistry pluginRgty;
 
-    private static List<PostVmInstantiateResourceExtensionPoint> extensions;
+    private final List<PostVmInstantiateResourceExtensionPoint> extensions = pluginRgty.getExtensionList(PostVmInstantiateResourceExtensionPoint.class);
 
-    public VmInstantiateResourcePostFlow() {
-        if (extensions == null) {
-            extensions = pluginRgty.getExtensionList(PostVmInstantiateResourceExtensionPoint.class);
-        }
-    }
 
     public void run(FlowTrigger trigger, Map data) {
         VmInstanceSpec spec = (VmInstanceSpec) data.get(VmInstanceConstant.Params.VmInstanceSpec.toString());

--- a/compute/src/main/java/org/zstack/compute/vm/VmInstantiateResourcePreFlow.java
+++ b/compute/src/main/java/org/zstack/compute/vm/VmInstantiateResourcePreFlow.java
@@ -29,14 +29,9 @@ public class VmInstantiateResourcePreFlow implements Flow {
     @Autowired
     private PluginRegistry pluginRgty;
 
-    private static List<PreVmInstantiateResourceExtensionPoint> extensions = null;
+    private final List<PreVmInstantiateResourceExtensionPoint> extensions = pluginRgty.getExtensionList(PreVmInstantiateResourceExtensionPoint.class);
     
-    public VmInstantiateResourcePreFlow() {
-        if (extensions == null) {
-            extensions = pluginRgty.getExtensionList(PreVmInstantiateResourceExtensionPoint.class);
-        }
-    }
-    
+
     private void runExtensions(final Iterator<PreVmInstantiateResourceExtensionPoint> it, final VmInstanceSpec spec, final FlowTrigger chain) {
         if (!it.hasNext()) {
             spec.setInstantiateResourcesSuccess(true);

--- a/compute/src/main/java/org/zstack/compute/vm/VmReleaseResourceFlow.java
+++ b/compute/src/main/java/org/zstack/compute/vm/VmReleaseResourceFlow.java
@@ -27,13 +27,7 @@ public class VmReleaseResourceFlow implements Flow {
     @Autowired
     private PluginRegistry pluginRgty;
     
-    private static List<VmReleaseResourceExtensionPoint> extensions = null;
-
-    public VmReleaseResourceFlow() {
-        if (extensions == null) {
-            extensions = pluginRgty.getExtensionList(VmReleaseResourceExtensionPoint.class);
-        }
-    }
+    private final List<VmReleaseResourceExtensionPoint> extensions = pluginRgty.getExtensionList(VmReleaseResourceExtensionPoint.class);
 
 
     private void fireExtensions(final Iterator<VmReleaseResourceExtensionPoint> it, final VmInstanceSpec spec, final Map<String, Object> ctx, final FlowTrigger chain) {

--- a/compute/src/main/java/org/zstack/compute/vm/VmStartOnHypervisorFlow.java
+++ b/compute/src/main/java/org/zstack/compute/vm/VmStartOnHypervisorFlow.java
@@ -19,18 +19,14 @@ import java.util.List;
 import java.util.Map;
 @Configurable(preConstruction = true, autowire = Autowire.BY_TYPE)
 public class VmStartOnHypervisorFlow implements Flow {
-    private static CLogger logger = Utils.getLogger(VmStartOnHypervisorFlow.class);
+    private static final CLogger logger = Utils.getLogger(VmStartOnHypervisorFlow.class);
 
     @Autowired
     private CloudBus bus;
     @Autowired
     private PluginRegistry pluginRgty;
 
-    private List<VmBeforeStartOnHypervisorExtensionPoint> exts;
-
-    public VmStartOnHypervisorFlow() {
-        exts = pluginRgty.getExtensionList(VmBeforeStartOnHypervisorExtensionPoint.class);
-    }
+    private final List<VmBeforeStartOnHypervisorExtensionPoint> exts = pluginRgty.getExtensionList(VmBeforeStartOnHypervisorExtensionPoint.class);;
 
     private void fireExtensions(VmInstanceSpec spec) {
         for (VmBeforeStartOnHypervisorExtensionPoint ext : exts) {

--- a/plugin/virtualRouterProvider/src/main/java/org/zstack/network/service/virtualrouter/eip/VirtualRouterSyncEipOnStartFlow.java
+++ b/plugin/virtualRouterProvider/src/main/java/org/zstack/network/service/virtualrouter/eip/VirtualRouterSyncEipOnStartFlow.java
@@ -46,7 +46,7 @@ import static org.zstack.core.Platform.operr;
  */
 @Configurable(preConstruction = true, autowire = Autowire.BY_TYPE)
 public class VirtualRouterSyncEipOnStartFlow implements Flow {
-    private static CLogger logger = Utils.getLogger(VirtualRouterSyncEipOnStartFlow.class);
+    private static final CLogger logger = Utils.getLogger(VirtualRouterSyncEipOnStartFlow.class);
 
     @Autowired
     private DatabaseFacade dbf;

--- a/plugin/virtualRouterProvider/src/main/java/org/zstack/network/service/virtualrouter/ha/VirtualRouterCleanupHaOnDestroyFlow.java
+++ b/plugin/virtualRouterProvider/src/main/java/org/zstack/network/service/virtualrouter/ha/VirtualRouterCleanupHaOnDestroyFlow.java
@@ -31,7 +31,7 @@ public class VirtualRouterCleanupHaOnDestroyFlow extends NoRollbackFlow {
     @Autowired
     protected VirtualRouterHaBackend haBackend;
 
-    private static CLogger logger = Utils.getLogger(VirtualRouterCleanupHaOnDestroyFlow.class);
+    private static final CLogger logger = Utils.getLogger(VirtualRouterCleanupHaOnDestroyFlow.class);
 
     @Override
     public void run(final FlowTrigger trigger, Map data) {

--- a/plugin/virtualRouterProvider/src/main/java/org/zstack/network/service/virtualrouter/lb/VirtualRouterCleanupLoadBalancerOnDestroyFlow.java
+++ b/plugin/virtualRouterProvider/src/main/java/org/zstack/network/service/virtualrouter/lb/VirtualRouterCleanupLoadBalancerOnDestroyFlow.java
@@ -20,7 +20,7 @@ import java.util.Map;
 public class VirtualRouterCleanupLoadBalancerOnDestroyFlow extends NoRollbackFlow {
     @Autowired
     private DatabaseFacade dbf;
-    private static CLogger logger = Utils.getLogger(VirtualRouterCleanupLoadBalancerOnDestroyFlow.class);
+    private static final CLogger logger = Utils.getLogger(VirtualRouterCleanupLoadBalancerOnDestroyFlow.class);
 
     @Override
     public void run(FlowTrigger trigger, Map data) {

--- a/plugin/virtualRouterProvider/src/main/java/org/zstack/network/service/virtualrouter/lifecycle/VirtualRouterDeployAgentFlow.java
+++ b/plugin/virtualRouterProvider/src/main/java/org/zstack/network/service/virtualrouter/lifecycle/VirtualRouterDeployAgentFlow.java
@@ -51,7 +51,7 @@ public class VirtualRouterDeployAgentFlow extends NoRollbackFlow {
     @Autowired
     private ErrorFacade errf;
 
-    private String agentPackageName = VirtualRouterGlobalProperty.AGENT_PACKAGE_NAME;
+    private final String agentPackageName = VirtualRouterGlobalProperty.AGENT_PACKAGE_NAME;
 
 	private void continueConnect(final VmNicInventory mgmtNic, final Map<String, Object> data, final FlowTrigger completion) {
         final VirtualRouterVmInventory vr = (VirtualRouterVmInventory) data.get(VirtualRouterConstant.Param.VR.toString());

--- a/plugin/virtualRouterProvider/src/main/java/org/zstack/network/service/virtualrouter/portforwarding/VirtualRouterSyncPortForwardingRulesOnStartFlow.java
+++ b/plugin/virtualRouterProvider/src/main/java/org/zstack/network/service/virtualrouter/portforwarding/VirtualRouterSyncPortForwardingRulesOnStartFlow.java
@@ -34,7 +34,7 @@ import java.util.stream.Collectors;
 
 @Configurable(preConstruction = true, autowire = Autowire.BY_TYPE)
 public class VirtualRouterSyncPortForwardingRulesOnStartFlow implements Flow {
-    private static CLogger logger = Utils.getLogger(VirtualRouterSyncPortForwardingRulesOnStartFlow.class);
+    private static final CLogger logger = Utils.getLogger(VirtualRouterSyncPortForwardingRulesOnStartFlow.class);
     
     @Autowired
     private DatabaseFacade dbf;

--- a/plugin/virtualRouterProvider/src/main/java/org/zstack/network/service/virtualrouter/vip/VirtualRouterCleanupVipOnDestroyFlow.java
+++ b/plugin/virtualRouterProvider/src/main/java/org/zstack/network/service/virtualrouter/vip/VirtualRouterCleanupVipOnDestroyFlow.java
@@ -33,7 +33,7 @@ public class VirtualRouterCleanupVipOnDestroyFlow extends NoRollbackFlow {
     @Autowired
     protected VipConfigProxy vipConfigProxy;
 
-    private static CLogger logger = Utils.getLogger(VirtualRouterCleanupVipOnDestroyFlow.class);
+    private static final CLogger logger = Utils.getLogger(VirtualRouterCleanupVipOnDestroyFlow.class);
 
     @Override
     public void run(final FlowTrigger trigger, Map data) {

--- a/storage/src/main/java/org/zstack/storage/primary/PrimaryStorageMainAllocatorFlow.java
+++ b/storage/src/main/java/org/zstack/storage/primary/PrimaryStorageMainAllocatorFlow.java
@@ -32,7 +32,7 @@ import static org.zstack.utils.CollectionUtils.distinctByKey;
  */
 @Configurable(preConstruction = true, autowire = Autowire.BY_TYPE)
 public class PrimaryStorageMainAllocatorFlow extends NoRollbackFlow {
-    private static CLogger logger = Utils.getLogger(PrimaryStorageMainAllocatorFlow.class);
+    private static final CLogger logger = Utils.getLogger(PrimaryStorageMainAllocatorFlow.class);
 
     @Autowired
     protected DatabaseFacade dbf;

--- a/storage/src/main/java/org/zstack/storage/primary/PrimaryStorageSortByAvailablePhysicalCapacityFlow.java
+++ b/storage/src/main/java/org/zstack/storage/primary/PrimaryStorageSortByAvailablePhysicalCapacityFlow.java
@@ -22,7 +22,7 @@ import java.util.stream.Collectors;
 
 @Configurable(preConstruction = true, autowire = Autowire.BY_TYPE)
 public class PrimaryStorageSortByAvailablePhysicalCapacityFlow extends NoRollbackFlow {
-    private static CLogger logger = Utils.getLogger(PrimaryStorageSortByAvailablePhysicalCapacityFlow.class);
+    private static final CLogger logger = Utils.getLogger(PrimaryStorageSortByAvailablePhysicalCapacityFlow.class);
 
 
     @Override

--- a/storage/src/main/java/org/zstack/storage/primary/PrimaryStorageSortFlow.java
+++ b/storage/src/main/java/org/zstack/storage/primary/PrimaryStorageSortFlow.java
@@ -23,7 +23,7 @@ import java.util.stream.Collectors;
 
 @Configurable(preConstruction = true, autowire = Autowire.BY_TYPE)
 public class PrimaryStorageSortFlow extends NoRollbackFlow {
-    private static CLogger logger = Utils.getLogger(PrimaryStorageSortFlow.class);
+    private static final CLogger logger = Utils.getLogger(PrimaryStorageSortFlow.class);
 
     @Autowired
     protected PrimaryStoragePriorityGetter priorityGetter;

--- a/storage/src/main/java/org/zstack/storage/primary/PrimaryStorageTagAllocatorFlow.java
+++ b/storage/src/main/java/org/zstack/storage/primary/PrimaryStorageTagAllocatorFlow.java
@@ -38,13 +38,8 @@ public class PrimaryStorageTagAllocatorFlow extends NoRollbackFlow {
     @Autowired
     private PluginRegistry pluginRgty;
 
-    protected static List<PrimaryStorageTagAllocatorExtensionPoint> tagExtensions;
+    protected final List<PrimaryStorageTagAllocatorExtensionPoint> tagExtensions = pluginRgty.getExtensionList(PrimaryStorageTagAllocatorExtensionPoint.class);;
 
-    public PrimaryStorageTagAllocatorFlow() {
-        if (tagExtensions == null) {
-            tagExtensions = pluginRgty.getExtensionList(PrimaryStorageTagAllocatorExtensionPoint.class);
-        }
-    }
 
     @Override
     public void run(FlowTrigger trigger, Map data) {


### PR DESCRIPTION
1、fix trash incorrect caused by concurrent volume migration
2、Removed some classes from using global variables

Resolves/Related: ZSTAC-67719

Change-Id: I9ioz6f687468706d74787267616279626999909b

sync from gitlab !6648