### PR TITLE
<fix>[volume]: support enableing extended l2 entries of qcow2

### DIFF
--- a/plugin/kvm/src/main/java/org/zstack/kvm/KVMAgentCommands.java
+++ b/plugin/kvm/src/main/java/org/zstack/kvm/KVMAgentCommands.java
@@ -3614,7 +3614,7 @@ public class KVMAgentCommands {
         }
     }
 
-    public static class TakeSnapshotCmd extends AgentCommand implements HasThreadContext {
+    public static class TakeSnapshotCmd extends PrimaryStorageCommand implements HasThreadContext {
         private String vmUuid;
         private String volumeUuid;
         private VolumeTO volume;

--- a/plugin/kvm/src/main/java/org/zstack/kvm/KVMHost.java
+++ b/plugin/kvm/src/main/java/org/zstack/kvm/KVMHost.java
@@ -2670,6 +2670,7 @@ public class KVMHost extends HostBase implements Host {
         cmd.setVolumeUuid(msg.getVolume().getUuid());
         cmd.setTimeout(timeoutManager.getTimeout());
         cmd.setVolume(VolumeTO.valueOf(msg.getVolume(), (KVMHostInventory) getSelfInventory()));
+        cmd.primaryStorageUuid = msg.getVolume().getPrimaryStorageUuid();
         completeTakeSnapshotCmd(msg, cmd);
 
         FlowChain chain = FlowChainBuilder.newSimpleFlowChain();


### PR DESCRIPTION
support enableing/disabling extended l2 entries of qcow2 for better performance

Resolves: ZSTAC-61808

Change-Id: I7a6269647878647363636669666b6e716c657169

sync from gitlab !6724