### PR TITLE
<fix>[mevoco]: check capacity before snapshot revert

### DIFF
--- a/plugin/ceph/src/main/java/org/zstack/storage/ceph/primary/CephPrimaryStorageBase.java
+++ b/plugin/ceph/src/main/java/org/zstack/storage/ceph/primary/CephPrimaryStorageBase.java
@@ -119,6 +119,8 @@ public class CephPrimaryStorageBase extends PrimaryStorageBase {
     private StorageTrash trash;
     @Autowired
     private PoolUsageReport poolUsageCollector;
+    @Autowired
+    protected PrimaryStoragePhysicalCapacityManager psPhysicalCapacityMgr;
 
 
     public CephPrimaryStorageBase() {
@@ -816,6 +818,7 @@ public class CephPrimaryStorageBase extends PrimaryStorageBase {
 
     public static class RollbackSnapshotCmd extends AgentCommand implements HasThreadContext {
         String snapshotPath;
+        double capacityThreshold;
 
         public String getSnapshotPath() {
             return snapshotPath;
@@ -823,6 +826,14 @@ public class CephPrimaryStorageBase extends PrimaryStorageBase {
 
         public void setSnapshotPath(String snapshotPath) {
             this.snapshotPath = snapshotPath;
+        }
+
+        public void setCapacityThreshold(double capacityThreshold) {
+            this.capacityThreshold = capacityThreshold;
+        }
+
+        public double getCapacityThreshold() {
+            return capacityThreshold;
         }
     }
 
@@ -5106,6 +5117,7 @@ public class CephPrimaryStorageBase extends PrimaryStorageBase {
 
                         RollbackSnapshotCmd cmd = new RollbackSnapshotCmd();
                         cmd.snapshotPath = msg.getSnapshot().getPrimaryStorageInstallPath();
+                        cmd.capacityThreshold = psPhysicalCapacityMgr.getRatio(getSelf().getUuid());
                         httpCall(ROLLBACK_SNAPSHOT_PATH, cmd, RollbackSnapshotRsp.class, new ReturnValueCompletion<RollbackSnapshotRsp>(msg) {
                             @Override
                             public void success(RollbackSnapshotRsp returnValue) {

--- a/testlib/src/main/java/org/zstack/testlib/CephPrimaryStorageSpec.groovy
+++ b/testlib/src/main/java/org/zstack/testlib/CephPrimaryStorageSpec.groovy
@@ -466,6 +466,8 @@ class CephPrimaryStorageSpec extends PrimaryStorageSpec {
             }
 
             simulator(CephPrimaryStorageBase.ROLLBACK_SNAPSHOT_PATH) { HttpEntity<String> e, EnvSpec spec ->
+                def cmd = JSONObjectUtil.toObject(e.body, CephPrimaryStorageBase.RollbackSnapshotCmd.class)
+                assert cmd.capacityThreshold > 0
                 return new CephPrimaryStorageBase.RollbackSnapshotRsp()
             }
 


### PR DESCRIPTION
use physical capacity threshold

Resolves: ZSTAC-65247

Change-Id: I77677475636770677168657977646f646c6c7364


(cherry picked from commit 2871c03bdcc42696fe05b788f0271e747f066ab5)

sync from gitlab !6840