### PR TITLE
<fix>[build]: template path support @

### DIFF
--- a/testlib/src/main/java/org/zstack/testlib/BeanConstructor.groovy
+++ b/testlib/src/main/java/org/zstack/testlib/BeanConstructor.groovy
@@ -58,7 +58,7 @@ class BeanConstructor {
     protected void generateSpringConfig() {
         try {
             //URL templatePath = this.getClass().getClassLoader().getResource("zstack-template.xml")
-            URL templatePath = this.getClass().getClassLoader().getResource("zstack-template.xml")
+            URI templatePath = this.getClass().getClassLoader().getResource("zstack-template.xml").toURI()
             File template = new File(templatePath.getPath())
             List<String> contents = template.readLines()
 


### PR DESCRIPTION
docker are used in kunpeng-native cicd environment, where
workspace path contains @, which is not supported by URL.

Resolves: ZHCI-2716

Change-Id: I6e7369796a73647a797573747367736c74646265

sync from gitlab !6859