### PR TITLE
<fix>[storage]: fix snapshot concurrence deletion

### DIFF
--- a/storage/src/main/java/org/zstack/storage/snapshot/group/VolumeSnapshotGroupBase.java
+++ b/storage/src/main/java/org/zstack/storage/snapshot/group/VolumeSnapshotGroupBase.java
@@ -212,7 +212,7 @@ public class VolumeSnapshotGroupBase implements VolumeSnapshotGroup {
             logger.debug(String.format("skip snapshots not belong to origin vm[uuid:%s]", self.getVmInstanceUuid()));
         }
 
-        new While<>(snapshots).all((snapshot, compl) -> {
+        new While<>(snapshots).each((snapshot, compl) -> {
             DeleteVolumeSnapshotMsg rmsg = new DeleteVolumeSnapshotMsg();
             rmsg.setSnapshotUuid(snapshot.getUuid());
             rmsg.setVolumeUuid(snapshot.getVolumeUuid());


### PR DESCRIPTION
concurrency deletion on qemu 6.2 may cause vm crash.

Resolves: ZSV-6621

Change-Id: I6574736577737173626b7263646c78716c766b76


(cherry picked from commit 5a4c34032bd320eba8b8a9b4b3d91c2217e32df4)

sync from gitlab !6862