### PR TITLE
<fix>[snapshot]: fixed the issue where too many snapshots caused the qmp...

### DIFF
--- a/conf/globalConfig/snapshot.xml
+++ b/conf/globalConfig/snapshot.xml
@@ -4,7 +4,7 @@
         <category>volumeSnapshot</category>
         <name>incrementalSnapshot.maxNum</name>
         <description>The length of a volume snapshot chain. When the lenght of a volume snapshot chain reaches this value, the next volume snapshot will be a full snapshot</description>
-        <defaultValue>128</defaultValue>
+        <defaultValue>64</defaultValue>
         <type>java.lang.Integer</type>
     </config>
 

--- a/storage/src/main/java/org/zstack/storage/snapshot/VolumeSnapshotGlobalConfig.java
+++ b/storage/src/main/java/org/zstack/storage/snapshot/VolumeSnapshotGlobalConfig.java
@@ -11,7 +11,7 @@ import org.zstack.core.config.GlobalConfigValidation;
 public class VolumeSnapshotGlobalConfig {
     public static final String CATEGORY = "volumeSnapshot";
 
-    @GlobalConfigValidation(numberGreaterThan = 0)
+    @GlobalConfigValidation(numberGreaterThan = 0, numberLessThan = 120)
     public static GlobalConfig MAX_INCREMENTAL_SNAPSHOT_NUM = new GlobalConfig(CATEGORY, "incrementalSnapshot.maxNum");
     @GlobalConfigValidation(numberGreaterThan = 0)
     public static GlobalConfig SNAPSHOT_DELETE_PARALLELISM_DEGREE = new GlobalConfig(CATEGORY, "delete.parallelismDegree");


### PR DESCRIPTION
<fix>[snapshot]: fixed the issue where too many snapshots caused the qmp 'query block' command to fail

when the maximum value of incremental snapshot exceeds 64, change it to 64.

Resolves/Related: ZSTAC-67846

Change-Id: I717a65746462647666626263717674796f627973

sync from gitlab !6866