### PR TITLE
<fix>[crypto]: Fix the failure to open certificate login

### DIFF
--- a/conf/db/upgrade/V4.4.64.1__schema.sql
+++ b/conf/db/upgrade/V4.4.64.1__schema.sql
@@ -26,3 +26,7 @@ ALTER TABLE `zstack`.`SanSecSecretResourcePoolVO` ADD COLUMN `username` varchar(
 ALTER TABLE `zstack`.`SanSecSecretResourcePoolVO` ADD COLUMN `password` varchar(128) DEFAULT NULL;
 ALTER TABLE `zstack`.`SanSecSecretResourcePoolVO` ADD COLUMN `sm3Key` varchar(128) DEFAULT NULL;
 ALTER TABLE `zstack`.`SanSecSecretResourcePoolVO` ADD COLUMN `sm4Key` varchar(128) DEFAULT NULL;
+
+ALTER TABLE `zstack`.`CCSCertificateVO` MODIFY COLUMN issuerDN varchar(255) NOT NULL;
+ALTER TABLE `zstack`.`CCSCertificateVO` MODIFY COLUMN subjectDN varchar(255) NOT NULL;
+ALTER TABLE `zstack`.`CCSCertificateVO` MODIFY COLUMN serNumber varchar(128) unsigned NOT NULL;


### PR DESCRIPTION
Increase the character length of the parameter in CCSCertificateVO to
prevent the parsed certificate from exceeding the character length set
by the database, resulting in failure to enable identity authentication

Resolves: ZSTAC-52999

Change-Id: I667652999b6e6c4885049366616964651012336c
(cherry picked from commit 9493c142147a246dc3ce46791926d88b9f73cbde)

sync from gitlab !6877