### PR TITLE
<fix>[config]: update globalConfigOptions number range

### DIFF
--- a/core/src/main/java/org/zstack/core/config/GlobalConfigFacadeImpl.java
+++ b/core/src/main/java/org/zstack/core/config/GlobalConfigFacadeImpl.java
@@ -745,6 +745,7 @@ public class GlobalConfigFacadeImpl extends AbstractService implements GlobalCon
                     }
                 }
 
+                boolean isInteger = Integer.class.getName().equals(config.getType());
                 config.installQueryExtension(new GlobalConfigQueryExtensionPoint() {
                     @Override
                     public GlobalConfigOptions getConfigOptions() {
@@ -753,18 +754,24 @@ public class GlobalConfigFacadeImpl extends AbstractService implements GlobalCon
                         if (at.validValues().length > 0) {
                             options.setValidValue(Arrays.asList(at.validValues()));
                         } else if (at.inNumberRange().length == 2){
-                            options.setNumberLessThan(at.inNumberRange()[1] + 1);
-                            options.setNumberGreaterThan(at.inNumberRange()[0] - 1);
+                            options.setNumberLessThanOrEqual(at.inNumberRange()[1]);
+                            options.setNumberGreaterThanOrEqual(at.inNumberRange()[0]);
                         } else if (at.numberLessThan() != Long.MAX_VALUE || at.numberGreaterThan() != Long.MIN_VALUE) {
-                            options.setNumberLessThan(Long.MAX_VALUE);
-                            options.setNumberGreaterThan(Long.MIN_VALUE);
+                            if (isInteger) {
+                                options.setNumberLessThanOrEqual((long) Integer.MAX_VALUE);
+                                options.setNumberGreaterThanOrEqual((long) Integer.MIN_VALUE);
+                            } else {
+                                options.setNumberLessThanOrEqual(Long.MAX_VALUE);
+                                options.setNumberGreaterThanOrEqual(Long.MIN_VALUE);
+                            }
                         }
 
                         if (at.numberLessThan() != Long.MAX_VALUE) {
-                            options.setNumberLessThan(at.numberLessThan());
+                            options.setNumberLessThanOrEqual(at.numberLessThan());
                         }
+
                         if (at.numberGreaterThan() != Long.MIN_VALUE) {
-                            options.setNumberGreaterThan(at.numberGreaterThan());
+                            options.setNumberGreaterThanOrEqual(at.numberGreaterThan());
                         }
 
                         return options;

--- a/core/src/main/java/org/zstack/core/config/GlobalConfigOptions.java
+++ b/core/src/main/java/org/zstack/core/config/GlobalConfigOptions.java
@@ -6,6 +6,8 @@ public class GlobalConfigOptions {
     private List<String> validValue;
     private Long numberGreaterThan;
     private Long numberLessThan;
+    private Long numberGreaterThanOrEqual;
+    private Long numberLessThanOrEqual;
 
     public List<String> getValidValue() {
         return validValue;
@@ -29,5 +31,21 @@ public class GlobalConfigOptions {
 
     public void setNumberLessThan(Long numberLessThan) {
         this.numberLessThan = numberLessThan;
+    }
+
+    public Long getNumberGreaterThanOrEqual() {
+        return numberGreaterThanOrEqual;
+    }
+
+    public void setNumberGreaterThanOrEqual(Long numberGreaterThanOrEqual) {
+        this.numberGreaterThanOrEqual = numberGreaterThanOrEqual;
+    }
+
+    public Long getNumberLessThanOrEqual() {
+        return numberLessThanOrEqual;
+    }
+
+    public void setNumberLessThanOrEqual(Long numberLessThanOrEqual) {
+        this.numberLessThanOrEqual = numberLessThanOrEqual;
     }
 }

--- a/core/src/main/java/org/zstack/core/config/GlobalConfigOptionsDoc_zh_cn.groovy
+++ b/core/src/main/java/org/zstack/core/config/GlobalConfigOptionsDoc_zh_cn.groovy
@@ -25,4 +25,16 @@ doc {
 		type "Long"
 		since "4.4.0"
 	}
+	field {
+		name "numberGreaterThanOrEqual"
+		desc "大于等于"
+		type "Long"
+		since "5.2.0"
+	}
+	field {
+		name "numberLessThanOrEqual"
+		desc "小于等于"
+		type "Long"
+		since "5.2.0"
+	}
 }

--- a/sdk/src/main/java/org/zstack/sdk/GlobalConfigOptions.java
+++ b/sdk/src/main/java/org/zstack/sdk/GlobalConfigOptions.java
@@ -28,4 +28,20 @@ public class GlobalConfigOptions  {
         return this.numberLessThan;
     }
 
+    public java.lang.Long numberGreaterThanOrEqual;
+    public void setNumberGreaterThanOrEqual(java.lang.Long numberGreaterThanOrEqual) {
+        this.numberGreaterThanOrEqual = numberGreaterThanOrEqual;
+    }
+    public java.lang.Long getNumberGreaterThanOrEqual() {
+        return this.numberGreaterThanOrEqual;
+    }
+
+    public java.lang.Long numberLessThanOrEqual;
+    public void setNumberLessThanOrEqual(java.lang.Long numberLessThanOrEqual) {
+        this.numberLessThanOrEqual = numberLessThanOrEqual;
+    }
+    public java.lang.Long getNumberLessThanOrEqual() {
+        return this.numberLessThanOrEqual;
+    }
+
 }

--- a/test/src/test/groovy/org/zstack/test/integration/core/config/GlobalConfigCase.groovy
+++ b/test/src/test/groovy/org/zstack/test/integration/core/config/GlobalConfigCase.groovy
@@ -92,9 +92,9 @@ class GlobalConfigCase extends SubCase {
             name = KVMGlobalConfig.VM_CREATE_CONCURRENCY.name
         } as GetGlobalConfigOptionsResult
 
-        // number range for this category is {1, 10}
-        assert configOptions.options.numberGreaterThan == 0
-        assert configOptions.options.numberLessThan == 11
+        // number range for this category is {1, 10},  1 <= value <= 10
+        assert configOptions.options.numberGreaterThanOrEqual == 1
+        assert configOptions.options.numberLessThanOrEqual == 10
     }
 
     void testGetNumberBoundary() {
@@ -103,9 +103,9 @@ class GlobalConfigCase extends SubCase {
             name = KVMGlobalConfig.HOST_SYNC_LEVEL.name
         } as GetGlobalConfigOptionsResult
 
-        // number boundary for this category is > 2
-        assert configOptions.options.numberGreaterThan == 2
-        assert configOptions.options.numberLessThan == Long.MAX_VALUE
+        // number boundary for this category is >=2 , range [2, 2147483647]
+        assert configOptions.options.numberGreaterThanOrEqual == 2
+        assert configOptions.options.numberLessThanOrEqual == (long) Integer.MAX_VALUE
     }
 
     void testFloatPointNumberTolerance() {


### PR DESCRIPTION
update globalConfigOptions number range,add options field name,
contains number equal scenario

Resolves: ZSTAC-66043

Change-Id: I756562666169776b6563646d6b61617467726a63
(cherry picked from commit bba7d3ca252c2a153f4c8e5b6beea25371d22bf8)

sync from gitlab !6885