### PR TITLE
<fix>[ceph]: correct ceph bs capacity calculation

### DIFF
--- a/test/src/test/groovy/org/zstack/test/integration/storage/primary/ceph/capacity/CephOpenSourcePoolCapacityCase.groovy
+++ b/test/src/test/groovy/org/zstack/test/integration/storage/primary/ceph/capacity/CephOpenSourcePoolCapacityCase.groovy
@@ -106,7 +106,9 @@ class CephOpenSourcePoolCapacityCase extends SubCase {
                             usedCapacity: SizeUnit.GIGABYTE.toByte(10),
                             availableCapacity : SizeUnit.GIGABYTE.toByte(90),
                             totalCapacity: SizeUnit.GIGABYTE.toByte(100),
-                            relatedOsds: "osd.4,osd.5,osd.6"
+                            relatedOsds: "osd.1,osd.2,osd.3",
+                            relatedOsdCapacity: osdMap,
+                            diskUtilization: 0.33
                     )
             ]
             rsp.type = CephConstants.CEPH_MANUFACTURER_OPENSOURCE
@@ -157,7 +159,9 @@ class CephOpenSourcePoolCapacityCase extends SubCase {
                             usedCapacity: SizeUnit.GIGABYTE.toByte(10),
                             availableCapacity : SizeUnit.GIGABYTE.toByte(90),
                             totalCapacity: SizeUnit.GIGABYTE.toByte(100),
-                            relatedOsds: "osd.4,osd.5,osd.6"
+                            relatedOsds: "osd.1,osd.2,osd.3",
+                            relatedOsdCapacity: osdMap,
+                            diskUtilization: 0.33
                     )
             ]
             rsp.type = CephConstants.CEPH_MANUFACTURER_OPENSOURCE
@@ -204,8 +208,8 @@ class CephOpenSourcePoolCapacityCase extends SubCase {
         BackupStorageInventory bsCapacity = queryBackupStorage {
             conditions = ["uuid=${bs.uuid}"]
         }[0]
-        assert bsCapacity.availableCapacity == SizeUnit.GIGABYTE.toByte(90)
-        assert bsCapacity.totalCapacity == SizeUnit.GIGABYTE.toByte(100)
+        assert bsCapacity.availableCapacity == 95670403072 // ~=89.1G
+        assert bsCapacity.totalCapacity == 106300440576 // 99G
         env.cleanSimulatorAndMessageHandlers()
     }
 }

--- a/test/src/test/groovy/org/zstack/test/integration/storage/primary/ceph/sandstone/capacity/CephSandStonePoolCapacityCase.groovy
+++ b/test/src/test/groovy/org/zstack/test/integration/storage/primary/ceph/sandstone/capacity/CephSandStonePoolCapacityCase.groovy
@@ -110,8 +110,7 @@ class CephSandStonePoolCapacityCase extends SubCase {
                             usedCapacity:  bs.getPoolUsedCapacity(),
                             availableCapacity : bs.availableCapacity + addSize,
                             totalCapacity: bs.totalCapacity + addSize,
-                            relatedOsds: "osd.2",
-                            relatedOsdCapacity: osdMap3
+                            relatedOsds: "osd.2"
                     ),
                     new CephPoolCapacity(
                             name : "other-pool",

--- a/test/src/test/groovy/org/zstack/test/integration/storage/primary/ceph/xsky/capacity/CephXskyPoolCapacityCase.groovy
+++ b/test/src/test/groovy/org/zstack/test/integration/storage/primary/ceph/xsky/capacity/CephXskyPoolCapacityCase.groovy
@@ -123,8 +123,7 @@ class CephXskyPoolCapacityCase extends SubCase {
                             usedCapacity:  bs.getPoolUsedCapacity(),
                             availableCapacity : bs.availableCapacity + addSize,
                             totalCapacity: bs.totalCapacity + addSize,
-                            relatedOsds: "osd.2",
-                            relatedOsdCapacity: osdMap3
+                            relatedOsds: "osd.2"
                     ),
                     new CephPoolCapacity(
                             name : "other-pool",


### PR DESCRIPTION
use osd capacity to calculate the total
capacity of ceph bs instead of using pool capacity

Resolves: ZSV-6636

Change-Id:I6c78776473716168746472706d7879716f697669

sync from gitlab !6894