### PR TITLE
<feature>[identity]: move share resource logic to ShareResourceHelper

### DIFF
--- a/conf/springConfigXml/AccountManager.xml
+++ b/conf/springConfigXml/AccountManager.xml
@@ -107,5 +107,7 @@
             <zstack:extension interface="org.zstack.header.identity.AfterUpdateAccountExtensionPoint"/>
         </zstack:plugin>
     </bean>
+
+    <bean id="ShareResourceHelper" class="org.zstack.identity.rbac.ShareResourceHelper"/>
 </beans>
 

--- a/conf/springConfigXml/NetworkManager.xml
+++ b/conf/springConfigXml/NetworkManager.xml
@@ -53,7 +53,7 @@
             <zstack:extension interface="org.zstack.header.identity.ReportQuotaExtensionPoint"/>
             <zstack:extension interface="org.zstack.header.identity.ResourceOwnerPreChangeExtensionPoint"/>
             <zstack:extension interface="org.zstack.header.managementnode.PrepareDbInitialValueExtensionPoint" />
-            <zstack:extension interface="org.zstack.identity.ResourceSharingExtensionPoint" />
+            <zstack:extension interface="org.zstack.identity.rbac.ResourceSharingExtensionPoint" />
         </zstack:plugin>
     </bean>
 

--- a/header/src/main/java/org/zstack/header/identity/APIRevokeResourceSharingMsg.java
+++ b/header/src/main/java/org/zstack/header/identity/APIRevokeResourceSharingMsg.java
@@ -20,7 +20,7 @@ import static org.zstack.utils.CollectionDSL.list;
         isAction = true,
         responseClass = APIRevokeResourceSharingEvent.class
 )
-public class APIRevokeResourceSharingMsg extends APIMessage implements AccountMessage {
+public class APIRevokeResourceSharingMsg extends APIMessage {
     @APIParam(resourceType = ResourceVO.class, nonempty = true, scope = APIParam.SCOPE_MUST_OWNER)
     private List<String> resourceUuids;
     private boolean toPublic;
@@ -60,11 +60,6 @@ public class APIRevokeResourceSharingMsg extends APIMessage implements AccountMe
         this.accountUuids = accountUuids;
     }
 
-    @Override
-    public String getAccountUuid() {
-        return getSession().getAccountUuid();
-    }
- 
     public static APIRevokeResourceSharingMsg __example__() {
         APIRevokeResourceSharingMsg msg = new APIRevokeResourceSharingMsg();
         msg.setAccountUuids(list(uuid(), uuid()));

--- a/header/src/main/java/org/zstack/header/identity/APIShareResourceMsg.java
+++ b/header/src/main/java/org/zstack/header/identity/APIShareResourceMsg.java
@@ -20,7 +20,7 @@ import static org.zstack.utils.CollectionDSL.list;
         responseClass = APIShareResourceEvent.class,
         isAction = true
 )
-public class APIShareResourceMsg extends APIMessage implements AccountMessage {
+public class APIShareResourceMsg extends APIMessage {
     @APIParam(resourceType = ResourceVO.class, nonempty = true, scope = APIParam.SCOPE_MUST_OWNER)
     private List<String> resourceUuids;
     @APIParam(resourceType = AccountVO.class, required = false)
@@ -65,11 +65,6 @@ public class APIShareResourceMsg extends APIMessage implements AccountMessage {
         this.permission = permission;
     }
 
-    @Override
-    public String getAccountUuid() {
-        return getSession().getAccountUuid();
-    }
- 
     public static APIShareResourceMsg __example__() {
         APIShareResourceMsg msg = new APIShareResourceMsg();
         msg.setAccountUuids(list(uuid(), uuid()));

--- a/identity/src/main/java/org/zstack/identity/rbac/ResourceSharingExtensionPoint.java
+++ b/identity/src/main/java/org/zstack/identity/rbac/ResourceSharingExtensionPoint.java
@@ -1,4 +1,4 @@
-package org.zstack.identity;
+package org.zstack.identity.rbac;
 
 import org.zstack.identity.header.ShareResourceContext;
 

--- a/identity/src/main/java/org/zstack/identity/rbac/ShareResourceHelper.java
+++ b/identity/src/main/java/org/zstack/identity/rbac/ShareResourceHelper.java
@@ -1,0 +1,207 @@
+package org.zstack.identity.rbac;
+
+import org.apache.commons.lang.StringUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.zstack.core.componentloader.PluginRegistry;
+import org.zstack.core.db.DatabaseFacade;
+import org.zstack.core.db.Q;
+import org.zstack.core.db.SQL;
+import org.zstack.header.identity.AccessLevel;
+import org.zstack.header.identity.AccountResourceRefVO;
+import org.zstack.header.identity.AccountResourceRefVO_;
+import org.zstack.identity.header.ShareResourceContext;
+import org.zstack.utils.Utils;
+import org.zstack.utils.data.Pair;
+import org.zstack.utils.logging.CLogger;
+
+import javax.persistence.Tuple;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import static org.zstack.utils.CollectionDSL.list;
+import static org.zstack.utils.CollectionUtils.*;
+
+public class ShareResourceHelper {
+    private static final CLogger logger = Utils.getLogger(ShareResourceHelper.class);
+
+    @Autowired
+    protected DatabaseFacade databaseFacade;
+    @Autowired
+    protected PluginRegistry pluginRegistry;
+
+    public void shareToAccounts(ShareResourceContext context, List<String> accountUuids) {
+        emitBeforeSharingExtensions(context);
+
+        final Set<String> allMasterResources = context.findAllMasterResources();
+        List<AccountResourceRefVO> needPersists = new ArrayList<>();
+
+        for (String masterResource : allMasterResources) {
+            List<AccountResourceRefVO> refs = context.buildShareAccountRecords(masterResource, accountUuids);
+
+            List<Tuple> existsTuples = Q.New(AccountResourceRefVO.class)
+                    .eq(AccountResourceRefVO_.type, AccessLevel.Share)
+                    .in(AccountResourceRefVO_.resourceUuid, transform(refs, AccountResourceRefVO::getResourceUuid))
+                    .in(AccountResourceRefVO_.accountUuid, accountUuids)
+                    .eq(AccountResourceRefVO_.resourcePermissionFrom, masterResource)
+                    .isNull(AccountResourceRefVO_.accountPermissionFrom)
+                    .select(
+                            AccountResourceRefVO_.resourceUuid,
+                            AccountResourceRefVO_.accountUuid,
+                            AccountResourceRefVO_.resourcePermissionFrom
+                    )
+                    .listTuple();
+            Set<String> existsRecords = transformToSet(existsTuples,
+                    tuple -> tuple.get(0, String.class) + "," + tuple.get(1, String.class) + "," + tuple.get(2, String.class));
+            refs.removeIf(ref -> existsRecords.contains(String.format("%s,%s,%s",
+                    ref.getResourceUuid(), ref.getAccountUuid(), ref.getResourcePermissionFrom())));
+            needPersists.addAll(refs);
+        }
+
+        List<AccountResourceRefVO> refs = context.buildShareAccountRecordsForSolitaryResources(accountUuids);
+        if (!refs.isEmpty()) {
+            List<Tuple> existsTuples = Q.New(AccountResourceRefVO.class)
+                    .eq(AccountResourceRefVO_.type, AccessLevel.Share)
+                    .in(AccountResourceRefVO_.resourceUuid, transform(refs, AccountResourceRefVO::getResourceUuid))
+                    .in(AccountResourceRefVO_.accountUuid, accountUuids)
+                    .isNull(AccountResourceRefVO_.resourcePermissionFrom)
+                    .isNull(AccountResourceRefVO_.accountPermissionFrom)
+                    .select(AccountResourceRefVO_.resourceUuid, AccountResourceRefVO_.accountUuid)
+                    .listTuple();
+            Set<Pair<String, String>> resourceAccountPairs = transformToSet(existsTuples,
+                    tuple -> new Pair<>(tuple.get(0, String.class), tuple.get(1, String.class)));
+            refs.removeIf(ref -> resourceAccountPairs.contains(
+                    new Pair<>(ref.getResourceUuid(), ref.getAccountUuid())));
+            needPersists.addAll(refs);
+        }
+
+        if (needPersists.isEmpty()) {
+            return;
+        }
+
+        databaseFacade.persistCollection(needPersists);
+        String texts = StringUtils.join(transform(needPersists,
+                shared -> String.format("\tuuid:%s type:%s", shared.getResourceUuid(), shared.getResourceType())), "\n");
+        logger.debug(String.format("Shared below resources to account[uuid:%s]: \n%s", accountUuids, texts));
+    }
+
+    public void shareToPublic(ShareResourceContext context) {
+        emitBeforeSharingExtensions(context);
+
+        final Set<String> allMasterResources = context.findAllMasterResources();
+        List<AccountResourceRefVO> needPersists = new ArrayList<>();
+
+        for (String masterResource : allMasterResources) {
+            List<AccountResourceRefVO> refs = context.buildShareToPublicRecords(masterResource);
+
+            List<String> existsUuidList = Q.New(AccountResourceRefVO.class)
+                    .eq(AccountResourceRefVO_.type, AccessLevel.SharePublic)
+                    .in(AccountResourceRefVO_.resourceUuid, transform(refs, AccountResourceRefVO::getResourceUuid))
+                    .eq(AccountResourceRefVO_.resourcePermissionFrom, masterResource)
+                    .select(AccountResourceRefVO_.resourceUuid)
+                    .listValues();
+            refs.removeIf(ref -> existsUuidList.contains(ref.getResourceUuid()));
+            needPersists.addAll(refs);
+        }
+
+        List<AccountResourceRefVO> refs = context.buildShareToPublicRecordsForSolitaryResources();
+        if (!refs.isEmpty()) {
+            List<String> existsUuidList = Q.New(AccountResourceRefVO.class)
+                    .eq(AccountResourceRefVO_.type, AccessLevel.SharePublic)
+                    .in(AccountResourceRefVO_.resourceUuid, transform(refs, AccountResourceRefVO::getResourceUuid))
+                    .isNull(AccountResourceRefVO_.resourcePermissionFrom)
+                    .select(AccountResourceRefVO_.resourceUuid)
+                    .listValues();
+            refs.removeIf(ref -> existsUuidList.contains(ref.getResourceUuid()));
+            needPersists.addAll(refs);
+        }
+
+        if (needPersists.isEmpty()) {
+            return;
+        }
+
+        databaseFacade.persistCollection(needPersists);
+        String texts = StringUtils.join(transform(needPersists,
+                shared -> String.format("\tuuid:%s type:%s", shared.getResourceUuid(), shared.getResourceType())), "\n");
+        logger.debug(String.format("Shared below resources to public: \n%s", texts));
+    }
+
+    public void revokeSharingToAccounts(ShareResourceContext context, List<String> accountUuids) {
+        emitBeforeSharingExtensions(context);
+
+        final Set<String> masterResourceUuidSet = context.findAllMasterResources();
+        final Set<String> resourceUuidSet = context.findAllSolitaryResources();
+        if (!masterResourceUuidSet.isEmpty()) {
+            SQL.New(AccountResourceRefVO.class)
+                    .in(AccountResourceRefVO_.resourcePermissionFrom, masterResourceUuidSet)
+                    .eq(AccountResourceRefVO_.type, AccessLevel.Share)
+                    .in(AccountResourceRefVO_.accountUuid, accountUuids)
+                    .isNull(AccountResourceRefVO_.accountPermissionFrom)
+                    .delete();
+        }
+        if (!resourceUuidSet.isEmpty()) {
+            SQL.New(AccountResourceRefVO.class)
+                    .in(AccountResourceRefVO_.resourceUuid, resourceUuidSet)
+                    .eq(AccountResourceRefVO_.type, AccessLevel.Share)
+                    .in(AccountResourceRefVO_.accountUuid, accountUuids)
+                    .isNull(AccountResourceRefVO_.accountPermissionFrom)
+                    .delete();
+        }
+
+        resourceUuidSet.addAll(masterResourceUuidSet);
+        logger.debug(String.format("Revoke shared resource for type(Share to Account): \n%s\nWith accounts: \n%s",
+                StringUtils.join(transform(resourceUuidSet, uuid -> String.format("\tuuid:%s", uuid)), "\n"),
+                StringUtils.join(transform(accountUuids, uuid -> String.format("\tuuid:%s", uuid)), "\n")));
+    }
+
+    public void revokeSharingToPublic(ShareResourceContext context) {
+        emitBeforeSharingExtensions(context);
+
+        final Set<String> masterResourceUuidSet = context.findAllMasterResources();
+        final Set<String> resourceUuidSet = context.findAllSolitaryResources();
+        if (!masterResourceUuidSet.isEmpty()) {
+            SQL.New(AccountResourceRefVO.class)
+                    .in(AccountResourceRefVO_.resourcePermissionFrom, masterResourceUuidSet)
+                    .eq(AccountResourceRefVO_.type, AccessLevel.SharePublic)
+                    .delete();
+        }
+        if (!resourceUuidSet.isEmpty()) {
+            SQL.New(AccountResourceRefVO.class)
+                    .in(AccountResourceRefVO_.resourceUuid, resourceUuidSet)
+                    .eq(AccountResourceRefVO_.type, AccessLevel.SharePublic)
+                    .delete();
+        }
+        resourceUuidSet.addAll(masterResourceUuidSet);
+        logger.debug(String.format("Revoke shared resource for type(SharePublic): \n%s",
+                StringUtils.join(transform(resourceUuidSet, uuid -> String.format("\tuuid:%s", uuid)), "\n")));
+    }
+
+    public void revokeSharingAll(ShareResourceContext context) {
+        emitBeforeSharingExtensions(context);
+
+        final Set<String> masterResourceUuidSet = context.findAllMasterResources();
+        final Set<String> resourceUuidSet = context.findAllSolitaryResources();
+        if (!masterResourceUuidSet.isEmpty()) {
+            SQL.New(AccountResourceRefVO.class)
+                    .in(AccountResourceRefVO_.resourcePermissionFrom, masterResourceUuidSet)
+                    .in(AccountResourceRefVO_.type, list(AccessLevel.Share, AccessLevel.SharePublic))
+                    .isNull(AccountResourceRefVO_.accountPermissionFrom)
+                    .delete();
+        }
+        if (!resourceUuidSet.isEmpty()) {
+            SQL.New(AccountResourceRefVO.class)
+                    .in(AccountResourceRefVO_.resourceUuid, resourceUuidSet)
+                    .in(AccountResourceRefVO_.type, list(AccessLevel.Share, AccessLevel.SharePublic))
+                    .isNull(AccountResourceRefVO_.accountPermissionFrom)
+                    .delete();
+        }
+        resourceUuidSet.addAll(masterResourceUuidSet);
+        logger.debug(String.format("Revoke shared resource for all types: \n%s",
+                StringUtils.join(transform(resourceUuidSet, uuid -> String.format("\tuuid:%s", uuid)), "\n")));
+    }
+
+    protected void emitBeforeSharingExtensions(ShareResourceContext context) {
+        safeForEach(pluginRegistry.getExtensionList(ResourceSharingExtensionPoint.class),
+                it -> it.beforeSharingResource(context));
+    }
+}

--- a/network/src/main/java/org/zstack/network/l3/L3NetworkManagerImpl.java
+++ b/network/src/main/java/org/zstack/network/l3/L3NetworkManagerImpl.java
@@ -29,7 +29,7 @@ import org.zstack.header.vm.VmNicVO;
 import org.zstack.header.vm.VmNicVO_;
 import org.zstack.header.zone.ZoneVO;
 import org.zstack.identity.AccountManager;
-import org.zstack.identity.ResourceSharingExtensionPoint;
+import org.zstack.identity.rbac.ResourceSharingExtensionPoint;
 import org.zstack.identity.header.ShareResourceContext;
 import org.zstack.network.service.MtuGetter;
 import org.zstack.network.service.NetworkServiceSystemTag;


### PR DESCRIPTION
Autowired class ShareResourceHelper used to:
* Share resources to specific accounts
* Share resources to public
* Revoke resources sharing to specific accounts
* Revoke resources sharing to public

Related: ZSV-6755
Related: ZSV-6559

Change-Id: I6d69706b6972756f637a61706977796b736e6a6e

sync from gitlab !6921