### PR TITLE
<fix>[conf]: ZQL search support RoleVO

### DIFF
--- a/conf/searchConfig/indexConfig.xml
+++ b/conf/searchConfig/indexConfig.xml
@@ -146,4 +146,7 @@
     <index name="org.zstack.header.identity.AccountVO" baseClass="false">
         <prop name="name"/>
     </index>
+    <index name="org.zstack.header.identity.role.RoleVO" baseClass="false">
+        <prop name="name"/>
+    </index>
 </indexes>


### PR DESCRIPTION
ZQL search scope includes RoleVO.name

Resolves: ZSV-6871
Related: ZSV-6559

Change-Id: I79716b6f6366676469706e716879786e686e6a62

sync from gitlab !6939