### PR TITLE
<fix>[conf]: fix mn unable to start after upgrade

### DIFF
--- a/conf/db/upgrade/V4.8.22__schema.sql
+++ b/conf/db/upgrade/V4.8.22__schema.sql
@@ -12,3 +12,5 @@ BEGIN
 END $$
 DELIMITER ;
 CALL check_and_insert_encrypt_metadata();
+
+UPDATE `zstack`.`GlobalConfigVO` SET value="64", defaultValue="64" WHERE category="volumeSnapshot" AND name="incrementalSnapshot.maxNum" AND value > 120;


### PR DESCRIPTION
update incrementalSnapshot.maxNum to be less than 121

DBImpact

Resolves: ZSTAC-67846

Change-Id: I64676a6776727378786877726767656364737562

sync from gitlab !6956