### PR TITLE
<fix>[compute]: fix update cluster os api for one host update bug

### DIFF
--- a/compute/src/main/java/org/zstack/compute/cluster/ClusterApiInterceptor.java
+++ b/compute/src/main/java/org/zstack/compute/cluster/ClusterApiInterceptor.java
@@ -97,6 +97,21 @@ public class ClusterApiInterceptor implements ApiMessageInterceptor {
                     ));
                 }
 
+                if (msg.getHostUuid() != null) {
+                    boolean hostConnected = q(HostVO.class)
+                            .eq(HostVO_.clusterUuid, msg.getUuid())
+                            .eq(HostVO_.uuid, msg.getHostUuid())
+                            .eq(HostVO_.status, HostStatus.Connected)
+                            .isExists();
+                    if (!hostConnected) {
+                        throw new ApiMessageInterceptionException(Platform.argerr(
+                                "host[uuid:%s] in cluster[uuid:%s] is not in the Connected status, cannot update cluster os right now",
+                                msg.getHostUuid(), msg.getUuid()
+                        ));
+                    }
+                    return;
+                }
+
                 // all hosts in the cluster must be connected
                 Long notConnected = q(HostVO.class)
                         .eq(HostVO_.clusterUuid, msg.getUuid())


### PR DESCRIPTION
if update one host's os, no need to check all cluster's host's status

Resolves: ZSTAC-69509

Change-Id: I6c79636f696771707a6e6264776e616869616163

sync from gitlab !6963