### PR TITLE
<feature>[header]: add field VmCdRomVO.occupant

### DIFF
--- a/compute/src/main/java/org/zstack/compute/vm/VmAllocateCdRomFlow.java
+++ b/compute/src/main/java/org/zstack/compute/vm/VmAllocateCdRomFlow.java
@@ -69,6 +69,7 @@ public class VmAllocateCdRomFlow implements Flow {
             vmCdRomVO.setName(String.format("vm-%s-cdRom", spec.getVmInventory().getUuid()));
             vmCdRomVO.setAccountUuid(acntUuid);
             vmCdRomVO.setIsoUuid(cdRomSpec.getImageUuid());
+            vmCdRomVO.setOccupant(vmCdRomVO.getIsoUuid() == null ? null : VmInstanceConstant.VM_CDROM_OCCUPANT_ISO);
             cdRomVOS.add(vmCdRomVO);
         }
 

--- a/compute/src/main/java/org/zstack/compute/vm/VmCdRomUpgradeExtension.java
+++ b/compute/src/main/java/org/zstack/compute/vm/VmCdRomUpgradeExtension.java
@@ -5,7 +5,6 @@ import org.zstack.core.Platform;
 import org.zstack.core.cloudbus.ResourceDestinationMaker;
 import org.zstack.core.db.DatabaseFacade;
 import org.zstack.core.db.Q;
-import org.zstack.header.Component;
 import org.zstack.header.image.ImagePlatform;
 import org.zstack.header.image.ImageVO;
 import org.zstack.header.image.ImageVO_;
@@ -77,6 +76,7 @@ public class VmCdRomUpgradeExtension implements ManagementNodeReadyExtensionPoin
             cdRomVO.setUuid(Platform.getUuid());
             cdRomVO.setDeviceId(deviceId);
             cdRomVO.setIsoUuid(vmDeviceIdIsoMap.get(deviceId));
+            cdRomVO.setOccupant(cdRomVO.getIsoUuid() == null ? null : VmInstanceConstant.VM_CDROM_OCCUPANT_ISO);
             cdRomVO.setVmInstanceUuid(vmUuid);
             cdRomVO.setName(String.format("vm-%s-cdRom", vmUuid));
             cdRomVO.setAccountUuid(acntUuid);
@@ -108,6 +108,7 @@ public class VmCdRomUpgradeExtension implements ManagementNodeReadyExtensionPoin
             cdRomVO.setUuid(Platform.getUuid());
             cdRomVO.setDeviceId(deviceId);
             cdRomVO.setIsoUuid(isoUuid);
+            cdRomVO.setOccupant(isoUuid == null ? null : VmInstanceConstant.VM_CDROM_OCCUPANT_ISO);
             cdRomVO.setVmInstanceUuid(vmUuid);
             cdRomVO.setName(String.format("vm-%s-cdRom", vmUuid));
             cdRomVO.setAccountUuid(acntUuid);

--- a/compute/src/main/java/org/zstack/compute/vm/VmInstanceBase.java
+++ b/compute/src/main/java/org/zstack/compute/vm/VmInstanceBase.java
@@ -4830,6 +4830,7 @@ public class VmInstanceBase extends AbstractVmInstance {
         if (self.getState() == VmInstanceState.Stopped || self.getState() == VmInstanceState.Destroyed) {
             targetVmCdRomVO.setIsoUuid(null);
             targetVmCdRomVO.setIsoInstallPath(null);
+            targetVmCdRomVO.setOccupant(null);
             dbf.update(targetVmCdRomVO);
             new IsoOperator().syncVmIsoSystemTag(self.getUuid());
             completion.success();
@@ -4861,6 +4862,7 @@ public class VmInstanceBase extends AbstractVmInstance {
             public void handle(Map data) {
                 targetVmCdRomVO.setIsoUuid(null);
                 targetVmCdRomVO.setIsoInstallPath(null);
+                targetVmCdRomVO.setOccupant(null);
                 dbf.update(targetVmCdRomVO);
                 new IsoOperator().syncVmIsoSystemTag(self.getUuid());
                 completion.success();
@@ -5158,6 +5160,7 @@ public class VmInstanceBase extends AbstractVmInstance {
 
         if (self.getState() == VmInstanceState.Stopped) {
             targetVmCdRomVO.setIsoUuid(isoUuid);
+            targetVmCdRomVO.setOccupant(VmInstanceConstant.VM_CDROM_OCCUPANT_ISO);
             dbf.update(targetVmCdRomVO);
             completion.success();
             new IsoOperator().syncVmIsoSystemTag(self.getUuid());
@@ -5190,6 +5193,7 @@ public class VmInstanceBase extends AbstractVmInstance {
                         .findAny()
                         .orElse(null);
                 targetVmCdRomVO.setIsoUuid(isoUuid);
+                targetVmCdRomVO.setOccupant(VmInstanceConstant.VM_CDROM_OCCUPANT_ISO);
                 targetVmCdRomVO.setIsoInstallPath(isoSpec != null ? isoSpec.getInstallPath() : null);
                 dbf.update(targetVmCdRomVO);
                 new IsoOperator().syncVmIsoSystemTag(self.getUuid());
@@ -5921,8 +5925,10 @@ public class VmInstanceBase extends AbstractVmInstance {
         String targetCdRomIsoUuid = targetCdRomVO.getIsoUuid();
         String path = targetCdRomVO.getIsoInstallPath();
         targetCdRomVO.setIsoUuid(sourceCdRomVO.getIsoUuid());
+        targetCdRomVO.setOccupant(VmInstanceConstant.VM_CDROM_OCCUPANT_ISO);
         targetCdRomVO.setIsoInstallPath(sourceCdRomVO.getIsoInstallPath());
         sourceCdRomVO.setIsoUuid(targetCdRomIsoUuid);
+        sourceCdRomVO.setOccupant(VmInstanceConstant.VM_CDROM_OCCUPANT_ISO);
         sourceCdRomVO.setIsoInstallPath(path);
 
         new SQLBatch() {
@@ -8474,6 +8480,7 @@ public class VmInstanceBase extends AbstractVmInstance {
         String cdRomUuid = msg.getResourceUuid() != null ? msg.getResourceUuid() : Platform.getUuid();
         cdRomVO.setUuid(cdRomUuid);
         cdRomVO.setDeviceId(targetDeviceId);
+        cdRomVO.setOccupant(msg.getIsoUuid() == null ? null : VmInstanceConstant.VM_CDROM_OCCUPANT_ISO);
         cdRomVO.setIsoUuid(msg.getIsoUuid());
         cdRomVO.setVmInstanceUuid(msg.getVmInstanceUuid());
         cdRomVO.setName(msg.getName());

--- a/conf/db/upgrade/V4.10.0__schema.sql
+++ b/conf/db/upgrade/V4.10.0__schema.sql
@@ -1,5 +1,13 @@
 CALL ADD_COLUMN('SNSApplicationEndpointVO', 'connectionStatus', 'varchar(10)', 1, 'UP');
 
+-- Improvement: VM Cdrom Occupant | ZSV-6691
+
+CALL INSERT_COLUMN('VmCdRomVO', 'occupant', 'varchar(64)', 1, null, 'deviceId');
+update `VmCdRomVO` set `occupant` = 'ISO' where `isoUuid` is not null;
+update `VmCdRomVO` set `occupant` = 'GuestTools'
+    where `vmInstanceUuid` in ( select `resourceUuid` from `SystemTagVO` where `tag` = 'guestToolsHasAttached' )
+    and `deviceId` = 0;
+
 -- Feature: IAM1 Role And Policy | ZSV-6559
 
 drop table if exists `IAM2TicketFlowCollectionVO`;

--- a/header/src/main/java/org/zstack/header/vm/VmInstanceConstant.java
+++ b/header/src/main/java/org/zstack/header/vm/VmInstanceConstant.java
@@ -92,4 +92,7 @@ public interface VmInstanceConstant {
     String NONE_CDROM = "none";
 
     String DETACH_NIC_FAILED_REGEX = ".*NIC device is still attached after.*";
+
+    String VM_CDROM_OCCUPANT_ISO = "ISO";
+    String VM_CDROM_OCCUPANT_GUEST_TOOLS = "GuestTools";
 }

--- a/header/src/main/java/org/zstack/header/vm/cdrom/VmCdRomInventory.java
+++ b/header/src/main/java/org/zstack/header/vm/cdrom/VmCdRomInventory.java
@@ -4,9 +4,10 @@ import org.zstack.header.query.ExpandedQueries;
 import org.zstack.header.query.ExpandedQuery;
 import org.zstack.header.search.Inventory;
 import org.zstack.header.vm.VmInstanceInventory;
+import org.zstack.utils.CollectionUtils;
+
 import java.io.Serializable;
 import java.sql.Timestamp;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
@@ -21,6 +22,8 @@ public class VmCdRomInventory implements Serializable {
     private String vmInstanceUuid;
 
     private Integer deviceId;
+
+    private String occupant;
 
     private String isoUuid;
 
@@ -39,6 +42,7 @@ public class VmCdRomInventory implements Serializable {
         inv.setUuid(vo.getUuid());
         inv.setVmInstanceUuid(vo.getVmInstanceUuid());
         inv.setDeviceId(vo.getDeviceId());
+        inv.setOccupant(vo.getOccupant());
         inv.setDescription(vo.getDescription());
         inv.setName(vo.getName());
         inv.setIsoUuid(vo.getIsoUuid());
@@ -50,11 +54,7 @@ public class VmCdRomInventory implements Serializable {
     }
 
     public static List<VmCdRomInventory> valueOf(Collection<VmCdRomVO> vos) {
-        List<VmCdRomInventory> invs = new ArrayList<VmCdRomInventory>(vos.size());
-        for (VmCdRomVO vo : vos) {
-            invs.add(VmCdRomInventory.valueOf(vo));
-        }
-        return invs;
+        return CollectionUtils.transform(vos, VmCdRomInventory::valueOf);
     }
 
     public String getUuid() {
@@ -79,6 +79,14 @@ public class VmCdRomInventory implements Serializable {
 
     public void setDeviceId(int deviceId) {
         this.deviceId = deviceId;
+    }
+
+    public String getOccupant() {
+        return occupant;
+    }
+
+    public void setOccupant(String occupant) {
+        this.occupant = occupant;
     }
 
     public Timestamp getCreateDate() {

--- a/header/src/main/java/org/zstack/header/vm/cdrom/VmCdRomVO.java
+++ b/header/src/main/java/org/zstack/header/vm/cdrom/VmCdRomVO.java
@@ -31,6 +31,16 @@ public class VmCdRomVO extends ResourceVO implements OwnedByAccount {
     @Column
     private Integer deviceId;
 
+    /**
+     * The occupant of the cdrom.
+     * Maybe 'ISO' for cdrom iso, or 'GuestTools' for guest-tools, or null for empty cdrom.
+     *
+     * @see org.zstack.header.vm.VmInstanceConstant#VM_CDROM_OCCUPANT_ISO
+     * @see org.zstack.header.vm.VmInstanceConstant#VM_CDROM_OCCUPANT_GUEST_TOOLS
+     */
+    @Column
+    private String occupant;
+
     @Column
     @ForeignKey(parentEntityClass = ImageEO.class, onDeleteAction = ReferenceOption.SET_NULL)
     private String isoUuid;
@@ -99,6 +109,14 @@ public class VmCdRomVO extends ResourceVO implements OwnedByAccount {
 
     public Integer getDeviceId() {
         return deviceId;
+    }
+
+    public String getOccupant() {
+        return occupant;
+    }
+
+    public void setOccupant(String occupant) {
+        this.occupant = occupant;
     }
 
     public String getIsoUuid() {

--- a/header/src/main/java/org/zstack/header/vm/cdrom/VmCdRomVO_.java
+++ b/header/src/main/java/org/zstack/header/vm/cdrom/VmCdRomVO_.java
@@ -18,6 +18,7 @@ public class VmCdRomVO_ extends ResourceVO_ {
     public static volatile SingularAttribute<VmCdRomVO, String> isoInstallPath;
     public static volatile SingularAttribute<VmNicVO, String> description;
     public static volatile SingularAttribute<VmNicVO, Integer> deviceId;
+    public static volatile SingularAttribute<VmNicVO, String> occupant;
     public static volatile SingularAttribute<VmCdRomVO, Timestamp> createDate;
     public static volatile SingularAttribute<VmCdRomVO, Timestamp> lastOpDate;
 }

--- a/sdk/src/main/java/org/zstack/sdk/VmCdRomInventory.java
+++ b/sdk/src/main/java/org/zstack/sdk/VmCdRomInventory.java
@@ -28,6 +28,14 @@ public class VmCdRomInventory  {
         return this.deviceId;
     }
 
+    public java.lang.String occupant;
+    public void setOccupant(java.lang.String occupant) {
+        this.occupant = occupant;
+    }
+    public java.lang.String getOccupant() {
+        return this.occupant;
+    }
+
     public java.lang.String isoUuid;
     public void setIsoUuid(java.lang.String isoUuid) {
         this.isoUuid = isoUuid;


### PR DESCRIPTION
VmCdRomVO.occupant can be:
* null, if this cdrom slot is empty;
* "ISO", if this cdrom slot has ISO
* "GuestTools", if this cdrom slot has guest-tools

Resolves: ZSV-6691

Change-Id: I6776706c716c6b6e6b72727a77786a6a70786e71

sync from gitlab !6967