### PR TITLE
<fix>[compute]: exclude conflicting hosts from VM migration options

### DIFF
--- a/compute/src/main/java/org/zstack/compute/allocator/HostAllocatorManagerImpl.java
+++ b/compute/src/main/java/org/zstack/compute/allocator/HostAllocatorManagerImpl.java
@@ -528,6 +528,10 @@ public class HostAllocatorManagerImpl extends AbstractService implements HostAll
 
                 @Override
                 public void rollback(FlowRollback trigger, Map data) {
+                    if (reply.getHost() == null) {
+                        trigger.rollback();
+                        return;
+                    }
                     ReturnHostCapacityMsg rmsg = new ReturnHostCapacityMsg();
                     rmsg.setHostUuid(reply.getHost().getUuid());
                     rmsg.setMemoryCapacity(spec.getMemoryCapacity());

--- a/compute/src/main/java/org/zstack/compute/allocator/HostSortorChain.java
+++ b/compute/src/main/java/org/zstack/compute/allocator/HostSortorChain.java
@@ -195,7 +195,7 @@ public class HostSortorChain implements HostSortorStrategy {
             @Override
             public void done(ErrorCodeList errorCodeList) {
                 if (selectedHost.get() == null) {
-                    completion.fail(errorCodeList);
+                    completion.fail(errorCodeList.getCauses().get(0));
                     return;
                 }
                 completion.success(selectedHost.get());


### PR DESCRIPTION
exclude mutually exclusive physical machines from the host list
available for VM migration in local storage scenarios.

Resolves: ZSTAC-67859

Change-Id: I646367859a6776667067706e7a6e667a796f686d

sync from gitlab !7044