### PR TITLE
<test>[core]: remove message_cn when locale is en_us

### DIFF
--- a/core/src/main/java/org/zstack/core/Platform.java
+++ b/core/src/main/java/org/zstack/core/Platform.java
@@ -1018,11 +1018,11 @@ public class Platform {
         // error from other component directly, so we need to check if the args is
         // matched with the regex at first
         if (args != null && args.length == 1 && StringSimilarity.isRegexMatched(ela.getRegex(), String.valueOf(args[0]))) {
-            result.setMessages(new ErrorCodeElaboration(ela));
+            result.setMessages(new ErrorCodeElaboration(ela, locale));
             String formatError = String.format(prefix, args[0]);
             result.setElaboration(StringSimilarity.formatElaboration(formatError));
         } else {
-            result.setMessages(new ErrorCodeElaboration(ela, args));
+            result.setMessages(new ErrorCodeElaboration(ela, locale, args));
             result.setElaboration(StringSimilarity.formatElaboration(String.format(prefix, msg), args));
         }
 

--- a/test/src/test/groovy/org/zstack/test/integration/core/ElaborationCase.groovy
+++ b/test/src/test/groovy/org/zstack/test/integration/core/ElaborationCase.groovy
@@ -86,10 +86,14 @@ class ElaborationCase extends SubCase {
         def err = operr("certificate has expired or is not yet valid") as ErrorCode
         assert err.elaboration != null
         assert err.elaboration.trim() == "Error message: The current system time has expired for ImageStore certificate. Possible reason: ImageStore server system time or certificate is modified."
+        assert err.messages.message_en != null
+        assert err.messages.message_cn == null
 
         err = operr("The state of vm[uuid:%s] is %s. Only these state[Running,Stopped] is allowed to update cpu or memory.", Platform.uuid, "Rebooting") as ErrorCode
         assert err.elaboration != null
         assert err.elaboration.trim() == "Error message: Only VMs with the status [Running, Stopped] support CPU/memory update. Current status: Rebooting."
+        assert err.messages.message_en != null
+        assert err.messages.message_cn == null
 
         err = operr("test for missed error") as ErrorCode
         assert err.elaboration == null

--- a/utils/src/main/java/org/zstack/utils/string/ErrorCodeElaboration.java
+++ b/utils/src/main/java/org/zstack/utils/string/ErrorCodeElaboration.java
@@ -1,5 +1,7 @@
 package org.zstack.utils.string;
 
+import java.util.Locale;
+
 /**
  * Created by mingjian.deng on 2018/11/28.
  */
@@ -17,17 +19,29 @@ public class ErrorCodeElaboration {
     public ErrorCodeElaboration() {
     }
 
-    public ErrorCodeElaboration(ErrorCodeElaboration other, Object...args) {
+    public ErrorCodeElaboration(ErrorCodeElaboration other, Locale locale, Object...args) {
         if (args != null) {
             this.message_en = String.format(other.message_en, args);
-            this.message_cn = String.format(other.message_cn, args);
+            this.message_cn = Locale.SIMPLIFIED_CHINESE.equals(locale) ? String.format(other.message_cn, args) : null;
         } else {
             this.message_en = other.message_en;
-            this.message_cn = other.message_cn;
+            this.message_cn = Locale.SIMPLIFIED_CHINESE.equals(locale) ? other.message_cn : null;
         }
         this.distance = other.distance;
         this.method = other.method;
         this.code = other.code;
+    }
+
+    public ErrorCodeElaboration(ErrorCodeElaboration other, Locale locale) {
+        category = other.category;
+        code = other.code;
+        regex = other.regex;
+        message_en = other.message_en;
+        message_cn = Locale.SIMPLIFIED_CHINESE.equals(locale) ? other.message_cn : null;
+        source = other.source;
+        distance = other.distance;
+        formatSrcError = other.formatSrcError;
+        method = other.method;
     }
 
     public ErrorCodeElaboration(ErrorCodeElaboration other) {


### PR DESCRIPTION
remove message_cn in ErrorCodeElaorationEnglish
where locale is en_us

Resolves: ZSTAC-71194

Change-Id: I6e61736662656d74797a716c617065697a6e6f6b

sync from gitlab !7206