### PR TITLE
<fix>[sdk]: support get ZCE-X license info by zcex additional type

### DIFF
--- a/sdk/src/main/java/org/zstack/sdk/AdditionalLicenseType.java
+++ b/sdk/src/main/java/org/zstack/sdk/AdditionalLicenseType.java
@@ -4,4 +4,5 @@ public enum AdditionalLicenseType {
 	cube,
 	edge,
 	zstone,
+	zcex,
 }


### PR DESCRIPTION
Introduce "zcex" additional license type.

Related: ZSV-7444

Change-Id: I6878686b79796f6d7366706a64696a696b6e6d72

sync from gitlab !7420