### PR TITLE
<fix>[kvm]: sync ovn dpdk nic when reconnecting host<description>

### DIFF
--- a/header/src/main/java/org/zstack/header/vm/VmNicOvnConstant.java
+++ b/header/src/main/java/org/zstack/header/vm/VmNicOvnConstant.java
@@ -1,8 +1,0 @@
-package org.zstack.header.vm;
-
-import org.zstack.header.configuration.PythonClass;
-
-@PythonClass
-public interface VmNicOvnConstant {
-    public static final String OVN_DPDK_VNIC_TYPE_VHOST_USER = "OvnDpdkVhostUser";
-}

--- a/plugin/kvm/src/main/java/org/zstack/kvm/KVMAgentCommands.java
+++ b/plugin/kvm/src/main/java/org/zstack/kvm/KVMAgentCommands.java
@@ -4750,6 +4750,8 @@ public class KVMAgentCommands {
         @GrayVersion(value = "5.4.0")
         public String vSwitchType;
         @GrayVersion(value = "5.4.0")
+        public Boolean sync;
+        @GrayVersion(value = "5.4.0")
         public Map<String, String> nicMap = new HashMap<>();
     }
 


### PR DESCRIPTION
Resolves: ZSTAC-72911

Change-Id: I656a7462706179647770716e71676a7067637476

sync from gitlab !7477