### PR TITLE
<fix>[conf]: update default value of VmHaVO.inhibitionTime

### DIFF
--- a/conf/db/upgrade/V4.10.6__schema.sql
+++ b/conf/db/upgrade/V4.10.6__schema.sql
@@ -68,7 +68,7 @@ CREATE TABLE IF NOT EXISTS `zstack`.`VmHaVO` (
     `haLevel` varchar(64) not null default 'Undefined',
     `haLevelUpdateTime` timestamp not null default CURRENT_TIMESTAMP,
     `inhibitionReason` varchar(255) default null,
-    `inhibitionTime` timestamp default '0000-00-00 00:00:00',
+    `inhibitionTime` timestamp default '1999-12-31 23:59:59',
     CONSTRAINT fkVmHaVOVmInstanceVO FOREIGN KEY (uuid) REFERENCES VmInstanceEO (uuid) ON DELETE CASCADE,
     PRIMARY KEY (`uuid`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;


### PR DESCRIPTION
The original default value '0000-00-00 00:00:00'
cannot be queried on MN and will result in
an error message 'Zero date value prohibited'

Related: ZSV-7433

Change-Id: I6d6c61786b68626467716a7a6e74616e6e646165
(cherry picked from commit 1c7e219c4d53981e096ae73971f1019b784cacca)

sync from gitlab !7524