### PR TITLE
<feature>[sdk]: support scan ceph plugin and env on MN

### DIFF
--- a/sdk/src/main/java/SourceClassMap.java
+++ b/sdk/src/main/java/SourceClassMap.java
@@ -648,6 +648,7 @@ public class SourceClassMap {
 			put("org.zstack.zstone.entity.ZStoneLicenseInventory", "org.zstack.sdk.zstone.entity.ZStoneLicenseInventory");
 			put("org.zstack.zstone.entity.ZStoneLicenseView", "org.zstack.sdk.zstone.entity.ZStoneLicenseView");
 			put("org.zstack.zstone.entity.ZStonePoolSummaryView", "org.zstack.sdk.zstone.entity.ZStonePoolSummaryView");
+			put("org.zstack.zsv.storage.entity.CephPluginConnectionView", "org.zstack.sdk.zsv.storage.entity.CephPluginConnectionView");
 			put("org.zstack.zwatch.alarm.APICreateAlarmMsg$ActionParam", "org.zstack.sdk.zwatch.alarm.ActionParam");
 			put("org.zstack.zwatch.alarm.AlarmActionInventory", "org.zstack.sdk.zwatch.alarm.AlarmActionInventory");
 			put("org.zstack.zwatch.alarm.AlarmDataAckInventory", "org.zstack.sdk.zwatch.alarm.AlarmDataAckInventory");
@@ -1355,6 +1356,7 @@ public class SourceClassMap {
 			put("org.zstack.sdk.zstone.entity.ZStoneLicenseInventory", "org.zstack.zstone.entity.ZStoneLicenseInventory");
 			put("org.zstack.sdk.zstone.entity.ZStoneLicenseView", "org.zstack.zstone.entity.ZStoneLicenseView");
 			put("org.zstack.sdk.zstone.entity.ZStonePoolSummaryView", "org.zstack.zstone.entity.ZStonePoolSummaryView");
+			put("org.zstack.sdk.zsv.storage.entity.CephPluginConnectionView", "org.zstack.zsv.storage.entity.CephPluginConnectionView");
 			put("org.zstack.sdk.zwatch.alarm.ActionParam", "org.zstack.zwatch.alarm.APICreateAlarmMsg$ActionParam");
 			put("org.zstack.sdk.zwatch.alarm.AlarmActionInventory", "org.zstack.zwatch.alarm.AlarmActionInventory");
 			put("org.zstack.sdk.zwatch.alarm.AlarmDataAckInventory", "org.zstack.zwatch.alarm.AlarmDataAckInventory");

--- a/sdk/src/main/java/org/zstack/sdk/zsv/storage/api/CheckCephPluginAction.java
+++ b/sdk/src/main/java/org/zstack/sdk/zsv/storage/api/CheckCephPluginAction.java
@@ -1,0 +1,98 @@
+package org.zstack.sdk.zsv.storage.api;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.zstack.sdk.*;
+
+public class CheckCephPluginAction extends AbstractAction {
+
+    private static final HashMap<String, Parameter> parameterMap = new HashMap<>();
+
+    private static final HashMap<String, Parameter> nonAPIParameterMap = new HashMap<>();
+
+    public static class Result {
+        public ErrorCode error;
+        public org.zstack.sdk.zsv.storage.api.CheckCephPluginResult value;
+
+        public Result throwExceptionIfError() {
+            if (error != null) {
+                throw new ApiException(
+                    String.format("error[code: %s, description: %s, details: %s]", error.code, error.description, error.details)
+                );
+            }
+            
+            return this;
+        }
+    }
+
+    @Param(required = false, nonempty = false, nullElements = false, emptyString = true, noTrim = false)
+    public boolean managementNode = true;
+
+    @Param(required = false, nonempty = false, nullElements = false, emptyString = true, noTrim = false)
+    public java.util.List hostUuidList;
+
+    @Param(required = false)
+    public java.util.List systemTags;
+
+    @Param(required = false)
+    public java.util.List userTags;
+
+    @Param(required = false)
+    public String sessionId;
+
+    @Param(required = false)
+    public String accessKeyId;
+
+    @Param(required = false)
+    public String accessKeySecret;
+
+    @Param(required = false)
+    public String requestIp;
+
+
+    private Result makeResult(ApiResult res) {
+        Result ret = new Result();
+        if (res.error != null) {
+            ret.error = res.error;
+            return ret;
+        }
+        
+        org.zstack.sdk.zsv.storage.api.CheckCephPluginResult value = res.getResult(org.zstack.sdk.zsv.storage.api.CheckCephPluginResult.class);
+        ret.value = value == null ? new org.zstack.sdk.zsv.storage.api.CheckCephPluginResult() : value; 
+
+        return ret;
+    }
+
+    public Result call() {
+        ApiResult res = ZSClient.call(this);
+        return makeResult(res);
+    }
+
+    public void call(final Completion<Result> completion) {
+        ZSClient.call(this, new InternalCompletion() {
+            @Override
+            public void complete(ApiResult res) {
+                completion.complete(makeResult(res));
+            }
+        });
+    }
+
+    protected Map<String, Parameter> getParameterMap() {
+        return parameterMap;
+    }
+
+    protected Map<String, Parameter> getNonAPIParameterMap() {
+        return nonAPIParameterMap;
+    }
+
+    protected RestInfo getRestInfo() {
+        RestInfo info = new RestInfo();
+        info.httpMethod = "PUT";
+        info.path = "/ceph-plugin/check";
+        info.needSession = true;
+        info.needPoll = false;
+        info.parameterName = "checkCephPlugin";
+        return info;
+    }
+
+}

--- a/sdk/src/main/java/org/zstack/sdk/zsv/storage/api/CheckCephPluginResult.java
+++ b/sdk/src/main/java/org/zstack/sdk/zsv/storage/api/CheckCephPluginResult.java
@@ -1,0 +1,14 @@
+package org.zstack.sdk.zsv.storage.api;
+
+
+
+public class CheckCephPluginResult {
+    public java.util.List inventories;
+    public void setInventories(java.util.List inventories) {
+        this.inventories = inventories;
+    }
+    public java.util.List getInventories() {
+        return this.inventories;
+    }
+
+}

--- a/sdk/src/main/java/org/zstack/sdk/zsv/storage/entity/CephPluginConnectionView.java
+++ b/sdk/src/main/java/org/zstack/sdk/zsv/storage/entity/CephPluginConnectionView.java
@@ -1,0 +1,39 @@
+package org.zstack.sdk.zsv.storage.entity;
+
+
+
+public class CephPluginConnectionView  {
+
+    public java.lang.String ip;
+    public void setIp(java.lang.String ip) {
+        this.ip = ip;
+    }
+    public java.lang.String getIp() {
+        return this.ip;
+    }
+
+    public java.lang.String pluginType;
+    public void setPluginType(java.lang.String pluginType) {
+        this.pluginType = pluginType;
+    }
+    public java.lang.String getPluginType() {
+        return this.pluginType;
+    }
+
+    public java.lang.String managementNodeUuid;
+    public void setManagementNodeUuid(java.lang.String managementNodeUuid) {
+        this.managementNodeUuid = managementNodeUuid;
+    }
+    public java.lang.String getManagementNodeUuid() {
+        return this.managementNodeUuid;
+    }
+
+    public java.lang.String hostUuid;
+    public void setHostUuid(java.lang.String hostUuid) {
+        this.hostUuid = hostUuid;
+    }
+    public java.lang.String getHostUuid() {
+        return this.hostUuid;
+    }
+
+}

--- a/testlib/src/main/java/org/zstack/testlib/ApiHelper.groovy
+++ b/testlib/src/main/java/org/zstack/testlib/ApiHelper.groovy
@@ -44820,6 +44820,33 @@ abstract class ApiHelper {
     }
 
 
+    def checkCephPlugin(@DelegatesTo(strategy = Closure.OWNER_FIRST, value = org.zstack.sdk.zsv.storage.api.CheckCephPluginAction.class) Closure c) {
+        def a = new org.zstack.sdk.zsv.storage.api.CheckCephPluginAction()
+        a.sessionId = Test.currentEnvSpec?.session?.uuid
+        c.resolveStrategy = Closure.OWNER_FIRST
+        c.delegate = a
+        c()
+        
+
+        if (System.getProperty("apipath") != null) {
+            if (a.apiId == null) {
+                a.apiId = Platform.uuid
+            }
+    
+            def tracker = new ApiPathTracker(a.apiId)
+            def out = errorOut(a.call())
+            def path = tracker.getApiPath()
+            if (!path.isEmpty()) {
+                Test.apiPaths[a.class.name] = path.join(" --->\n")
+            }
+        
+            return out
+        } else {
+            return errorOut(a.call())
+        }
+    }
+
+
     def ackAlarmData(@DelegatesTo(strategy = Closure.OWNER_FIRST, value = org.zstack.sdk.zwatch.alarm.AckAlarmDataAction.class) Closure c) {
         def a = new org.zstack.sdk.zwatch.alarm.AckAlarmDataAction()
         a.sessionId = Test.currentEnvSpec?.session?.uuid


### PR DESCRIPTION
APICheckCephPluginMsg is for scaning
all installed Ceph environments
on the specific management node and hosts.

APICheckCephPluginMsg support to scan
ZStone or ZCE-X ceph plugins.

Resolves: ZSV-8174
Related: ZSV-7443
Related: ZSV-7444

Change-Id: I6569777771786274756e6e6576766b767a7a7572

sync from gitlab !7528