### PR TITLE
<fix>[sdk]: cloning vm supports full parameter specification

### DIFF
--- a/sdk/src/main/java/org/zstack/sdk/CloneVmInstanceAction.java
+++ b/sdk/src/main/java/org/zstack/sdk/CloneVmInstanceAction.java
@@ -55,6 +55,9 @@ public class CloneVmInstanceAction extends AbstractAction {
     @Param(required = false, nonempty = false, nullElements = false, emptyString = true, noTrim = false)
     public java.lang.String hostUuid;
 
+    @Param(required = false, nonempty = false, nullElements = false, emptyString = true, noTrim = false)
+    public java.util.List diskAOs;
+
     @Param(required = false)
     public java.util.List systemTags;
 


### PR DESCRIPTION
1 add parameter diskAOs to APICloneVmInstanceMsg to specify the configuration for volume and vm.

2 new parameter passing rules for APICloneVmInstanceMsg:

Quick Creation:
1) Use primaryStorageUuidForDataVolume and dataVolumeSystemTags to assign identical configurations to all data volume.
2) Use primaryStorageUuidForRootVolume and rootVolumeSystemTags to configure the root volume.

Custom Cloning:
pass parameters for specific volumes via the DiskAO structure:
DiskAO.sourceUuid: Original volume UUID of the source vm.
DiskAO.primaryStorageUuid: Primary storage UUID for the disk.
DiskAO.systemTag: Configuration settings for the volume.

3 Custom Cloning and Quick Cloning parameters are mutually exclusive.
If diskAOs is not empty,
providing any value for parameters such as primaryStorageUuidForRootVolume,
primaryStorageUuidForDataVolume, rootVolumeSystemTag, or dataVolumeSystemTags will trigger an error.

Resolves: ZSV-8316

Change-Id: I77616b73626d7a6f77746a7779646d6c65676c77

sync from gitlab !7606