### PR TITLE
<fix>[sharedblock]: support automatic repair of sanlock metadata

### DIFF
--- a/header/src/main/java/org/zstack/header/host/HostCanonicalEvents.java
+++ b/header/src/main/java/org/zstack/header/host/HostCanonicalEvents.java
@@ -33,6 +33,7 @@ public class HostCanonicalEvents {
     public static final String HOST_PROCESS_PHYSICAL_MEMORY_USAGE_ABNORMAL = "/host/process/physicalMemory/usage/abnormal";
     public static final String HOST_PING_SKIP = "/host/ping/skip";
     public static final String HOST_PING_CANCEL_SKIP = "/host/ping/cancel/skip";
+    public static final String HOST_PRIMARY_STORAGE_METADATA_REPAIR = "/host/primarystorage/metadata/repair";
 
     @NeedJsonSchema
     public static class HostPhysicalHbaPortStateAbnormalData {


### PR DESCRIPTION
support automatic repair of sanlock metadata

Resolves/Related: ZSTAC-73786

Change-Id: I62776571697477646d7473786b766e6b62727171

sync from gitlab !7610