### PR TITLE
<fix>[dependencies]: update avro version to 1.11.4

### DIFF
--- a/header/pom.xml
+++ b/header/pom.xml
@@ -77,7 +77,7 @@
         <dependency>
             <groupId>org.apache.avro</groupId>
             <artifactId>avro</artifactId>
-            <version>1.11.3</version>
+            <version>1.11.4</version>
         </dependency>
         <dependency>
             <groupId>org.hibernate</groupId>


### PR DESCRIPTION
update avro version to 1.11.4 to fix CVEs of compile dependency
commons-compress.

Resolves: ZSTAC-72937

Change-Id: I6164666b73736c6f6b6a666b7462726e73747475

sync from gitlab !7618