### PR TITLE
<fix>[identity]: add method AccountManager.isInSystemAdminType

### DIFF
--- a/header/src/main/java/org/zstack/header/identity/AccountConstant.java
+++ b/header/src/main/java/org/zstack/header/identity/AccountConstant.java
@@ -50,7 +50,7 @@ public interface AccountConstant {
      * account has SystemAdmin type also have admin permission,
      * but this method only check "admin" account.
      *
-     * use Account.isAdminPermission(SessionInventory)
+     * use Account.isAdminPermission(SessionInventory) or isAdmin(SessionInventory)
      */
     @Deprecated
     static boolean isAdminPermission(SessionInventory session) {
@@ -61,10 +61,18 @@ public interface AccountConstant {
      * account has SystemAdmin type also have admin permission,
      * but this method only check "admin" account.
      *
-     * use Account.isAdminPermission(String)
+     * use Account.isAdminPermission(String) or isAdmin(String)
      */
     @Deprecated
     static boolean isAdminPermission(String accountUuid) {
+        return INITIAL_SYSTEM_ADMIN_UUID.equals(accountUuid);
+    }
+
+    static boolean isAdmin(SessionInventory session) {
+        return isAdmin(session.getAccountUuid());
+    }
+
+    static boolean isAdmin(String accountUuid) {
         return INITIAL_SYSTEM_ADMIN_UUID.equals(accountUuid);
     }
 

--- a/identity/src/main/java/org/zstack/identity/Account.java
+++ b/identity/src/main/java/org/zstack/identity/Account.java
@@ -17,7 +17,7 @@ public interface Account {
     }
 
     static boolean isAdminPermission(String accountUuid) {
-        if (AccountConstant.INITIAL_SYSTEM_ADMIN_UUID.equals(accountUuid)) {
+        if (isAdmin(accountUuid)) {
             return true;
         }
 
@@ -25,5 +25,13 @@ public interface Account {
                 .eq(AccountVO_.uuid, accountUuid)
                 .eq(AccountVO_.type, AccountType.SystemAdmin)
                 .isExists();
+    }
+
+    static boolean isAdmin(SessionInventory session) {
+        return AccountConstant.isAdmin(session.getAccountUuid());
+    }
+
+    static boolean isAdmin(String accountUuid) {
+        return AccountConstant.isAdmin(accountUuid);
     }
 }

--- a/identity/src/main/java/org/zstack/identity/Account.java
+++ b/identity/src/main/java/org/zstack/identity/Account.java
@@ -2,6 +2,10 @@ package org.zstack.identity;
 
 import org.zstack.core.db.Q;
 import org.zstack.header.identity.*;
+import org.zstack.header.identity.role.RoleAccountRefVO;
+import org.zstack.header.identity.role.RoleAccountRefVO_;
+
+import static org.zstack.header.identity.AccountConstant.SOD_AUDITOR_ROLE_UUID;
 
 public interface Account {
     static String getAccountUuidOfResource(String resUuid) {
@@ -33,5 +37,20 @@ public interface Account {
 
     static boolean isAdmin(String accountUuid) {
         return AccountConstant.isAdmin(accountUuid);
+    }
+
+    static boolean supportToQueryAuditsFromAllAccounts(SessionInventory session) {
+        return supportToQueryAuditsFromAllAccounts(session.getAccountUuid());
+    }
+
+    static boolean supportToQueryAuditsFromAllAccounts(String accountUuid) {
+        if (isAdmin(accountUuid)) {
+            return true;
+        }
+
+        return Q.New(RoleAccountRefVO.class)
+                    .eq(RoleAccountRefVO_.accountUuid, accountUuid)
+                    .eq(RoleAccountRefVO_.roleUuid, SOD_AUDITOR_ROLE_UUID)
+                    .isExists();
     }
 }

--- a/identity/src/main/java/org/zstack/identity/AccountManager.java
+++ b/identity/src/main/java/org/zstack/identity/AccountManager.java
@@ -23,7 +23,15 @@ public interface AccountManager {
 
     AccountResourceRefInventory changeResourceOwner(String resourceUuid, String newOwnerUuid);
 
+    /**
+     * return true only when the account is "admin" account
+     */
     boolean isAdmin(SessionInventory session);
+
+    /**
+     * return true if the account is in {@link AccountType#SystemAdmin} type
+     */
+    boolean isInSystemAdminType(SessionInventory session);
 
     void adminAdoptAllOrphanedResource(List<String> resourceUuid, String originAccountUuid);
 

--- a/identity/src/main/java/org/zstack/identity/AccountManagerImpl.java
+++ b/identity/src/main/java/org/zstack/identity/AccountManagerImpl.java
@@ -192,6 +192,11 @@ public class AccountManagerImpl extends AbstractService implements AccountManage
         return AccountConstant.INITIAL_SYSTEM_ADMIN_UUID.equals(session.getAccountUuid());
     }
 
+    @Override
+    public boolean isInSystemAdminType(SessionInventory session) {
+        return Account.isAdminPermission(session);
+    }
+
     private void passThrough(AccountMessage msg) {
         AccountVO vo = dbf.findByUuid(msg.getAccountUuid(), AccountVO.class);
         if (vo == null) {


### PR DESCRIPTION
Here are two methods to distinguish
between isAdmin and isInSystemAdminType:
* AccountManager.isAdmin() return true
  return true only when the account is "admin" account
* AccountManager.isInSystemAdminType()
  return true if the account is in SystemAdmin type.

Related: ZSV-8493
Related: ZSV-7696

Change-Id: I706a696c667a6b656877707564636264646b6873

sync from gitlab !7641