### PR TITLE
<fix>[volumeSnapshot]: fix flatten volume failed on sblk

### DIFF
--- a/plugin/kvm/src/main/java/org/zstack/kvm/KVMHost.java
+++ b/plugin/kvm/src/main/java/org/zstack/kvm/KVMHost.java
@@ -2678,10 +2678,10 @@ public class KVMHost extends HostBase implements Host {
 
         MergeSnapshotCmd cmd = new MergeSnapshotCmd();
         cmd.setFullRebase(msg.isFullRebase());
-        cmd.setDestPath(volume.getInstallPath());
         cmd.setSrcPath(msg.getFrom() != null ? msg.getFrom().getPrimaryStorageInstallPath() : null);
         cmd.setVmUuid(volume.getVmInstanceUuid());
         cmd.setVolume(VolumeTO.valueOf(volume, (KVMHostInventory) getSelfInventory()));
+        cmd.setDestPath(cmd.getVolume().getInstallPath());
 
         extEmitter.beforeMergeSnapshot((KVMHostInventory) getSelfInventory(), msg, cmd);
         new Http<>(mergeSnapshotPath, cmd, MergeSnapshotRsp.class)


### PR DESCRIPTION
fix flatten volume failed on sblk because cannot getting backing file of top.

Resolves/Related: ZSTAC-74092

Change-Id: I656c63786e6a766b676964686e6e61636661617a

sync from gitlab !7653