### PR TITLE
<fix>[conf]: reset sharedblock qcow2 allocation

### DIFF
--- a/conf/db/upgrade/V4.10.10__schema.sql
+++ b/conf/db/upgrade/V4.10.10__schema.sql
@@ -5,3 +5,5 @@ UPDATE `zstack`.`ResourceVO` set `resourceType` = 'ThirdPartyAccountSourceVO' wh
 
 UPDATE `zstack`.`AlarmVO` SET `name` = 'Data Storage Available Capacity' WHERE `name` = 'Primary Storage Available Capacity';
 UPDATE `zstack`.`AlarmVO` SET `name` = 'Data Storage Available Physical Capacity' WHERE `name` = 'Primary Storage Available Physical Capacity';
+
+DELETE FROM `zstack`.`ResourceConfigVO` WHERE `category`='sharedblock' AND `name`='qcow2.allocation';


### PR DESCRIPTION
metadata is slow on volume backup.
none is fast on volume backup.
subcluster can resolve write amplification on empty volume.

so set allocation to default config: none.

DBImpact

Resolves: ZSV-8559
Resolves: ZSTAC-66340

Change-Id: I61646877736e676768627562627476686d79636d

sync from gitlab !7692