### PR TITLE
<fix>[compute]: introduce CreateVmComplementApiInterceptor

### DIFF
--- a/compute/src/main/java/org/zstack/compute/vm/CreateVmComplementApiInterceptor.java
+++ b/compute/src/main/java/org/zstack/compute/vm/CreateVmComplementApiInterceptor.java
@@ -1,0 +1,255 @@
+package org.zstack.compute.vm;
+
+import org.zstack.core.db.Q;
+import org.zstack.header.apimediator.ApiMessageInterceptionException;
+import org.zstack.header.apimediator.GlobalApiMessageInterceptor;
+import org.zstack.header.configuration.DiskOfferingVO;
+import org.zstack.header.configuration.DiskOfferingVO_;
+import org.zstack.header.image.ImageVO;
+import org.zstack.header.image.ImageVO_;
+import org.zstack.header.message.APIMessage;
+import org.zstack.header.vm.APICreateVmInstanceMsg;
+import org.zstack.header.vm.DiskAO;
+import org.zstack.header.vo.ResourceVO;
+import org.zstack.header.vo.ResourceVO_;
+
+import javax.persistence.Tuple;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.zstack.core.Platform.argerr;
+import static org.zstack.utils.CollectionDSL.list;
+import static org.zstack.utils.CollectionUtils.findOneOrNull;
+import static org.zstack.utils.CollectionUtils.isEmpty;
+
+public class CreateVmComplementApiInterceptor implements GlobalApiMessageInterceptor {
+
+    private static final List<String> VALID_DISK_SOURCE_TYPES = list(
+            "LunVO",
+            "IscsiLunVO",
+            "FiberChannelLunVO",
+            "VolumeVO"
+    );
+
+    @Override
+    public APIMessage intercept(APIMessage msg) throws ApiMessageInterceptionException {
+        if (msg instanceof APICreateVmInstanceMsg) {
+            validate((APICreateVmInstanceMsg) msg);
+        }
+        return msg;
+    }
+
+    private void validate(APICreateVmInstanceMsg msg) {
+        if (isEmpty(msg.getDiskAOs())) {
+            buildDiskAOList(msg);
+        }
+
+        completeDiskAOs(msg);
+    }
+
+    private void buildDiskAOList(APICreateVmInstanceMsg msg) {
+        int diskNum = isEmpty(msg.getDataDiskOfferingUuids()) ? 0 : msg.getDataDiskOfferingUuids().size();
+        diskNum += isEmpty(msg.getDataDiskSizes()) ? 0 : msg.getDataDiskSizes().size();
+        // include root volume
+        diskNum ++;
+
+        final ArrayList<DiskAO> disks = new ArrayList<>();
+        msg.setDiskAOs(disks);
+        for (int i = 0; i < diskNum; i++) {
+            disks.add(new DiskAO());
+            disks.get(i).setSystemTags(new ArrayList<>());
+        }
+
+        disks.get(0).setBoot(true);
+
+        // replace rootDiskSize by diskAOs[0].size
+        if (msg.getRootDiskSize() != null) {
+            disks.get(0).setSize(msg.getRootDiskSize());
+            msg.setRootDiskSize(null);
+        }
+
+        // replace rootDiskOfferingUuid by diskAOs[0].size
+        if (msg.getRootDiskOfferingUuid() != null) {
+            // skip account checker: diskOffering will be deprecated soon
+            List<Long> diskSizeList = Q.New(DiskOfferingVO.class)
+                    .eq(DiskOfferingVO_.uuid, msg.getRootDiskOfferingUuid())
+                    .select(DiskOfferingVO_.diskSize)
+                    .listValues();
+            if (diskSizeList.isEmpty()) {
+                throw new ApiMessageInterceptionException(
+                        argerr("rootDiskOfferingUuid[%s] is invalid, it must be a valid disk offering uuid",
+                        msg.getRootDiskOfferingUuid()));
+            }
+            disks.get(0).setSize(diskSizeList.get(0));
+            msg.setRootDiskOfferingUuid(null);
+        }
+
+        // replace dataDiskOfferingUuids by diskAOs[1..].size
+        if (!isEmpty(msg.getDataDiskOfferingUuids())) {
+            // skip account checker: diskOffering will be deprecated soon
+            List<Tuple> diskSizeTuples = Q.New(DiskOfferingVO.class)
+                    .in(DiskOfferingVO_.uuid, msg.getDataDiskOfferingUuids())
+                    .select(DiskOfferingVO_.uuid, DiskOfferingVO_.diskSize)
+                    .listTuple();
+
+            int index = 1;
+            for (String offeringUuid : msg.getDataDiskOfferingUuids()) {
+                Tuple tuple = findOneOrNull(diskSizeTuples, t -> t.get(0).equals(offeringUuid));
+                if (tuple == null) {
+                    throw new ApiMessageInterceptionException(
+                            argerr("dataDiskOfferingUuid[%s] is invalid, it must be a valid disk offering uuid",
+                            offeringUuid));
+                }
+
+                disks.get(index).setSize((long) tuple.get(1));
+                index++;
+            }
+
+            msg.setDataDiskOfferingUuids(null);
+        }
+
+        // replace dataDiskSizes by diskAOs[1..].size
+        if (!isEmpty(msg.getDataDiskSizes())) {
+            int index = disks.size() - msg.getDataDiskSizes().size();
+            for (Long size : msg.getDataDiskSizes()) {
+                disks.get(index).setSize(size);
+                index++;
+            }
+
+            msg.setDataDiskSizes(null);
+        }
+
+        // move rootVolumeSystemTags to diskAOs[0].systemTags
+        if (!isEmpty(msg.getRootVolumeSystemTags())) {
+            disks.get(0).getSystemTags().addAll(msg.getRootVolumeSystemTags());
+            msg.setRootVolumeSystemTags(null);
+        }
+
+        // move dataVolumeSystemTags to diskAOs[1..].systemTags
+        if (!isEmpty(msg.getDataVolumeSystemTags())) {
+            for (int i = 1; i < diskNum; i++) {
+                disks.get(i).getSystemTags().addAll(msg.getDataVolumeSystemTags());
+            }
+            msg.setDataVolumeSystemTags(null);
+        }
+
+        // move dataVolumeSystemTagsOnIndex to diskAOs[1..].systemTags
+        if (msg.getDataVolumeSystemTagsOnIndex() != null && msg.getDataVolumeSystemTagsOnIndex().isEmpty()) {
+            msg.getDataVolumeSystemTagsOnIndex().forEach((dataVolumeIndex, tags) -> {
+                if (isEmpty(tags)) {
+                    return;
+                }
+
+                int diskIndex = Integer.parseInt(dataVolumeIndex) + 1;
+                if (diskIndex >= disks.size() || diskIndex < 1) {
+                    throw new ApiMessageInterceptionException(
+                            argerr("dataVolumeSystemTagsOnIndex[%s] is invalid, it must be between 1 and %s",
+                            dataVolumeIndex, disks.size() - 1));
+                }
+
+                disks.get(diskIndex).getSystemTags().addAll(tags);
+            });
+            msg.setDataVolumeSystemTagsOnIndex(null);
+        }
+
+        // mark diskAOs[0].primaryStorageUuid by primaryStorageUuidForRootVolume
+        if (msg.getPrimaryStorageUuidForRootVolume() != null) {
+            disks.get(0).setPrimaryStorageUuid(msg.getPrimaryStorageUuidForRootVolume());
+        }
+
+        // mark diskAOs[0].platform by platform
+        if (msg.getPlatform() != null) {
+            disks.get(0).setPlatform(msg.getPlatform());
+        }
+
+        // mark diskAOs[0].guestOsType by guestOsType
+        if (msg.getGuestOsType() != null) {
+            disks.get(0).setGuestOsType(msg.getGuestOsType());
+        }
+
+        // mark diskAOs[0].architecture by architecture
+        if (msg.getArchitecture() != null) {
+            disks.get(0).setArchitecture(msg.getArchitecture());
+        }
+
+        // mark diskAOs[0].platform / guestOsType / architecture by imageUuid
+        if (msg.getImageUuid() != null) {
+            DiskAO bootDisk = disks.get(0);
+
+            ImageVO image = Q.New(ImageVO.class)
+                    .eq(ImageVO_.uuid, msg.getImageUuid())
+                    .find();
+            if (image == null) {
+                throw new ApiMessageInterceptionException(
+                        argerr("imageUuid[%s] is invalid, it must be a valid image uuid", msg.getImageUuid()));
+            }
+
+            bootDisk.withImage(msg.getImageUuid());
+            if (image.getPlatform() != null && bootDisk.getPlatform() == null) {
+                bootDisk.setPlatform(image.getPlatform().toString());
+            }
+            if (image.getGuestOsType() != null && bootDisk.getGuestOsType() == null) {
+                bootDisk.setGuestOsType(image.getGuestOsType());
+            }
+            if (image.getArchitecture() != null && bootDisk.getArchitecture() == null) {
+                bootDisk.setArchitecture(image.getArchitecture());
+            }
+        }
+    }
+
+    private void completeDiskAOs(APICreateVmInstanceMsg msg) {
+        for (DiskAO disk : msg.getDiskAOs()) {
+            if (disk.getSourceType() == null && disk.getSourceUuid() != null) {
+                String resourceType = Q.New(ResourceVO.class)
+                        .eq(ResourceVO_.uuid, disk.getSourceUuid())
+                        .select(ResourceVO_.resourceType)
+                        .findValue();
+                if (resourceType == null) {
+                    throw new ApiMessageInterceptionException(
+                            argerr("sourceUuid[%s] is invalid, it must be a valid resource uuid", disk.getSourceUuid()));
+                }
+
+                if (!VALID_DISK_SOURCE_TYPES.contains(resourceType)) {
+                    throw new ApiMessageInterceptionException(
+                            argerr("sourceUuid[%s] is invalid, it must be a valid %s uuid", disk.getSourceUuid(),
+                                    String.join(" or ", VALID_DISK_SOURCE_TYPES)));
+                }
+                disk.setSourceType(resourceType);
+            }
+        }
+
+        final DiskAO bootDisk = msg.findBootDisk();
+        if (bootDisk == null) {
+            throw new ApiMessageInterceptionException(argerr("missing root disk"));
+        }
+
+        String platform = msg.getPlatform() == null ? bootDisk.getPlatform() : msg.getPlatform();
+        msg.setPlatform(platform);
+        bootDisk.setPlatform(platform);
+
+        String guestOsType = msg.getGuestOsType() == null ? bootDisk.getGuestOsType() : msg.getGuestOsType();
+        msg.setGuestOsType(guestOsType);
+        bootDisk.setGuestOsType(guestOsType);
+
+        String architecture = msg.getArchitecture() == null ? bootDisk.getArchitecture() : msg.getArchitecture();
+        msg.setArchitecture(architecture);
+        bootDisk.setArchitecture(architecture);
+    }
+
+    @Override
+    @SuppressWarnings("rawtypes")
+    public List<Class> getMessageClassToIntercept() {
+        return list(APICreateVmInstanceMsg.class);
+    }
+
+    @Override
+    public InterceptorPosition getPosition() {
+        return InterceptorPosition.SYSTEM;
+    }
+
+    @Override
+    public int getPriority() {
+        // before ApiParamValidator
+        return -2;
+    }
+}

--- a/compute/src/main/java/org/zstack/compute/vm/VmInstanceApiInterceptor.java
+++ b/compute/src/main/java/org/zstack/compute/vm/VmInstanceApiInterceptor.java
@@ -1106,14 +1106,10 @@ public class VmInstanceApiInterceptor implements ApiMessageInterceptor {
         }
     }
 
-    private void validateRootDiskOffering(ImageMediaType imgFormat, APICreateVmInstanceMsg msg) throws ApiMessageInterceptionException {
+    private void validateRootDiskOffering(ImageMediaType imgFormat, DiskAO rootDisk) throws ApiMessageInterceptionException {
         if (imgFormat == ImageMediaType.ISO) {
-            if (msg.getRootDiskOfferingUuid() == null) {
-                if (msg.getRootDiskSize() == null) {
-                    throw new ApiMessageInterceptionException(argerr("image mediaType is ISO but missing root disk settings"));
-                }
-
-                if (msg.getRootDiskSize() <= 0) {
+            if (rootDisk.getDiskOfferingUuid() == null) {
+                if (rootDisk.getSize() <= 0L) {
                     throw new ApiMessageInterceptionException(operr("Unexpected root disk settings"));
                 }
             }
@@ -1121,7 +1117,15 @@ public class VmInstanceApiInterceptor implements ApiMessageInterceptor {
     }
 
     private void validatePsWhetherSameCluster(APICreateVmInstanceMsg msg) {
-        if (msg.getPrimaryStorageUuidForRootVolume() == null || msg.getSystemTags() == null || msg.getSystemTags().isEmpty()) {
+        String psUuid = msg.getPrimaryStorageUuidForRootVolume();
+        if (psUuid == null) {
+            psUuid = msg.findBootDisk().getPrimaryStorageUuid();
+            if (psUuid == null) {
+                return;
+            }
+        }
+
+        if (msg.getSystemTags() == null || msg.getSystemTags().isEmpty()) {
             return;
         }
 
@@ -1130,7 +1134,7 @@ public class VmInstanceApiInterceptor implements ApiMessageInterceptor {
             return;
         }
 
-        List<String> clusterUuidsForRootVolume = Q.New(PrimaryStorageClusterRefVO.class).select(PrimaryStorageClusterRefVO_.clusterUuid).eq(PrimaryStorageClusterRefVO_.primaryStorageUuid, msg.getPrimaryStorageUuidForRootVolume()).listValues();
+        List<String> clusterUuidsForRootVolume = Q.New(PrimaryStorageClusterRefVO.class).select(PrimaryStorageClusterRefVO_.clusterUuid).eq(PrimaryStorageClusterRefVO_.primaryStorageUuid, psUuid).listValues();
         List<String> clusterUuidsForDataVolume = Q.New(PrimaryStorageClusterRefVO.class).select(PrimaryStorageClusterRefVO_.clusterUuid).eq(PrimaryStorageClusterRefVO_.primaryStorageUuid, primaryStorageUuidForDataVolume).listValues();
 
         clusterUuidsForRootVolume.retainAll(clusterUuidsForDataVolume);
@@ -1187,12 +1191,12 @@ public class VmInstanceApiInterceptor implements ApiMessageInterceptor {
         }
     }
 
-    private void validateDataDiskSizes(APICreateVmInstanceMsg msg) throws ApiMessageInterceptionException {
-        if (CollectionUtils.isEmpty(msg.getDataDiskSizes())) {
+    private void validateDataDiskSizes(List<DiskAO> nonRootDisks) throws ApiMessageInterceptionException {
+        if (CollectionUtils.isEmpty(nonRootDisks)) {
             return;
         }
-        msg.getDataDiskSizes().forEach(dataDiskSize -> {
-            if (dataDiskSize <= 0) {
+        nonRootDisks.forEach(disks -> {
+            if (disks.getSize() <= 0) {
                 throw new ApiMessageInterceptionException(operr("Unexpected data disk settings. dataDiskSizes need to be greater than 0"));
             }
         });
@@ -1202,18 +1206,12 @@ public class VmInstanceApiInterceptor implements ApiMessageInterceptor {
         boolean virtIOTagExists = (isEmpty(msg.getSystemTags())) ? false :
                 msg.getSystemTags().contains(VmSystemTags.VIRTIO.getTagFormat());
 
-        if (CollectionUtils.isNotEmpty(msg.getDiskAOs())) {
-            DiskAO rootDiskAO = msg.getDiskAOs().stream()
-                    .filter(DiskAO::isBoot).findFirst().orElse(null);
-            if (rootDiskAO == null) {
-                throw new ApiMessageInterceptionException(argerr("missing root disk"));
-            }
-            msg.setPlatform(rootDiskAO.getPlatform());
-            msg.setGuestOsType(rootDiskAO.getGuestOsType());
-            msg.setArchitecture(rootDiskAO.getArchitecture());
-            if (!virtIOTagExists && CollectionUtils.isNotEmpty(rootDiskAO.getSystemTags())) {
-                virtIOTagExists = rootDiskAO.getSystemTags().contains(VmSystemTags.VIRTIO.getTagFormat());
-            }
+        DiskAO rootDisk = msg.findBootDisk();
+        if (rootDisk == null) {
+            throw new ApiMessageInterceptionException(argerr("missing root disk"));
+        }
+        if (!virtIOTagExists && CollectionUtils.isNotEmpty(rootDisk.getSystemTags())) {
+            virtIOTagExists = rootDisk.getSystemTags().contains(VmSystemTags.VIRTIO.getTagFormat());
         }
 
         if (virtIOTagExists && msg.getVirtio() == Boolean.FALSE) {
@@ -1222,22 +1220,30 @@ public class VmInstanceApiInterceptor implements ApiMessageInterceptor {
             msg.setVirtio(true);
         }
 
-        ImageVO image = Q.New(ImageVO.class).eq(ImageVO_.uuid, msg.getImageUuid()).find();
+        String imageUuid = msg.getImageUuid();
+        if (imageUuid == null) {
+            imageUuid = rootDisk.getTemplateUuid();
+        }
+
+        ImageVO image = Q.New(ImageVO.class)
+                .eq(ImageVO_.uuid, imageUuid)
+                .find();
+
         if (image == null) {
             List<String> errorList = new ArrayList<>();
-            if (msg.getPlatform() == null) {
+            if (rootDisk.getPlatform() == null) {
                 errorList.add(Platform.missingVariables("platform"));
             }
 
-            if (msg.getGuestOsType() == null) {
+            if (rootDisk.getGuestOsType() == null) {
                 errorList.add(Platform.missingVariables("guestOsType"));
             }
 
-            if (msg.getArchitecture() == null) {
+            if (rootDisk.getArchitecture() == null) {
                 errorList.add(Platform.missingVariables("architecture"));
             }
 
-            if (msg.getRootDiskOfferingUuid() == null && msg.getRootDiskSize() == null) {
+            if (rootDisk.getDiskOfferingUuid() == null && rootDisk.getSize() <= 0L) {
                 errorList.add("rootDiskOfferingUuid or rootDiskSize cannot be all null");
             }
 
@@ -1278,24 +1284,17 @@ public class VmInstanceApiInterceptor implements ApiMessageInterceptor {
                 throw new ApiMessageInterceptionException(operr("at least one of field architecture in msg or image[uuid:%s] should be set", msg.getImageUuid()));
             }
 
-            validateRootDiskOffering(imgFormat, msg);
+            validateRootDiskOffering(imgFormat, rootDisk);
+        }
 
-            if (msg.getVirtio() == null) {
-                if (image.getVirtio() != null) {
-                    msg.setVirtio(image.getVirtio());
-                }
+        validateDataDiskSizes(msg.findAllNonBootDisks());
+
+        List<String> allDiskOfferingUuids = new ArrayList<>();
+        msg.getDiskAOs().forEach(disk -> {
+            if (disk.getDiskOfferingUuid() != null) {
+                allDiskOfferingUuids.add(disk.getDiskOfferingUuid());
             }
-        }
-
-        validateDataDiskSizes(msg);
-
-        List<String> allDiskOfferingUuids = new ArrayList<String>();
-        if (msg.getRootDiskOfferingUuid() != null) {
-            allDiskOfferingUuids.add(msg.getRootDiskOfferingUuid());
-        }
-        if (msg.getDataDiskOfferingUuids() != null) {
-            allDiskOfferingUuids.addAll(msg.getDataDiskOfferingUuids());
-        }
+        });
 
         if (!allDiskOfferingUuids.isEmpty()) {
             SimpleQuery<DiskOfferingVO> dq = dbf.createQuery(DiskOfferingVO.class);
@@ -1309,7 +1308,7 @@ public class VmInstanceApiInterceptor implements ApiMessageInterceptor {
         }
 
         validatePsWhetherSameCluster(msg);
-        validateDataDiskAOs(msg);
+        validateDataDiskAOs(msg.findAllNonBootDisks());
 
         if (msg.getAllocatorStrategy() != null && !HostAllocatorStrategyType.hasType(msg.getAllocatorStrategy())) {
             throw new ApiMessageInterceptionException(
@@ -1317,15 +1316,9 @@ public class VmInstanceApiInterceptor implements ApiMessageInterceptor {
         }
     }
 
-    private void validateDataDiskAOs(APICreateVmInstanceMsg msg) {
-        if (CollectionUtils.isEmpty(msg.getDiskAOs())) {
-            return;
-        }
-        for (DiskAO diskAO : msg.getDiskAOs()) {
-            if (diskAO.isBoot()) {
-                continue;
-            }
-            checkMutualExclusion(diskAO);
+    private void validateDataDiskAOs(List<DiskAO> nonBootDisks) {
+        for (DiskAO disk : nonBootDisks) {
+            checkMutualExclusion(disk);
         }
     }
 

--- a/conf/springConfigXml/VmInstanceManager.xml
+++ b/conf/springConfigXml/VmInstanceManager.xml
@@ -186,6 +186,12 @@
         </zstack:plugin>
     </bean>
 
+    <bean id="CreateVmComplementApiInterceptor" class="org.zstack.compute.vm.CreateVmComplementApiInterceptor">
+        <zstack:plugin>
+            <zstack:extension interface="org.zstack.header.apimediator.GlobalApiMessageInterceptor" />
+        </zstack:plugin>
+    </bean>
+
     <bean id="VmCascadeExtension" class="org.zstack.compute.vm.VmCascadeExtension">
         <zstack:plugin>
 			<zstack:extension interface="org.zstack.core.cascade.CascadeExtensionPoint" />

--- a/header/src/main/java/org/zstack/header/vm/APICreateVmInstanceMsg.java
+++ b/header/src/main/java/org/zstack/header/vm/APICreateVmInstanceMsg.java
@@ -22,6 +22,8 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import static org.zstack.utils.CollectionDSL.list;
+import static org.zstack.utils.CollectionUtils.filter;
+import static org.zstack.utils.CollectionUtils.findOneOrNull;
 
 /**
  * @api create a new vm instance
@@ -224,6 +226,14 @@ public class APICreateVmInstanceMsg extends APICreateMessage implements APIAudit
 
     @APIParam(required = false)
     private List<DiskAO> diskAOs;
+
+    public DiskAO findBootDisk() {
+        return findOneOrNull(diskAOs, DiskAO::isBoot);
+    }
+
+    public List<DiskAO> findAllNonBootDisks() {
+        return filter(diskAOs, disk -> !disk.isBoot());
+    }
 
     public List<DiskAO> getDiskAOs() {
         return diskAOs;

--- a/storage/src/main/java/org/zstack/storage/volume/VolumeApiInterceptor.java
+++ b/storage/src/main/java/org/zstack/storage/volume/VolumeApiInterceptor.java
@@ -630,10 +630,6 @@ public class VolumeApiInterceptor implements ApiMessageInterceptor, Component, G
 
     @Transactional
     protected void validate(APICreateVmInstanceMsg msg) {
-        if (CollectionUtils.isEmpty(msg.getDiskAOs())) {
-            return;
-        }
-
         List<String> volumeUuids = msg.getDiskAOs().stream()
                 .filter(diskAO -> Objects.equals(diskAO.getSourceType(), VolumeVO.class.getSimpleName()))
                 .map(DiskAO::getSourceUuid).collect(Collectors.toList());


### PR DESCRIPTION
CreateVmComplementApiInterceptor used to build
APICreateVmInstanceMsg.diskAOs from deprecated
fields values.

Resolves: ZSV-8585

Change-Id: I6f6c7577636479776b796a6b67717070707a7074

sync from gitlab !7739