### PR TITLE
<fix>[mevoco]: numa enable tag only support value=true

### DIFF
--- a/conf/db/upgrade/V4.10.10__schema.sql
+++ b/conf/db/upgrade/V4.10.10__schema.sql
@@ -7,3 +7,5 @@ UPDATE `zstack`.`AlarmVO` SET `name` = 'Data Storage Available Capacity' WHERE `
 UPDATE `zstack`.`AlarmVO` SET `name` = 'Data Storage Available Physical Capacity' WHERE `name` = 'Primary Storage Available Physical Capacity';
 
 DELETE FROM `zstack`.`ResourceConfigVO` WHERE `category`='sharedblock' AND `name`='qcow2.allocation';
+
+DELETE FROM `zstack`.`SystemTagVO` WHERE `tag`='vmNumaEnable::false' AND `resourceType`='VmInstanceVO';

--- a/conf/i18n/messages_en_US.properties
+++ b/conf/i18n/messages_en_US.properties
@@ -3676,7 +3676,7 @@ No\ host\ is\ available\ to\ create\ vm\ Instance.Because\ vNuma\ vms\ need\ to\
 
 # at: src/main/java/org/zstack/compute/vm/numa/VmNumaManagerImpl.java:92
 # args: 
-fail\ to\ set\ vm\ numa,\ incorrect\ input\ format,only\ accept\ true\ or\ false = fail to set vm numa, incorrect input format,only accept true or false
+fail\ to\ set\ vm\ numa,\ incorrect\ input\ format,\ only\ accept\ true = fail to set vm numa, incorrect input format, only accept "true"
 
 # at: src/main/java/org/zstack/compute/vm/numa/VmNumaUtils.java:46
 # args: word

--- a/conf/i18n/messages_zh_CN.properties
+++ b/conf/i18n/messages_zh_CN.properties
@@ -3676,7 +3676,7 @@ No\ host\ is\ available\ to\ create\ vm\ Instance.Because\ vNuma\ vms\ need\ to\
 
 # at: src/main/java/org/zstack/compute/vm/numa/VmNumaManagerImpl.java:92
 # args: 
-fail\ to\ set\ vm\ numa,\ incorrect\ input\ format,only\ accept\ true\ or\ false = 无法设置VM NUMA，输入格式不正确，仅接受TRUE或FALSE
+fail\ to\ set\ vm\ numa,\ incorrect\ input\ format,\ only\ accept\ true = 无法设置VM NUMA，输入格式不正确，仅接受参数true
 
 # at: src/main/java/org/zstack/compute/vm/numa/VmNumaUtils.java:46
 # args: word


### PR DESCRIPTION
"vmNumaEnable::false" is invalid.
If VM numa is disabled, vmNumaEnable tag will be deleted.

Resolves: ZSV-7461

DBImpact

Change-Id: I747868687763696f6c716d706772766b6c6b6680

sync from gitlab !7753