### PR TITLE
<fix>[migration]: fix attach data volume to vm failed

### DIFF
--- a/conf/springConfigXml/HostAllocatorManager.xml
+++ b/conf/springConfigXml/HostAllocatorManager.xml
@@ -173,6 +173,7 @@
                 <value>org.zstack.compute.allocator.HostStateAndHypervisorAllocatorFlow</value>
                 <value>org.zstack.compute.allocator.ImageBackupStorageAllocatorFlow</value>
                 <value>org.zstack.compute.allocator.HostCapacityAllocatorFlow</value>
+                <value>org.zstack.compute.allocator.AttachedVolumePrimaryStorageAllocatorFlow</value>
                 <value>org.zstack.compute.allocator.HostPrimaryStorageAllocatorFlow</value>
                 <value>org.zstack.compute.allocator.AvoidHostAllocatorFlow</value>
                 <value>org.zstack.compute.allocator.TagAllocatorFlow</value>


### PR DESCRIPTION
add AttachedVolumePrimaryStorageAllocatorFlow into DefaultHostAllocatorStrategyFactory

Resolves/Related: ZSTAC-71738

Change-Id: I66616867656579676b6c717967677670656b7062

sync from gitlab !7804