### PR TITLE
<fix>[sdk]: support multiple date formats for HTTP headers and allow custom...

### DIFF
--- a/rest/src/main/java/org/zstack/rest/RestServer.java
+++ b/rest/src/main/java/org/zstack/rest/RestServer.java
@@ -162,8 +162,37 @@ public class RestServer implements Component, CloudBusEventListener {
         }
 
         formatter = new DateTimeFormatterBuilder()
-                .parseCaseInsensitive()
-                .appendPattern("EEE, dd MMM yyyy HH:mm:ss z")
+                .parseCaseInsensitive() // Allows parsing of month names and day periods (e.g., "Jan" or "JAN", "AM" or "am") in a case-insensitive manner.
+
+                // Common RFC 1123-like format with two-digit day and time zone name (e.g., "Thu, 26 Oct 2023 10:30:00 GMT").
+                // Note: The 'z' pattern has limited support for time zone names (e.g., typically parses "GMT" but not full IDs like "Asia/Shanghai").
+                .appendOptional(DateTimeFormatter.ofPattern("EEE, dd MMM yyyy HH:mm:ss z", Locale.ENGLISH))
+
+                // Standard RFC 1123 date-time formatter, commonly used in HTTP headers.
+                // It handles single-digit days (e.g., '5 Jun') and formats time zones as offsets (e.g., '+0800') or 'GMT'.
+                // Example: "Thu, 5 Jun 2025 15:47:29 +0800".
+                .appendOptional(DateTimeFormatter.RFC_1123_DATE_TIME)
+
+                // ISO 8601 (International Organization for Standardization standard)
+                // Appends the ISO-8601 date-time formatter with an offset from UTC. Example: "2023-10-26T10:30:00+08:00".
+                .appendOptional(DateTimeFormatter.ISO_OFFSET_DATE_TIME)
+
+                // Appends a custom formatter for date-time with milliseconds and a two-character ISO-8601 offset. Example: "2023-10-26T10:30:00.123+08".
+                .appendOptional(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSxx", Locale.ENGLISH))
+
+                // Appends a custom formatter for date-time with milliseconds and a four-digit offset (e.g., "+0800"). Example: "2023-10-26T10:30:00.123+0800".
+                .appendOptional(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSZ", Locale.ENGLISH))
+
+                // Appends a custom formatter for date-time with a colon-separated ISO-8601 extended offset. Example: "2023-10-26T10:30:00+08:00".
+                .appendOptional(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ssXXX", Locale.ENGLISH))
+
+                // Appends a custom formatter for date-time (no milliseconds) with a two-character ISO-8601 offset. Example: "2023-10-26T10:30:00+08".
+                .appendOptional(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ssxx", Locale.ENGLISH))
+
+                // Appends a custom formatter for date-time (no milliseconds) with a four-digit offset. Example: "2023-10-26T10:30:00+0800".
+                .appendOptional(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ssZ", Locale.ENGLISH))
+
+                // Completes the builder and creates the final DateTimeFormatter, ensuring that English locale rules are used for parsing (e.g., for month names).
                 .toFormatter(Locale.ENGLISH);
     }
 
@@ -1060,7 +1089,10 @@ public class RestServer implements Component, CloudBusEventListener {
         try {
             date = ZonedDateTime.parse(dateStr, formatter);
         } catch (RuntimeException e) {
-            throw new RestException(HttpStatus.BAD_REQUEST.value(), "'Date' format error, correct format is 'EEE, dd MMM yyyy HH:mm:ss z'");
+            throw new RestException(HttpStatus.BAD_REQUEST.value(),
+                    "Date format error. The 'Date' header must conform to one of the supported RFC 1123 or ISO 8601 formats. " +
+                            "Examples include: 'Thu, 5 Jun 2025 15:47:29 +0800', '2025-06-05T16:08:42+08:00', or '2025-06-05T16:08:42.123Z'."
+            );
         }
 
         ZonedDateTime now = ZonedDateTime.now();

--- a/sdk/src/main/java/org/zstack/sdk/ZSClient.java
+++ b/sdk/src/main/java/org/zstack/sdk/ZSClient.java
@@ -383,8 +383,15 @@ public class ZSClient {
 
         private void calculateAccessKeySignature(Request.Builder reqBuilder, String accessKeyId, String accessKeySecret, String path) throws Exception {
             ZonedDateTime date = ZonedDateTime.now();
-            String dateStr = date.format(formatter);
+            DateTimeFormatter fmt = formatter;
+            if (getConfig() != null && getConfig().accessKeyDateStr != null) {
+                fmt = new DateTimeFormatterBuilder()
+                        .parseCaseInsensitive()
+                        .appendPattern(getConfig().accessKeyDateStr)
+                        .toFormatter(Locale.ENGLISH);
+            }
 
+            String dateStr = date.format(fmt);
             StringBuilder sb = new StringBuilder();
             sb.append(info.httpMethod).append("\n");
             sb.append(dateStr).append("\n").append("/v1").append(path);

--- a/sdk/src/main/java/org/zstack/sdk/ZSConfig.java
+++ b/sdk/src/main/java/org/zstack/sdk/ZSConfig.java
@@ -14,6 +14,7 @@ public class ZSConfig {
     Long readTimeout;
     Long writeTimeout;
     String contextPath;
+    String accessKeyDateStr;
 
     public String getHostname() {
         return hostname;
@@ -74,6 +75,10 @@ public class ZSConfig {
             return this;
         }
 
+        public Builder setAccessKeyDateStr(String name) {
+            config.accessKeyDateStr = name;
+            return this;
+        }
 
         public ZSConfig build() {
             return config;


### PR DESCRIPTION
<fix>[sdk]: support multiple date formats for HTTP headers and allow custom date format in SDK signature

Resolves: ZSTAC-75469

Change-Id: I6662617a73786979676768697a67736f6e6b6e65

sync from gitlab !7890