### PR TITLE
<fix>[storage]: trash top after storage live migration

### DIFF
--- a/header/src/main/java/org/zstack/header/storage/snapshot/VolumeSnapshotTree.java
+++ b/header/src/main/java/org/zstack/header/storage/snapshot/VolumeSnapshotTree.java
@@ -348,6 +348,7 @@ public class VolumeSnapshotTree {
 
     private SnapshotLeaf root;
     private String volumeUuid;
+    private String uuid;
 
     public static VolumeSnapshotTree fromInventories(List<VolumeSnapshotInventory> invs) {
         VolumeSnapshotTree tree = new VolumeSnapshotTree();
@@ -377,6 +378,7 @@ public class VolumeSnapshotTree {
             }
 
             tree.volumeUuid = inv.getVolumeUuid();
+            tree.uuid = inv.getTreeUuid();
         }
 
         DebugUtils.Assert(tree.root != null, "why tree root is null???");
@@ -403,6 +405,14 @@ public class VolumeSnapshotTree {
         this.volumeUuid = volumeUuid;
     }
 
+    public String getUuid() {
+        return uuid;
+    }
+
+    public void setUuid(String uuid) {
+        this.uuid = uuid;
+    }
+
     private SnapshotLeaf findSnapshot(final List<SnapshotLeaf> leafs, final Function<Boolean, VolumeSnapshotInventory> func) {
         for (SnapshotLeaf leaf : leafs) {
             SnapshotLeaf ret = findSnapshot(leaf.children, func);
@@ -423,5 +433,13 @@ public class VolumeSnapshotTree {
             return root;
         }
         return findSnapshot(root.children, func);
+    }
+
+    public SnapshotLeaf findSnapshot(String snapshotUuid) {
+        if (snapshotUuid == null) {
+            return null;
+        }
+
+        return findSnapshot(arg -> arg.getUuid().equals(snapshotUuid));
     }
 }

--- a/header/src/main/java/org/zstack/header/storage/snapshot/reference/VolumeSnapshotReferenceInventory.java
+++ b/header/src/main/java/org/zstack/header/storage/snapshot/reference/VolumeSnapshotReferenceInventory.java
@@ -36,6 +36,9 @@ public class VolumeSnapshotReferenceInventory {
 
     private String directSnapshotInstallUrl;
 
+    /**
+     * the UUID of resource referencing @volumeUuid.
+     */
     private String referenceUuid;
 
     private String referenceType;

--- a/header/src/main/java/org/zstack/header/storage/snapshot/reference/VolumeSnapshotReferenceVO.java
+++ b/header/src/main/java/org/zstack/header/storage/snapshot/reference/VolumeSnapshotReferenceVO.java
@@ -52,6 +52,9 @@ public class VolumeSnapshotReferenceVO {
     private Long parentId;
 
 
+    /**
+     * the UUID of resource referencing @volumeUuid.
+     */
     @Column
     private String referenceUuid;
 

--- a/storage/src/main/java/org/zstack/storage/snapshot/reference/VolumeSnapshotReferenceUtils.java
+++ b/storage/src/main/java/org/zstack/storage/snapshot/reference/VolumeSnapshotReferenceUtils.java
@@ -82,33 +82,55 @@ public class VolumeSnapshotReferenceUtils {
         return null;
     }
 
-    public static List<String> getVolumeInstallUrlsReferenceByOtherVolumes(String volumeUuid) {
+    // use getVolumeAllSnapshotsReferencedOtherVolumes or isVolumeDirectlyReferenceByOthers
+    @Deprecated
+    public static List<String> getVolumeSnapshotsReferencedByOtherVolumes(String volumeUuid) {
         return getVolumeReferenceRef(volumeUuid).stream()
                 .map(VolumeSnapshotReferenceVO::getVolumeSnapshotInstallUrl).distinct()
                 .collect(Collectors.toList());
     }
 
     // get volume snapshotUuids referenced by other volumes directly or indirectly
+    // FIXME split different primary storage snapshot reference
     public static Set<String> getVolumeAllSnapshotsReferencedByOtherVolumes(String volumeUuid) {
-        List<String> refVolumeSnapshotUuids = getVolumeReferenceRef(volumeUuid).stream()
-                .map(VolumeSnapshotReferenceVO::getVolumeSnapshotUuid).distinct()
-                .collect(Collectors.toList());
-        if (refVolumeSnapshotUuids.isEmpty()) {
+        Set<String> refSnapshotUuids = getVolumeReferenceRef(volumeUuid).stream()
+                .map(VolumeSnapshotReferenceVO::getVolumeSnapshotUuid)
+                .collect(Collectors.toSet());
+        if (refSnapshotUuids.isEmpty()) {
             return Collections.emptySet();
         }
 
         List<VolumeSnapshotVO> allSnapshots = Q.New(VolumeSnapshotVO.class).eq(VolumeSnapshotVO_.volumeUuid, volumeUuid).list();
-
-        Map<String, List<VolumeSnapshotVO>> treeSnapshotsMap = allSnapshots.stream().collect(Collectors.groupingBy(VolumeSnapshotVO::getTreeUuid));
-        List<String> refVolumeSnapshotUuidsInTree = new ArrayList<>();
-        for (VolumeSnapshotVO refSnapshot : allSnapshots.stream().filter(sp -> refVolumeSnapshotUuids.contains(sp.getUuid())).collect(Collectors.toList())) {
-            refVolumeSnapshotUuidsInTree.add(refSnapshot.getUuid());
-            VolumeSnapshotTree tree = VolumeSnapshotTree.fromVOs(treeSnapshotsMap.get(refSnapshot.getTreeUuid()));
-            VolumeSnapshotTree.SnapshotLeaf snapshotLeaf = tree.findSnapshot(arg -> arg.getUuid().equals(refSnapshot.getUuid()));
-            refVolumeSnapshotUuidsInTree.addAll(snapshotLeaf.getAncestors().stream()
-                    .map(VolumeSnapshotInventory::getUuid).collect(Collectors.toList()));
+        // snapshotUuid in VolumeSnapshotReferenceVO may not exist in VolumeSnapshotVO,
+        // maybe because the snapshot has been deleted db only after volume migration,
+        // so we need to filter them out
+        refSnapshotUuids.retainAll(allSnapshots.stream().map(VolumeSnapshotVO::getUuid).collect(Collectors.toSet()));
+        if (refSnapshotUuids.isEmpty()) {
+            return Collections.emptySet();
         }
-        return new HashSet<>(refVolumeSnapshotUuidsInTree);
+
+        Set<String> allRefSnapshotUuids = new HashSet<>(refSnapshotUuids);
+        Map<String, VolumeSnapshotTree> trees = allSnapshots.stream()
+                .collect(Collectors.groupingBy(VolumeSnapshotVO::getTreeUuid, Collectors.toList()))
+                .values().stream()
+                .collect(Collectors.toMap(
+                        snaps -> snaps.get(0).getTreeUuid(),
+                        VolumeSnapshotTree::fromVOs
+                ));
+
+        List<VolumeSnapshotVO> refSnapshots = allSnapshots.stream()
+                .filter(sp -> refSnapshotUuids.contains(sp.getUuid()))
+                .collect(Collectors.toList());
+        for (VolumeSnapshotVO refSnapshot : refSnapshots) {
+            Set<String> ancestorUuids = trees.get(refSnapshot.getTreeUuid())
+                    .findSnapshot(refSnapshot.getUuid())
+                    .getAncestors().stream()
+                    .map(VolumeSnapshotInventory::getUuid)
+                    .collect(Collectors.toSet());
+            allRefSnapshotUuids.addAll(ancestorUuids);
+        }
+
+        return allRefSnapshotUuids;
     }
 
     public static List<VolumeInventory> getReferenceVolume(String volumeUuid) {


### PR DESCRIPTION
top is unused after storage migration even if
its snapshot referenced by other volumes.

only skip trash volume when its snapshots are inner snapshot.

Resolves: ZSTAC-71514

Change-Id: I636b6d726d6c757478737869726f6a777a736663

sync from gitlab !7895