### PR TITLE
<fix>[sdk]: ping ZCE-X by new url path

### DIFF
--- a/sdk/src/main/java/org/zstack/sdk/zcex/api/ZceXTestConnectionAction.java
+++ b/sdk/src/main/java/org/zstack/sdk/zcex/api/ZceXTestConnectionAction.java
@@ -32,7 +32,7 @@ public class ZceXTestConnectionAction extends AbstractAction {
     public java.lang.Integer port = 8056;
 
     @Param(required = false, nonempty = false, nullElements = false, emptyString = false, noTrim = false)
-    public java.lang.String url = "/";
+    public java.lang.String url = "/api/v1/cluster/time";
 
     @Param(required = false)
     public java.util.List systemTags;


### PR DESCRIPTION
Ping ZCE-X path update to "/api/v1/cluster/time"

Resolves: ZSV-8959
Related: ZSV-7444

Change-Id: I6e7979776a677062727071717465626674746768
(cherry picked from commit 18216a47c5d7a3e9e5054ffc32f36733efababa9)

sync from gitlab !7939