### PR TITLE
<fix>[host]: Write to fstab using the disk's UUID

### DIFF
--- a/compute/src/main/java/org/zstack/compute/host/HostApiInterceptor.java
+++ b/compute/src/main/java/org/zstack/compute/host/HostApiInterceptor.java
@@ -25,6 +25,8 @@ import org.zstack.utils.gson.JSONObjectUtil;
 import org.zstack.utils.logging.CLogger;
 import org.zstack.utils.network.NetworkUtils;
 
+import java.util.Set;
+
 import static org.zstack.core.Platform.argerr;
 import static org.zstack.core.Platform.operr;
 
@@ -162,6 +164,57 @@ public class HostApiInterceptor implements ApiMessageInterceptor {
         }
         msg.setPassword(proxyHardware.getPassword());
         msg.setUsername(msg.getUsername() != null ? msg.getUsername() : proxyHardware.getUsername());
+
+        validatePath(msg.getPath());
+        validateMountPoint(msg.getMountPoint());
+    }
+
+    private void validatePath(String path) {
+        if (path == null || path.isEmpty()) {
+            throw new IllegalArgumentException("path cannot be empty");
+        }
+
+        if (!path.startsWith("/")) {
+            throw new SecurityException("only absolute paths are allowed");
+        }
+
+        if (path.contains("..") || path.contains("//")) {
+            throw new SecurityException("invalid path traversal detected");
+        }
+    }
+
+    private void validateMountPoint(String mountPoint) {
+        if (mountPoint == null || mountPoint.isEmpty()) {
+            throw new IllegalArgumentException("mountPoint cannot be empty");
+        }
+
+        if (!mountPoint.startsWith("/")) {
+            throw new SecurityException("mount point must be an absolute path (start with '/')");
+        }
+
+        if (mountPoint.contains("..") || mountPoint.contains("//")) {
+            throw new SecurityException("path traversal detected in mount point");
+        }
+
+        String safePattern = "^[a-zA-Z0-9_\\-./]+$";
+        if (!mountPoint.matches(safePattern)) {
+            throw new SecurityException(
+                    "the mount point must strictly follow the security pattern: '^[a-zA-Z0-9_\\-./]+$'. " +
+                            "this requires: \n" +
+                            "1. only alphanumeric characters [a-z, A-Z, 0-9]\n" +
+                            "2. limited special characters: hyphen (-), underscore (_), period (.), and forward slash (/)\n" +
+                            "3. must be a valid absolute path starting with '/'\n\n" +
+                            "valid examples:\n" +
+                            "  - /mnt/data\n" +
+                            "  /volumes/drive01\n" +
+                            "  /backup-2023.disk\n\n" +
+                            "invalid value detected: '" + mountPoint + "'"
+            );
+        }
+
+        if (mountPoint.endsWith("/") && !mountPoint.equals("/")) {
+            throw new SecurityException("mountPoint should not end with '/' except root directory");
+        }
     }
 
     private ProxyHardware getProxyHardware(String hostname) {

--- a/compute/src/main/java/org/zstack/compute/host/HostManagerImpl.java
+++ b/compute/src/main/java/org/zstack/compute/host/HostManagerImpl.java
@@ -536,37 +536,75 @@ public class HostManagerImpl extends AbstractService implements HostManager, Man
             return;
         }
 
-        List<String> commands = new ArrayList<>();
-        commands.add(String.format("mkdir -p '%s'", msg.getMountPoint()));
-        commands.add(buildMkfsCommd(msg.getFilesystemType(), msg.getPath()));
-        commands.add(String.format("mount | grep -w '%s' | grep -w '%s' || mount '%s' '%s'",
-                msg.getPath(), msg.getMountPoint(), msg.getPath(), msg.getMountPoint()));
-        commands.add(String.format("grep -w '%s' /etc/fstab | grep -w '%s' | grep -w '%s' || echo '%s %s %s defaults 0 0' >> /etc/fstab",
-                msg.getPath(), msg.getMountPoint(), msg.getFilesystemType(), msg.getPath(), msg.getMountPoint(), msg.getFilesystemType()));
-
         Ssh ssh = new Ssh();
         ssh.setUsername(msg.getUsername()).setPassword(msg.getPassword()).setPort(msg.getSshPort())
                 .setHostname(msg.getHostName()).setTimeout(20);
         try {
-            for (String command : commands) {
-                if (command.startsWith("mkfs")) {
-                    long timeout = (msg.getMessageDeadline() - new Date().getTime()) / 1000 - 30;
-                    command = String.format("timeout %d %s", timeout, command);
-                }
-                SshResult ret = ssh.command(command).run();
-                ssh.reset();
-                if (ret.getReturnCode() != 0) {
-                    event.setError(operr("failed to execute the command[%s], " +
-                                    "because [stderr:%s, stdout:%s, exitErrorMessage:%s]",
-                            command, ret.getStderr(), ret.getStdout(), ret.getExitErrorMessage()));
-                    event.setSuccess(false);
-                    break;
-                }
+            // Create mount point directory
+            executeSshCommand(ssh, String.format("mkdir -p '%s'", msg.getMountPoint()));
+
+            // Check if device already has a filesystem
+            SshResult blkidResult = executeSshCommand(ssh, String.format("blkid -p -o value -s TYPE '%s'", msg.getPath()));
+            if (!blkidResult.getStdout().isEmpty() && !msg.isForce()) {
+                throw new OperationFailureException(operr("device %s already contains a %s filesystem. to overwrite it, set the 'force' parameter to 'true'. warning: this will destroy all existing data on the device!", msg.getPath()));
             }
+
+            // Format the device
+            executeSshCommand(ssh, buildMkfsCommd(msg.getFilesystemType(), msg.getPath()));
+
+            // Retrieve device UUID
+            SshResult ret = executeSshCommand(ssh, String.format("blkid -s UUID -o value '%s'", msg.getPath()));
+            String uuid = ret.getStdout().trim();
+            if (uuid.isEmpty()) {
+                throw new OperationFailureException(operr("failed to get UUID for device %s", msg.getPath()));
+            }
+
+            // Check if mount point is already occupied
+            SshResult mountPointCheck = ssh.command(String.format("findmnt -n -o SOURCE '%s'", msg.getMountPoint())).run();
+            ssh.reset();
+            if (mountPointCheck.getReturnCode() == 0 && !mountPointCheck.getStdout().trim().isEmpty()) {
+                throw new OperationFailureException(operr("mountPoint %s is already mount on device %s",
+                        msg.getMountPoint(), mountPointCheck.getStdout().trim()));
+            }
+
+            // Mount device using UUID
+            executeSshCommand(ssh, String.format("mount -U '%s' '%s'", uuid, msg.getMountPoint()));
+
+            String fstabEntry = String.format("UUID=%s %s %s defaults 0 0", uuid, msg.getMountPoint(), msg.getFilesystemType());
+
+            // Check if fstabEntry already exists in /etc/fstab
+            String checkCommand = String.format("grep -w '%s' /etc/fstab", fstabEntry);
+            SshResult fstabCheck = executeSshCommand(ssh, checkCommand);
+            if (fstabCheck.getReturnCode() == 0 && fstabCheck.getStdout().trim().equals(fstabEntry)) {
+                logger.info(String.format("fstabEntry for UUID %s already exists in fstab, skipping update", uuid));
+                bus.publish(event);
+                return;
+            }
+
+            String mountPointCheckCmd = String.format("grep -w '%s' /etc/fstab", msg.getMountPoint());
+            SshResult mpCheck = executeSshCommand(ssh, mountPointCheckCmd);
+            if (mpCheck.getReturnCode() == 0) {
+                executeSshCommand(ssh, String.format("umount '%s'", msg.getMountPoint()));
+                throw new OperationFailureException(operr("failed add '%s' to fstab. umount %s. mountPoint %s is already configured for another device in /etc/fstab. please resolve the conflict manually before proceeding.",
+                        fstabEntry, msg.getMountPoint(), msg.getMountPoint(), msg.getPath(), uuid));
+            }
+
+            // add new entry to fstab
+            executeSshCommand(ssh, String.format("echo '%s' >> /etc/fstab", fstabEntry));
+
             bus.publish(event);
         } finally {
             ssh.close();
         }
+    }
+
+    private SshResult executeSshCommand(Ssh ssh, String command) {
+        SshResult ret = ssh.command(command).run();
+        ssh.reset();
+        if (ret.getReturnCode() != 0) {
+            throw new CloudRuntimeException(String.format("SSH command failed [%s]: stderr=%s, stdout=%s", command, ret.getStderr(), ret.getStdout()));
+        }
+        return ret;
     }
 
     private void handle(final APIGetHostBlockDevicesMsg msg) {

--- a/header/src/main/java/org/zstack/header/host/APIMountBlockDeviceMsg.java
+++ b/header/src/main/java/org/zstack/header/host/APIMountBlockDeviceMsg.java
@@ -28,6 +28,8 @@ public class APIMountBlockDeviceMsg extends APIMessage {
     private String mountPoint;
     @APIParam(required = false, maxLength = 255, validValues = {"ext4", "xfs"})
     private String filesystemType = "xfs";
+    @APIParam(required = false)
+    private boolean force = false;
 
     public static class mkfsCommd {
         public static String buildMkfsCommd(String filesystemType, String blockDevicePath) {
@@ -95,6 +97,14 @@ public class APIMountBlockDeviceMsg extends APIMessage {
 
     public void setFilesystemType(String filesystemType) {
         this.filesystemType = filesystemType;
+    }
+
+    public boolean isForce() {
+        return force;
+    }
+
+    public void setForce(boolean force) {
+        this.force = force;
     }
 
     public static APIMountBlockDeviceMsg __example__() {

--- a/header/src/main/java/org/zstack/header/host/APIMountBlockDeviceMsgDoc_zh_cn.groovy
+++ b/header/src/main/java/org/zstack/header/host/APIMountBlockDeviceMsgDoc_zh_cn.groovy
@@ -86,6 +86,15 @@ doc {
 					values ("ext4","xfs")
 				}
 				column {
+					name "force"
+					enclosedIn ""
+					desc "强制格式化"
+					location "body"
+					type "boolean"
+					optional true
+					since "4.10.16"
+				}
+				column {
 					name "systemTags"
 					enclosedIn ""
 					desc "系统标签"

--- a/sdk/src/main/java/org/zstack/sdk/MountBlockDeviceAction.java
+++ b/sdk/src/main/java/org/zstack/sdk/MountBlockDeviceAction.java
@@ -46,6 +46,9 @@ public class MountBlockDeviceAction extends AbstractAction {
     @Param(required = false, validValues = {"ext4","xfs"}, maxLength = 255, nonempty = false, nullElements = false, emptyString = true, noTrim = false)
     public java.lang.String filesystemType = "xfs";
 
+    @Param(required = false, nonempty = false, nullElements = false, emptyString = true, noTrim = false)
+    public boolean force = false;
+
     @Param(required = false)
     public java.util.List systemTags;
 


### PR DESCRIPTION
Example fstab entry:
UUID=123e4567-e89b-12d3-a456-426614174000 /mnt/data xfs defaults 0 0

APIImpact

Resolves: ZSV-8303

Change-Id: I646b76646f786378796171767468627861626969

sync from gitlab !7962