### PR TITLE
<fix>[iam2]: multe region adapter

### DIFF
--- a/header/src/main/java/org/zstack/header/identity/APICreateAccountMsg.java
+++ b/header/src/main/java/org/zstack/header/identity/APICreateAccountMsg.java
@@ -21,7 +21,7 @@ public class APICreateAccountMsg extends APICreateMessage implements APIAuditor 
     @APIParam(maxLength = 255, password = true)
     @NoLogging
     private String password;
-    @APIParam(validValues = {"SystemAdmin", "Normal"}, required = false)
+    @APIParam(validValues = {"SystemAdmin", "Normal", "ThirdParty"}, required = false)
     private String type;
     @APIParam(maxLength = 2048, required = false)
     private String description;

--- a/sdk/src/main/java/org/zstack/sdk/CreateAccountAction.java
+++ b/sdk/src/main/java/org/zstack/sdk/CreateAccountAction.java
@@ -31,7 +31,7 @@ public class CreateAccountAction extends AbstractAction {
     @Param(required = true, maxLength = 255, nonempty = false, nullElements = false, emptyString = true, noTrim = false)
     public java.lang.String password;
 
-    @Param(required = false, validValues = {"SystemAdmin","Normal"}, nonempty = false, nullElements = false, emptyString = true, noTrim = false)
+    @Param(required = false, validValues = {"SystemAdmin","Normal","ThirdParty"}, nonempty = false, nullElements = false, emptyString = true, noTrim = false)
     public java.lang.String type;
 
     @Param(required = false, maxLength = 2048, nonempty = false, nullElements = false, emptyString = true, noTrim = false)

--- a/sdk/src/main/java/org/zstack/sdk/iam2/api/Attribute.java
+++ b/sdk/src/main/java/org/zstack/sdk/iam2/api/Attribute.java
@@ -4,6 +4,14 @@ package org.zstack.sdk.iam2.api;
 
 public class Attribute  {
 
+    public java.lang.String uuid;
+    public void setUuid(java.lang.String uuid) {
+        this.uuid = uuid;
+    }
+    public java.lang.String getUuid() {
+        return this.uuid;
+    }
+
     public java.lang.String name;
     public void setName(java.lang.String name) {
         this.name = name;

--- a/sdk/src/main/java/org/zstack/sdk/iam2/api/CreateIAM2VirtualIDAction.java
+++ b/sdk/src/main/java/org/zstack/sdk/iam2/api/CreateIAM2VirtualIDAction.java
@@ -46,6 +46,9 @@ public class CreateIAM2VirtualIDAction extends AbstractAction {
     @Param(required = false, nonempty = false, nullElements = false, emptyString = true, noTrim = false)
     public boolean withoutDefaultRole = false;
 
+    @Param(required = false, validValues = {"ZStack","OAuth2","Ldap"}, nonempty = false, nullElements = false, emptyString = true, noTrim = false)
+    public java.lang.String type;
+
     @Param(required = false)
     public java.lang.String resourceUuid;
 


### PR DESCRIPTION
1、APICreateAccountMsg support set `type`
2、APICreateIAM2VirtualIDMsg support set `type`
3、APICreateIAM2VirtualIDMsg.attributes support set `uuid`
4、APICreateIAM2OrganizationMsg.attributes support set `uuid`
5、APICreateIAM2VirtualIDGroupMsg.attributes support set `uuid`
6、APICreateIAM2ProjectMsg.attributes support set `uuid`

Resolves: ZSTAC-74189

Change-Id: I62726d7a736b67706b6176726d75636568677068

sync from gitlab !8012