### PR TITLE
<fix>[rest]: support multiple date formats for HTTP headers in RestServer

### DIFF
--- a/rest/src/main/java/org/zstack/rest/RestServer.java
+++ b/rest/src/main/java/org/zstack/rest/RestServer.java
@@ -64,6 +64,7 @@ import org.zstack.utils.DebugUtils;
 import org.zstack.utils.FieldUtils;
 import org.zstack.utils.GroovyUtils;
 import org.zstack.utils.HttpServletRequestUtils;
+import org.zstack.utils.TimeUtils;
 import org.zstack.utils.TypeUtils;
 import org.zstack.utils.Utils;
 import org.zstack.utils.gson.JSONObjectUtil;
@@ -83,8 +84,6 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Modifier;
 import java.time.Duration;
 import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
-import java.time.format.DateTimeFormatterBuilder;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -96,7 +95,6 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -118,7 +116,6 @@ public class RestServer implements Component, CloudBusEventListener {
 
     private static final OkHttpClient http;
     private static final MediaType JSON = MediaType.parse("application/json; charset=utf-8");
-    private static final DateTimeFormatter formatter;
     private static final Set<String> maskSensitiveInfoClassNames = Platform.getReflections()
             .getTypesAnnotatedWith(MaskSensitiveInfo.class).stream()
             .map(Class::getSimpleName).collect(Collectors.toSet());
@@ -154,11 +151,6 @@ public class RestServer implements Component, CloudBusEventListener {
                     .hostnameVerifier(DefaultSSLVerifier::verify)
                     .build();
         }
-
-        formatter = new DateTimeFormatterBuilder()
-                .parseCaseInsensitive()
-                .appendPattern("EEE, dd MMM yyyy HH:mm:ss z")
-                .toFormatter(Locale.ENGLISH);
     }
 
     static class RequestInfo {
@@ -1046,9 +1038,12 @@ public class RestServer implements Component, CloudBusEventListener {
 
         ZonedDateTime date;
         try {
-            date = ZonedDateTime.parse(dateStr, formatter);
+            date = TimeUtils.parseZonedDateTimeByBasicFormatter(dateStr);
         } catch (RuntimeException e) {
-            throw new RestException(HttpStatus.BAD_REQUEST.value(), "'Date' format error, correct format is 'EEE, dd MMM yyyy HH:mm:ss z'");
+            throw new RestException(HttpStatus.BAD_REQUEST.value(),
+                    "Date format error. The 'Date' header must conform to one of the supported RFC 1123 or ISO 8601 formats. " +
+                            "Examples include: 'Thu, 5 Jun 2025 15:47:29 +0800', '2025-06-05T16:08:42+08:00', or '2025-06-05T16:08:42.123Z'."
+            );
         }
 
         ZonedDateTime now = ZonedDateTime.now();

--- a/sdk/src/main/java/org/zstack/sdk/ZSClient.java
+++ b/sdk/src/main/java/org/zstack/sdk/ZSClient.java
@@ -362,8 +362,15 @@ public class ZSClient {
 
         private void calculateAccessKeySignature(Request.Builder reqBuilder, String accessKeyId, String accessKeySecret, String path) throws Exception {
             ZonedDateTime date = ZonedDateTime.now();
-            String dateStr = date.format(formatter);
+            DateTimeFormatter fmt = formatter;
+            if (getConfig() != null && getConfig().accessKeyDateStr != null) {
+                fmt = new DateTimeFormatterBuilder()
+                        .parseCaseInsensitive()
+                        .appendPattern(getConfig().accessKeyDateStr)
+                        .toFormatter(Locale.ENGLISH);
+            }
 
+            String dateStr = date.format(fmt);
             StringBuilder sb = new StringBuilder();
             sb.append(info.httpMethod).append("\n");
             sb.append(dateStr).append("\n").append("/v1").append(path);

--- a/sdk/src/main/java/org/zstack/sdk/ZSConfig.java
+++ b/sdk/src/main/java/org/zstack/sdk/ZSConfig.java
@@ -14,6 +14,7 @@ public class ZSConfig {
     Long readTimeout;
     Long writeTimeout;
     String contextPath;
+    String accessKeyDateStr;
 
     public String getHostname() {
         return hostname;
@@ -74,6 +75,10 @@ public class ZSConfig {
             return this;
         }
 
+        public Builder setAccessKeyDateStr(String name) {
+            config.accessKeyDateStr = name;
+            return this;
+        }
 
         public ZSConfig build() {
             return config;

--- a/utils/src/main/java/org/zstack/utils/TimeUtils.java
+++ b/utils/src/main/java/org/zstack/utils/TimeUtils.java
@@ -11,8 +11,11 @@ import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
 import java.util.Calendar;
+import java.util.Locale;
 import java.util.TimeZone;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
@@ -30,6 +33,32 @@ public class TimeUtils {
             "yyyy-MM-dd'T'HH:mm:ss'Z'",
             "yyyy-MM-dd'T'HH:mm:ss.SSSX"
     };
+
+    private static final DateTimeFormatter basicFormatter;
+
+    static {
+        basicFormatter = new DateTimeFormatterBuilder()
+                // Allowed:     "Jan" or "JAN" / "AM" or "am"
+                .parseCaseInsensitive()
+                // Allowed:     "Thu, 26 Oct 2023 10:30:00 GMT"
+                // Not Allowed: "Thu, 26 Oct 2023 10:30:00 Asia/Shanghai"  see more in ZSV-9028
+                .appendOptional(DateTimeFormatter.ofPattern("EEE, dd MMM yyyy HH:mm:ss z", Locale.ENGLISH))
+                // Allowed:     "Thu, 5 Jun 2025 15:47:29 +0800"
+                .appendOptional(DateTimeFormatter.RFC_1123_DATE_TIME)
+                // Allowed:     "2023-10-26T10:30:00+08:00"
+                .appendOptional(DateTimeFormatter.ISO_OFFSET_DATE_TIME)
+                // Allowed:     "2023-10-26T10:30:00.123+08"
+                .appendOptional(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSxx", Locale.ENGLISH))
+                // Allowed:     "2023-10-26T10:30:00.123+0800"
+                .appendOptional(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSZ", Locale.ENGLISH))
+                // Allowed:     "2023-10-26T10:30:00+08:00"
+                .appendOptional(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ssXXX", Locale.ENGLISH))
+                // Allowed:     "2023-10-26T10:30:00+08"
+                .appendOptional(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ssxx", Locale.ENGLISH))
+                // Allowed:     "2023-10-26T10:30:00+0800"
+                .appendOptional(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ssZ", Locale.ENGLISH))
+                .toFormatter(Locale.ENGLISH);
+    }
 
     private static CLogger logger = Utils.getLogger(TimeUtils.class);
 
@@ -227,5 +256,9 @@ public class TimeUtils {
 
     public static OffsetDateTime offsetDateTimeOf(long timestampInMilli) {
         return OffsetDateTime.ofInstant(Instant.ofEpochMilli(timestampInMilli), ZoneId.systemDefault());
+    }
+
+    public static ZonedDateTime parseZonedDateTimeByBasicFormatter(String text) {
+        return ZonedDateTime.parse(text, basicFormatter);
     }
 }


### PR DESCRIPTION
Support multiple date formats for HTTP headers and
allow custom date format in SDK signature.

Resolves: ZSV-9028
Related: ZSTAC-75469

Change-Id: I6662617a73786979676768697a67736f6e6b6e65

sync from gitlab !8075