### PR TITLE
<fix>[sdk]: remove cube license supports

### DIFF
--- a/sdk/src/main/java/org/zstack/sdk/AdditionalLicenseType.java
+++ b/sdk/src/main/java/org/zstack/sdk/AdditionalLicenseType.java
@@ -1,7 +1,6 @@
 package org.zstack.sdk;
 
 public enum AdditionalLicenseType {
-	cube,
 	edge,
 	zstone,
 	zcex,


### PR DESCRIPTION
Related: ZSV-9355

Change-Id: I6676767769747476756f716578646c61786b7576

sync from gitlab !8077