### PR TITLE
<fix>[compute]: fix error in selecting VM boot order if image uuid is null

### DIFF
--- a/compute/src/main/java/org/zstack/compute/vm/VmImageSelectBackupStorageFlow.java
+++ b/compute/src/main/java/org/zstack/compute/vm/VmImageSelectBackupStorageFlow.java
@@ -11,25 +11,25 @@ import org.zstack.core.errorcode.ErrorFacade;
 import org.zstack.header.core.workflow.FlowTrigger;
 import org.zstack.header.core.workflow.NoRollbackFlow;
 import org.zstack.header.errorcode.OperationFailureException;
-import org.zstack.header.image.ImageBackupStorageRefInventory;
 import org.zstack.header.image.ImageConstant.ImageMediaType;
+import org.zstack.header.image.ImageInventory;
 import org.zstack.header.image.ImageStatus;
 import org.zstack.header.storage.primary.*;
 import org.zstack.header.vm.VmInstanceConstant;
 import org.zstack.header.vm.VmInstanceConstant.VmOperation;
 import org.zstack.header.vm.VmInstanceSpec;
-import org.zstack.utils.CollectionUtils;
 import org.zstack.utils.DebugUtils;
-import org.zstack.utils.function.Function;
 
 import javax.persistence.TypedQuery;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import static org.zstack.core.Platform.operr;
 import static org.zstack.core.progress.ProgressReportService.taskProgress;
+import static org.zstack.utils.CollectionUtils.findOneOrNull;
 
 /**
  */
@@ -134,56 +134,63 @@ public class VmImageSelectBackupStorageFlow extends NoRollbackFlow {
     }
 
     @Override
+    @SuppressWarnings("rawtypes")
     public void run(FlowTrigger trigger, Map data) {
         VmInstanceSpec spec = (VmInstanceSpec) data.get(VmInstanceConstant.Params.VmInstanceSpec.toString());
+        final VmOperation operation = spec.getCurrentVmOperation();
 
-        if (VmOperation.NewCreate == spec.getCurrentVmOperation()
-                || VmOperation.ChangeImage == spec.getCurrentVmOperation()) {
-            if (spec.getImageSpec().getInventory() == null) {
-                trigger.next();
-                return;
-            }
-
-            final String bsUuid = findBackupStorage(spec, spec.getImageSpec().getInventory().getUuid());
-            spec.getImageSpec().setSelectedBackupStorage(CollectionUtils.find(
-                    spec.getImageSpec().getInventory().getBackupStorageRefs(),
-                    new Function<ImageBackupStorageRefInventory, ImageBackupStorageRefInventory>() {
-                        @Override
-                        public ImageBackupStorageRefInventory call(ImageBackupStorageRefInventory arg) {
-                            return arg.getBackupStorageUuid().equals(bsUuid)
-                                    && ImageStatus.Ready.toString().equals(arg.getStatus())
-                                    ? arg : null;
-                        }
-                    }));
-
-            if (ImageMediaType.ISO.toString().equals(spec.getImageSpec().getInventory().getMediaType())) {
-                spec.getCdRomSpecs().get(0).setBackupStorageUuid(bsUuid);
-            }
-
-            spec.getCdRomSpecs().forEach(cdRomSpec -> {
-                if (cdRomSpec.getBackupStorageUuid() != null) {
-                    return;
-                }
-                if (cdRomSpec.getImageUuid() == null) {
-                    return;
-                }
-                cdRomSpec.setBackupStorageUuid(
-                        findIsoBsUuidInTheZone(cdRomSpec.getImageUuid(), spec.getVmInventory().getZoneUuid())
-                );
-            });
-        } else if ((VmOperation.Start == spec.getCurrentVmOperation()
-                || VmOperation.Reboot == spec.getCurrentVmOperation())
-                && !spec.getCdRomSpecs().isEmpty()) {
-            spec.getCdRomSpecs().forEach(cdRomSpec -> {
-                if (cdRomSpec.getImageUuid() == null) {
-                    return;
-                }
-                cdRomSpec.setBackupStorageUuid(
-                        findIsoBsUuidInTheZone(cdRomSpec.getImageUuid(), spec.getVmInventory().getZoneUuid())
-                );
-            });
+        if (VmOperation.NewCreate == operation || VmOperation.ChangeImage == operation) {
+            runWithNewCreateOrChangeImageOperation(spec);
+        } else if (VmOperation.Start == operation || VmOperation.Reboot == operation) {
+            runWithStartOrRebootOperation(spec);
         }
 
         trigger.next();
+    }
+
+    private void runWithNewCreateOrChangeImageOperation(VmInstanceSpec spec) {
+        final VmInstanceSpec.ImageSpec imageSpec = spec.getImageSpec();
+        if (imageSpec.getInventory() != null) {
+            final ImageInventory image = imageSpec.getInventory();
+            final String bsUuid = findBackupStorage(spec, image.getUuid());
+
+            imageSpec.setSelectedBackupStorage(findOneOrNull(
+                    image.getBackupStorageRefs(),
+                    arg -> arg.getBackupStorageUuid().equals(bsUuid) && ImageStatus.Ready.toString().equals(arg.getStatus())));
+
+            if (ImageMediaType.ISO.toString().equals(image.getMediaType())) {
+                VmInstanceSpec.CdRomSpec cdRomSpec = findOneOrNull(
+                        spec.getCdRomSpecs(),
+                        cdromSpec -> Objects.equals(cdromSpec.getImageUuid(), image.getUuid()));
+                if (cdRomSpec != null) {
+                    cdRomSpec.setBackupStorageUuid(bsUuid);
+                }
+            }
+        }
+
+        for (VmInstanceSpec.CdRomSpec cdRomSpec : spec.getCdRomSpecs()) {
+            if (cdRomSpec.getBackupStorageUuid() != null) {
+                continue;
+            }
+            if (cdRomSpec.getImageUuid() == null) {
+                continue;
+            }
+            cdRomSpec.setBackupStorageUuid(
+                    findIsoBsUuidInTheZone(cdRomSpec.getImageUuid(), spec.getVmInventory().getZoneUuid()));
+        }
+    }
+
+    private void runWithStartOrRebootOperation(VmInstanceSpec spec) {
+        if (spec.getCdRomSpecs().isEmpty()) {
+            return;
+        }
+
+        for (VmInstanceSpec.CdRomSpec cdRomSpec : spec.getCdRomSpecs()) {
+            if (cdRomSpec.getImageUuid() == null) {
+                continue;
+            }
+            cdRomSpec.setBackupStorageUuid(
+                    findIsoBsUuidInTheZone(cdRomSpec.getImageUuid(), spec.getVmInventory().getZoneUuid()));
+        }
     }
 }

--- a/compute/src/main/java/org/zstack/compute/vm/VmInstanceBase.java
+++ b/compute/src/main/java/org/zstack/compute/vm/VmInstanceBase.java
@@ -3055,8 +3055,11 @@ public class VmInstanceBase extends AbstractVmInstance {
         List<CdRomSpec> cdRomSpecs = spec.getCdRomSpecs().stream()
                 .filter(cdRom -> cdRom.getImageUuid() != null)
                 .collect(Collectors.toList());
-        if (spec.getCurrentVmOperation() == VmOperation.NewCreate && !cdRomSpecs.isEmpty()) {
-            ImageVO imageVO = dbf.findByUuid(spec.getVmInventory().getImageUuid(), ImageVO.class);
+        String cdromImageUuid = cdRomSpecs.isEmpty() ? null : cdRomSpecs.get(0).getImageUuid();
+        String imageUuidNullable = spec.getVmInventory().getImageUuid();
+
+        if (spec.getCurrentVmOperation() == VmOperation.NewCreate && cdromImageUuid != null) {
+            ImageVO imageVO = dbf.findByUuid(imageUuidNullable == null ? cdromImageUuid: imageUuidNullable, ImageVO.class);
             assert imageVO != null;
 
             if (imageVO.getMediaType() == ImageMediaType.ISO) {

--- a/compute/src/main/java/org/zstack/compute/vm/VmSystemTags.java
+++ b/compute/src/main/java/org/zstack/compute/vm/VmSystemTags.java
@@ -155,7 +155,13 @@ public class VmSystemTags {
     public static String CD_ROM_2 = "cdrom2";
     public static PatternedSystemTag CREATE_VM_CD_ROM_LIST = new PatternedSystemTag(String.format("cdroms::{%s}::{%s}::{%s}", CD_ROM_0, CD_ROM_1, CD_ROM_2), VmInstanceVO.class);
 
+    @Deprecated
     public static String CREATE_WITHOUT_CD_ROM_TOKEN = "createWithoutCdRom";
+    /**
+     * Deprecated. If VM has no cdrom, it will have 0 "CdRomVO".
+     * Please use "cdroms::None::None::None" system tag instead when creating VM.
+     */
+    @Deprecated
     public static PatternedSystemTag CREATE_WITHOUT_CD_ROM = new PatternedSystemTag(String.format("createWithoutCdRom::{%s}", CREATE_WITHOUT_CD_ROM_TOKEN), VmInstanceVO.class);
 
     public static String CD_ROM_UUID_TOKEN = "cdromUuid";

--- a/storage/src/main/java/org/zstack/storage/volume/DownloadIsoForVmExtension.java
+++ b/storage/src/main/java/org/zstack/storage/volume/DownloadIsoForVmExtension.java
@@ -12,6 +12,7 @@ import org.zstack.header.core.Completion;
 import org.zstack.header.core.WhileDoneCompletion;
 import org.zstack.header.errorcode.ErrorCode;
 import org.zstack.header.errorcode.ErrorCodeList;
+import org.zstack.header.errorcode.OperationFailureException;
 import org.zstack.header.image.ImageBackupStorageRefInventory;
 import org.zstack.header.image.ImageInventory;
 import org.zstack.header.image.ImageStatus;
@@ -40,7 +41,9 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static org.zstack.core.Platform.multiErr;
+import static org.zstack.core.Platform.operr;
 import static org.zstack.utils.CollectionDSL.list;
+import static org.zstack.utils.CollectionUtils.transform;
 
 /**
  * Created by frank on 5/23/2015.
@@ -74,7 +77,7 @@ public class DownloadIsoForVmExtension implements PreVmInstantiateResourceExtens
             return;
         }
 
-        List<String> isoUuids = spec.getCdRomSpecs().stream().map(CdRomSpec::getImageUuid).collect(Collectors.toList());
+        List<String> isoUuids = transform(spec.getCdRomSpecs(), CdRomSpec::getImageUuid);
         if (isoUuids.isEmpty()) {
             completion.success();
             return;
@@ -87,10 +90,8 @@ public class DownloadIsoForVmExtension implements PreVmInstantiateResourceExtens
             assert cdRomSpec.getBackupStorageUuid() != null : "backup storage uuid cannot be null";
         });
 
-        List<DownloadIsoToPrimaryStorageMsg> msgs = CollectionUtils.transformToList(spec.getCdRomSpecs(),
-             new Function<DownloadIsoToPrimaryStorageMsg, CdRomSpec>() {
-                @Override
-                public DownloadIsoToPrimaryStorageMsg call(CdRomSpec cdRomSpec) {
+        List<DownloadIsoToPrimaryStorageMsg> msgs = CollectionUtils.transformAndRemoveNull(spec.getCdRomSpecs(),
+                cdRomSpec -> {
                     if (cdRomSpec.getImageUuid() == null) {
                         return null;
                     }
@@ -99,17 +100,20 @@ public class DownloadIsoForVmExtension implements PreVmInstantiateResourceExtens
                     ImageSpec imageSpec = new ImageSpec();
                     final ImageInventory iso = ImageInventory.valueOf(dbf.findByUuid(cdRomSpec.getImageUuid(), ImageVO.class));
                     imageSpec.setInventory(iso);
-                    imageSpec.setSelectedBackupStorage(CollectionUtils.find(iso.getBackupStorageRefs(), new Function<ImageBackupStorageRefInventory, ImageBackupStorageRefInventory>() {
-                        @Override
-                        public ImageBackupStorageRefInventory call(ImageBackupStorageRefInventory arg) {
-                            return arg.getBackupStorageUuid().equals(cdRomSpec.getBackupStorageUuid()) &&
-                                    ImageStatus.Ready.toString().equals(arg.getStatus())? arg : null;
-                        }
-                    }));
+                    imageSpec.setSelectedBackupStorage(CollectionUtils.findOneOrNull(iso.getBackupStorageRefs(),
+                            arg -> arg.getBackupStorageUuid().equals(cdRomSpec.getBackupStorageUuid()) &&
+                                    ImageStatus.Ready.toString().equals(arg.getStatus())));
+                    if (imageSpec.getSelectedBackupStorage() == null) {
+                        throw new OperationFailureException(operr(
+                                "failed to select backup storage to download iso[uuid=%s]", cdRomSpec.getImageUuid())
+                                .withOpaque("image.uuid", iso.getUuid())
+                                .withOpaque("backup.storage.refs",
+                                        transform(iso.getBackupStorageRefs(), ImageBackupStorageRefInventory::getBackupStorageUuid)));
+                    }
 
                     if (VmOperation.NewCreate == spec.getCurrentVmOperation()) {
                         VolumeSpec vspec = spec.getVolumeSpecs().stream().filter(it -> VolumeType.Root.toString().equals(it.getType()))
-                                .findFirst().orElse(spec.getVolumeSpecs().get(0));;
+                                .findFirst().orElse(spec.getVolumeSpecs().get(0));
                         PrimaryStorageInventory pinv = vspec.getPrimaryStorageInventory();
                         psUuid = pinv.getUuid();
                     } else {
@@ -124,11 +128,10 @@ public class DownloadIsoForVmExtension implements PreVmInstantiateResourceExtens
                     bus.makeTargetServiceIdByResourceUuid(msg, PrimaryStorageConstant.SERVICE_ID, psUuid);
                     return msg;
                 }
-             }
         );
 
         List<ErrorCode> errorCodes = new ArrayList<>();
-        new While<>(msgs).all((msg, whileCompletion) -> {
+        new While<>(msgs).step((msg, whileCompletion) -> {
             bus.send(msg, new CloudBusCallBack(completion) {
                 @Override
                 public void run(MessageReply reply) {
@@ -155,7 +158,7 @@ public class DownloadIsoForVmExtension implements PreVmInstantiateResourceExtens
                     whileCompletion.done();
                 }
             });
-        }).run(new WhileDoneCompletion(completion) {
+        }, 3).run(new WhileDoneCompletion(completion) {
             @Override
             public void done(ErrorCodeList errorCodeList) {
                 if (errorCodes.isEmpty()) {
@@ -163,9 +166,7 @@ public class DownloadIsoForVmExtension implements PreVmInstantiateResourceExtens
                     return;
                 }
 
-                ErrorCode ec = multiErr(errorCodes, "unable to download iso to primary storage, becasue: %s",
-                        errorCodes.get(0).getDetails());
-
+                ErrorCode ec = multiErr(errorCodes, "unable to download iso to primary storage");
                 completion.fail(ec);
             }
         });


### PR DESCRIPTION
ZSphere support imageUuid = null && cdrom is not null.

Resolves: ZSV-8984

Change-Id: I74616578646b6e636a6863676677657971617664

sync from gitlab !8087