### PR TITLE
<fix>[header]: skip build schema of APIReply if field is transient

### DIFF
--- a/header/src/main/java/org/zstack/header/message/JsonSchemaBuilder.java
+++ b/header/src/main/java/org/zstack/header/message/JsonSchemaBuilder.java
@@ -27,7 +27,7 @@ public class JsonSchemaBuilder {
 
     private boolean isSkip(Field f) {
         return f.isAnnotationPresent(NoJsonSchema.class) || Modifier.isStatic(f.getModifiers())
-                || f.isAnnotationPresent(GsonTransient.class);
+                || f.isAnnotationPresent(GsonTransient.class) || Modifier.isTransient(f.getModifiers());
     }
 
     private void build(Object o, Stack<String> paths) throws IllegalAccessException {


### PR DESCRIPTION
Related: ZSV-8949

Change-Id: I626964757679706b66656f666669656567626270

sync from gitlab !8190