### PR TITLE
<fix>[header]: merge VmSpec.requiredPsUuid to VmSpec.rootDisk

### DIFF
--- a/compute/src/main/java/org/zstack/compute/vm/VmAllocatePrimaryStorageFlow.java
+++ b/compute/src/main/java/org/zstack/compute/vm/VmAllocatePrimaryStorageFlow.java
@@ -85,7 +85,7 @@ public class VmAllocatePrimaryStorageFlow implements Flow {
                     volumeSpec.setDiskOfferingUuid(msg.getDiskOfferingUuid());
                     volumeSpec.setTags(msg.getSystemTags());
                     if (VolumeType.Root.toString().equals(volumeSpec.getType())) {
-                        spec.setAllocatedPrimaryStorageUuidForRootVolume(ar.getPrimaryStorageInventory().getUuid());
+                        spec.getRootDisk().setPrimaryStorageUuid(ar.getPrimaryStorageInventory().getUuid());
                     } else {
                         spec.setAllocatedPrimaryStorageUuidForDataVolume(ar.getPrimaryStorageInventory().getUuid());
                     }

--- a/header/src/main/java/org/zstack/header/vm/CreateVmInstanceMsg.java
+++ b/header/src/main/java/org/zstack/header/vm/CreateVmInstanceMsg.java
@@ -40,7 +40,7 @@ public class CreateVmInstanceMsg extends NeedReplyMessage implements CreateVmIns
     private List<String> sshKeyPairUuids;
     private final List<String> candidatePrimaryStorageUuidsForRootVolume = new ArrayList<>();
     private final List<String> candidatePrimaryStorageUuidsForDataVolume = new ArrayList<>();
-    private DiskAO rootDisk;
+    private DiskAO rootDisk = DiskAO.rootDisk();
     private List<DiskAO> dataDisks;
     private List<DiskAO> deprecatedDataVolumeSpecs = new ArrayList<>();
 

--- a/header/src/main/java/org/zstack/header/vm/VmInstanceSpec.java
+++ b/header/src/main/java/org/zstack/header/vm/VmInstanceSpec.java
@@ -335,7 +335,6 @@ public class VmInstanceSpec implements Serializable {
     private String requiredClusterUuid;
     private String requiredHostUuid;
     private String memorySnapshotUuid;
-    private String allocatedPrimaryStorageUuidForRootVolume;
     private String allocatedPrimaryStorageUuidForDataVolume;
     private final List<String> candidatePrimaryStorageUuidsForRootVolume = new ArrayList<>();
     private final List<String> candidatePrimaryStorageUuidsForDataVolume = new ArrayList<>();
@@ -399,7 +398,7 @@ public class VmInstanceSpec implements Serializable {
     }
 
     private List<String> disableL3Networks;
-    private DiskAO rootDisk;
+    private DiskAO rootDisk = DiskAO.rootDisk();
     private List<DiskAO> dataDisks;
     private List<DiskAO> deprecatedDisksSpecs = new ArrayList<>();
 
@@ -766,11 +765,6 @@ public class VmInstanceSpec implements Serializable {
         return nsTypes;
     }
 
-    @Deprecated
-    public String getRequiredPrimaryStorageUuidForRootVolume() {
-        return this.candidatePrimaryStorageUuidsForRootVolume.isEmpty() ? null : this.candidatePrimaryStorageUuidsForRootVolume.get(0);
-    }
-
     public void setRequiredPrimaryStorageUuidForRootVolume(String primaryStorageUuidForRootVolume) {
         this.candidatePrimaryStorageUuidsForRootVolume.clear();
         if (primaryStorageUuidForRootVolume != null) {
@@ -867,14 +861,6 @@ public class VmInstanceSpec implements Serializable {
 
     public void setDisableL3Networks(List<String> disableL3Networks) {
         this.disableL3Networks = disableL3Networks;
-    }
-
-    public String getAllocatedPrimaryStorageUuidForRootVolume() {
-        return allocatedPrimaryStorageUuidForRootVolume;
-    }
-
-    public void setAllocatedPrimaryStorageUuidForRootVolume(String allocatedPrimaryStorageUuidForRootVolume) {
-        this.allocatedPrimaryStorageUuidForRootVolume = allocatedPrimaryStorageUuidForRootVolume;
     }
 
     public String getAllocatedPrimaryStorageUuidForDataVolume() {

--- a/plugin/localstorage/src/main/java/org/zstack/storage/primary/local/LocalStorageDefaultAllocateCapacityFlow.java
+++ b/plugin/localstorage/src/main/java/org/zstack/storage/primary/local/LocalStorageDefaultAllocateCapacityFlow.java
@@ -40,6 +40,7 @@ import java.util.*;
 
 import static org.zstack.core.Platform.argerr;
 import static org.zstack.core.Platform.operr;
+import static org.zstack.utils.CollectionUtils.isEmpty;
 import static org.zstack.utils.CollectionUtils.transformAndRemoveNull;
 
 /**
@@ -125,7 +126,14 @@ public class LocalStorageDefaultAllocateCapacityFlow implements Flow {
     public void run(final FlowTrigger trigger, Map data) {
         final VmInstanceSpec spec = (VmInstanceSpec) data.get(VmInstanceConstant.Params.VmInstanceSpec.toString());
 
-        String localStorageUuid = getRequiredStorageUuid(spec.getDestHost().getUuid(), spec.getRequiredPrimaryStorageUuidForRootVolume());
+        String rootPs = spec.getRootDisk().getPrimaryStorageUuid();
+        List<String> rootPsCandidates = spec.getCandidatePrimaryStorageUuidsForRootVolume();
+        if (rootPs == null && !isEmpty(rootPsCandidates) && rootPsCandidates.size() == 1) {
+            rootPs = rootPsCandidates.get(0);
+            spec.getRootDisk().setPrimaryStorageUuid(rootPs);
+        }
+
+        String localStorageUuid = getRequiredStorageUuid(spec.getDestHost().getUuid(), rootPs);
 
 
         List<String> primaryStorageTypes = null;

--- a/plugin/localstorage/src/main/java/org/zstack/storage/primary/local/LocalStorageDesignatedAllocateCapacityFlow.java
+++ b/plugin/localstorage/src/main/java/org/zstack/storage/primary/local/LocalStorageDesignatedAllocateCapacityFlow.java
@@ -120,10 +120,16 @@ public class LocalStorageDesignatedAllocateCapacityFlow implements Flow {
     }
 
     private ErrorCode checkIfSpecifyPrimaryStorage(VmInstanceSpec spec) {
-        if (spec.getRequiredPrimaryStorageUuidForRootVolume() == null) {
-            ErrorCode errorCode = operr("The cluster[uuid=%s] mounts multiple primary storage[LocalStorage, other non-LocalStorage primary storage], You must specify the primary storage where the root disk is located",
-                    spec.getDestHost().getClusterUuid());
-            return errorCode;
+        String rootPs = spec.getRootDisk().getPrimaryStorageUuid();
+        List<String> rootPsCandidates = spec.getCandidatePrimaryStorageUuidsForRootVolume();
+        if (rootPs == null) {
+            if (!isEmpty(rootPsCandidates) && rootPsCandidates.size() == 1) {
+                rootPs = rootPsCandidates.get(0);
+                spec.getRootDisk().setPrimaryStorageUuid(rootPs);
+            } else {
+                return operr("The cluster[uuid=%s] mounts multiple primary storage[LocalStorage, other non-LocalStorage primary storage], You must specify the primary storage where the root disk is located",
+                        spec.getDestHost().getClusterUuid());
+            }
         }
 
         if(!isEmpty(spec.getDeprecatedDisksSpecs()) && spec.getRequiredPrimaryStorageUuidForDataVolume() == null){
@@ -151,7 +157,7 @@ public class LocalStorageDesignatedAllocateCapacityFlow implements Flow {
         if (spec.getImageSpec() != null && spec.getImageSpec().getInventory() != null) {
             rmsg.setImageUuid(spec.getImageSpec().getInventory().getUuid());
         }
-        rmsg.setRequiredPrimaryStorageUuid(spec.getRequiredPrimaryStorageUuidForRootVolume());
+        rmsg.setRequiredPrimaryStorageUuid(spec.getRootDisk().getPrimaryStorageUuid());
         rmsg.setRequiredHostUuid(spec.getDestHost().getUuid());
         rmsg.setSize(spec.getRootDiskAllocateSize());
         rmsg.setSystemTags(spec.getRootVolumeSystemTags());
@@ -167,7 +173,7 @@ public class LocalStorageDesignatedAllocateCapacityFlow implements Flow {
 
         String requiredPrimaryStorageType = Q.New(PrimaryStorageVO.class)
                 .select(PrimaryStorageVO_.type)
-                .eq(PrimaryStorageVO_.uuid, spec.getRequiredPrimaryStorageUuidForRootVolume())
+                .eq(PrimaryStorageVO_.uuid, spec.getRootDisk().getPrimaryStorageUuid())
                 .findValue();
         if(LocalStorageConstants.LOCAL_STORAGE_TYPE.equals(requiredPrimaryStorageType)){
             rmsg.setAllocationStrategy(LocalStorageConstants.LOCAL_STORAGE_ALLOCATOR_STRATEGY);

--- a/plugin/localstorage/src/main/java/org/zstack/storage/primary/local/LocalStorageFactory.java
+++ b/plugin/localstorage/src/main/java/org/zstack/storage/primary/local/LocalStorageFactory.java
@@ -423,8 +423,14 @@ public class LocalStorageFactory implements PrimaryStorageFactory, Component,
                     return null;
                 }
 
-                boolean requireNoneLocalStorage = spec.getRequiredPrimaryStorageUuidForRootVolume() != null && Q.New(PrimaryStorageVO.class)
-                        .eq(PrimaryStorageVO_.uuid, spec.getRequiredPrimaryStorageUuidForRootVolume())
+                String rootPs = spec.getRootDisk().getPrimaryStorageUuid();
+                List<String> rootPsCandidates = spec.getCandidatePrimaryStorageUuidsForRootVolume();
+                if (rootPs == null && !isEmpty(rootPsCandidates) && rootPsCandidates.size() == 1) {
+                    rootPs = rootPsCandidates.get(0);
+                }
+
+                boolean requireNoneLocalStorage = rootPs != null && Q.New(PrimaryStorageVO.class)
+                        .eq(PrimaryStorageVO_.uuid, rootPs)
                         .notEq(PrimaryStorageVO_.type, LocalStorageConstants.LOCAL_STORAGE_TYPE)
                         .isExists();
                 requireNoneLocalStorage = requireNoneLocalStorage && (isEmpty(spec.getDeprecatedDisksSpecs()) ||
@@ -445,8 +451,7 @@ public class LocalStorageFactory implements PrimaryStorageFactory, Component,
                         .param("ptype", LocalStorageConstants.LOCAL_STORAGE_TYPE)
                         .list().isEmpty();
 
-                if (!isOnlyLocalStorage && (spec.getRequiredPrimaryStorageUuidForRootVolume() != null ||
-                        spec.getRequiredPrimaryStorageUuidForDataVolume() != null)) {
+                if (!isOnlyLocalStorage && (rootPs != null || spec.getRequiredPrimaryStorageUuidForDataVolume() != null)) {
                     return new LocalStorageDesignatedAllocateCapacityFlow();
                 } else {
                     return new LocalStorageDefaultAllocateCapacityFlow();


### PR DESCRIPTION
Remove deprecate method
VmInstanceSpec.getRequiredPrimaryStorageUuidForRootVolume.

Required primary storage uuid for root volume is in
VmInstanceSpec.rootDisk.primaryStorageUuid.

Resolves: ZSV-8585

Change-Id: I63776d797963746d637a617868716d7661727669

sync from gitlab !8347