### PR TITLE
<fix>[conf]: Add new column to Gpu device and spec

### DIFF
--- a/conf/db/upgrade/V5.3.52__schema.sql
+++ b/conf/db/upgrade/V5.3.52__schema.sql
@@ -9,3 +9,6 @@ CREATE TABLE  `zstack`.`PodVO` (
     `status` varchar(64) NOT NULL,
      PRIMARY KEY  (`uuid`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+CALL ADD_COLUMN('GpuDeviceVO', 'gpuType', 'VARCHAR(255)', 1, NULL);
+CALL ADD_COLUMN('GpuDeviceSpecVO', 'gpuType', 'VARCHAR(255)', 1, NULL);


### PR DESCRIPTION
- Add gpu type to gpu device vo instead of using
  pci device's any field
- Gpu type will be used for gpu related scheduling
  like pod deployment or display

DBImpact

Resolves: ZSTAC-77522

Change-Id: I75666c72686461636f71647377777a76696a766b

sync from gitlab !8450