### PR TITLE
<fix>[kvm]: add reason setting for Ansible force run execution

### DIFF
--- a/plugin/kvm/src/main/java/org/zstack/kvm/KVMAgentCommands.java
+++ b/plugin/kvm/src/main/java/org/zstack/kvm/KVMAgentCommands.java
@@ -266,7 +266,16 @@ public class KVMAgentCommands {
         private boolean ignoreMsrs;
         private boolean pageTableExtensionDisabled;
         private int tcpServerPort;
+        private boolean isInstallHostShutdownHook;
         private String version;
+
+        public boolean isInstallHostShutdownHook() {
+            return isInstallHostShutdownHook;
+        }
+
+        public void setInstallHostShutdownHook(boolean installHostShutdownHook) {
+            isInstallHostShutdownHook = installHostShutdownHook;
+        }
 
         public boolean isIgnoreMsrs() {
             return ignoreMsrs;
@@ -4269,7 +4278,7 @@ public class KVMAgentCommands {
     }
 
     public static class ReportHostStopEventCmd {
-        public String hostIp;
+        public String hostUuid;
     }
 
     public static class ShutdownHostCmd extends AgentCommand {

--- a/plugin/kvm/src/main/java/org/zstack/kvm/KVMHost.java
+++ b/plugin/kvm/src/main/java/org/zstack/kvm/KVMHost.java
@@ -5026,6 +5026,7 @@ public class KVMHost extends HostBase implements Host {
             cmd.setIgnoreMsrs(KVMGlobalConfig.KVM_IGNORE_MSRS.value(Boolean.class));
             cmd.setTcpServerPort(KVMGlobalProperty.TCP_SERVER_PORT);
             cmd.setVersion(dbf.getDbVersion());
+            cmd.setInstallHostShutdownHook(KVMGlobalConfig.INSTALL_HOST_SHUTDOWN_HOOK.value(Boolean.class));
             if (HostSystemTags.PAGE_TABLE_EXTENSION_DISABLED.hasTag(self.getUuid(), HostVO.class) || !KVMSystemTags.EPT_CPU_FLAG.hasTag(self.getUuid())) {
                 cmd.setPageTableExtensionDisabled(true);
             }
@@ -5643,10 +5644,6 @@ public class KVMHost extends HostBase implements Host {
 
                         if ("baremetal2".equals(self.getHypervisorType())) {
                             deployArguments.setIsBareMetal2Gateway("true");
-                        }
-                        if (KVMGlobalConfig.INSTALL_HOST_SHUTDOWN_HOOK.value(Boolean.class)) {
-                            deployArguments.setIsInstallHostShutdownHook("true");
-                            runner.setForceRun(true);
                         }
 
                         if (KVMSystemTags.FORCE_DEPLOYMENT_ONCE.hasTag(self.getUuid())) {

--- a/plugin/kvm/src/main/java/org/zstack/kvm/KVMHostDeployArguments.java
+++ b/plugin/kvm/src/main/java/org/zstack/kvm/KVMHostDeployArguments.java
@@ -24,8 +24,6 @@ public class KVMHostDeployArguments extends SyncTimeRequestedDeployArguments {
     private String updatePackages;
     @SerializedName("post_url")
     private String postUrl;
-    @SerializedName("isInstallHostShutdownHook")
-    private String isInstallHostShutdownHook;
     @SerializedName("isEnableKsm")
     private String isEnableKsm;
     @SerializedName("enable_spice_tls")
@@ -107,14 +105,6 @@ public class KVMHostDeployArguments extends SyncTimeRequestedDeployArguments {
 
     public void setPostUrl(String postUrl) {
         this.postUrl = postUrl;
-    }
-
-    public String getIsInstallHostShutdownHook() {
-        return isInstallHostShutdownHook;
-    }
-
-    public void setIsInstallHostShutdownHook(String isInstallHostShutdownHook) {
-        this.isInstallHostShutdownHook = isInstallHostShutdownHook;
     }
 
     public String getIsEnableKsm() {

--- a/plugin/kvm/src/main/java/org/zstack/kvm/KVMHostFactory.java
+++ b/plugin/kvm/src/main/java/org/zstack/kvm/KVMHostFactory.java
@@ -515,13 +515,12 @@ public class KVMHostFactory extends AbstractService implements HypervisorFactory
         });
 
         restf.registerSyncHttpCallHandler(KVMConstant.KVM_REPORT_HOST_STOP_EVENT, KVMAgentCommands.ReportHostStopEventCmd.class, cmd -> {
-            ChangeHostStatusMsg cmsg = new ChangeHostStatusMsg();
-            HostVO hostVO = Q.New(HostVO.class).eq(HostVO_.managementIp, cmd.hostIp).find();
-
-            if (hostVO == null) {
+            if (StringUtils.isEmpty(cmd.hostUuid)) {
                 return null;
             }
-            cmsg.setUuid(hostVO.getUuid());
+
+            ChangeHostStatusMsg cmsg = new ChangeHostStatusMsg();
+            cmsg.setUuid(cmd.hostUuid);
             cmsg.setStatusEvent(HostStatusEvent.disconnected.toString());
             bus.makeTargetServiceIdByResourceUuid(cmsg, HostConstant.SERVICE_ID, cmsg.getHostUuid());
             bus.send(cmsg);


### PR DESCRIPTION
Introduced the ability to specify a reason when triggering an Ansible
force run, providing clarity on why the force run is necessary.

Resolves: ZSTAC-65206

Change-Id: I646365206a6776667067706e7a6e667a796f686d

sync from gitlab !8603