### PR TITLE
<fix>[ceph]: adding GC for some cases where ceph cannot delete images

### DIFF
--- a/header/src/main/java/org/zstack/header/storage/primary/DeleteVolumeChainOnPrimaryStorageMsg.java
+++ b/header/src/main/java/org/zstack/header/storage/primary/DeleteVolumeChainOnPrimaryStorageMsg.java
@@ -1,6 +1,7 @@
 package org.zstack.header.storage.primary;
 
 import org.zstack.header.message.NeedReplyMessage;
+import org.zstack.utils.CollectionUtils;
 
 import java.util.List;
 
@@ -13,6 +14,9 @@ public class DeleteVolumeChainOnPrimaryStorageMsg extends NeedReplyMessage imple
     private List<String> installPaths;
 
     private String volumeFormat;
+
+    // for gc, used to deduplicate GC
+    private String chainTop;
 
     @Override
     public String getPrimaryStorageUuid() {
@@ -45,5 +49,18 @@ public class DeleteVolumeChainOnPrimaryStorageMsg extends NeedReplyMessage imple
 
     public void setVolumeFormat(String volumeFormat) {
         this.volumeFormat = volumeFormat;
+    }
+
+    public String getChainTop() {
+        if (chainTop != null) {
+            return chainTop;
+        } else if (!CollectionUtils.isEmpty(installPaths)) {
+            return installPaths.get(0);
+        }
+        return null;
+    }
+
+    public void setChainTop(String chainTop) {
+        this.chainTop = chainTop;
     }
 }

--- a/header/src/main/java/org/zstack/header/storage/primary/DeleteVolumeChainOnPrimaryStorageReply.java
+++ b/header/src/main/java/org/zstack/header/storage/primary/DeleteVolumeChainOnPrimaryStorageReply.java
@@ -2,5 +2,17 @@ package org.zstack.header.storage.primary;
 
 import org.zstack.header.message.MessageReply;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public class DeleteVolumeChainOnPrimaryStorageReply extends MessageReply {
+    private List<String> undeletedInstallPaths = new ArrayList<>();
+
+    public List<String> getUndeletedInstallPaths() {
+        return undeletedInstallPaths;
+    }
+
+    public void setUndeletedInstallPaths(List<String> undeletedInstallPaths) {
+        this.undeletedInstallPaths = undeletedInstallPaths;
+    }
 }

--- a/plugin/ceph/src/main/java/org/zstack/storage/ceph/primary/CephDeleteVolumeChainGC.java
+++ b/plugin/ceph/src/main/java/org/zstack/storage/ceph/primary/CephDeleteVolumeChainGC.java
@@ -1,0 +1,61 @@
+package org.zstack.storage.ceph.primary;
+
+import org.zstack.core.Platform;
+import org.zstack.core.cloudbus.CloudBusCallBack;
+import org.zstack.core.gc.GC;
+import org.zstack.core.gc.GCCompletion;
+import org.zstack.core.gc.TimeBasedGarbageCollector;
+import org.zstack.header.message.MessageReply;
+import org.zstack.header.storage.primary.DeleteVolumeChainOnPrimaryStorageMsg;
+import org.zstack.header.storage.primary.DeleteVolumeChainOnPrimaryStorageReply;
+import org.zstack.header.storage.primary.PrimaryStorageConstant;
+import org.zstack.header.storage.primary.PrimaryStorageVO;
+import org.zstack.utils.CollectionUtils;
+import org.zstack.utils.Utils;
+import org.zstack.utils.logging.CLogger;
+
+import java.util.List;
+
+public class CephDeleteVolumeChainGC extends TimeBasedGarbageCollector {
+    @GC
+    public String primaryStorageUuid;
+    @GC
+    public List<String> installPaths;
+    @GC
+    public String chainTop;
+
+    private static final CLogger logger = Utils.getLogger(CephDeleteVolumeChainGC.class);
+
+    @Override
+    protected void triggerNow(GCCompletion completion) {
+        if (!dbf.isExist(primaryStorageUuid, PrimaryStorageVO.class) || CollectionUtils.isEmpty(installPaths)) {
+            completion.cancel();
+            return;
+        }
+
+        DeleteVolumeChainOnPrimaryStorageMsg msg = new DeleteVolumeChainOnPrimaryStorageMsg();
+        msg.setPrimaryStorageUuid(primaryStorageUuid);
+        msg.setChainTop(chainTop);
+        msg.setInstallPaths(installPaths);
+        bus.makeTargetServiceIdByResourceUuid(msg, PrimaryStorageConstant.SERVICE_ID, primaryStorageUuid);
+        bus.send(msg, new CloudBusCallBack(completion) {
+            @Override
+            public void run(MessageReply reply) {
+                if (!reply.isSuccess()) {
+                    completion.fail(reply.getError());
+                    return;
+                }
+
+                DeleteVolumeChainOnPrimaryStorageReply r = reply.castReply();
+                if (CollectionUtils.isEmpty(r.getUndeletedInstallPaths())) {
+                    completion.success();
+                } else {
+                    installPaths = r.getUndeletedInstallPaths();
+                    updateContext();
+                    completion.fail(Platform.operr("delete volume chain error, continue to delete"));
+                }
+            }
+        });
+    }
+}
+

--- a/plugin/ceph/src/main/java/org/zstack/storage/ceph/primary/CephDeleteVolumeSnapshotGC.java
+++ b/plugin/ceph/src/main/java/org/zstack/storage/ceph/primary/CephDeleteVolumeSnapshotGC.java
@@ -1,0 +1,49 @@
+package org.zstack.storage.ceph.primary;
+
+import org.zstack.core.cloudbus.CloudBusCallBack;
+import org.zstack.core.gc.GC;
+import org.zstack.core.gc.GCCompletion;
+import org.zstack.core.gc.TimeBasedGarbageCollector;
+import org.zstack.header.message.MessageReply;
+import org.zstack.header.storage.primary.DeleteSnapshotOnPrimaryStorageMsg;
+import org.zstack.header.storage.primary.DeleteVolumeBitsOnPrimaryStorageMsg;
+import org.zstack.header.storage.primary.PrimaryStorageConstant;
+import org.zstack.header.storage.primary.PrimaryStorageVO;
+import org.zstack.header.storage.snapshot.VolumeSnapshotInventory;
+import org.zstack.header.volume.VolumeInventory;
+import org.zstack.storage.volume.VolumeErrors;
+import org.zstack.utils.Utils;
+import org.zstack.utils.logging.CLogger;
+
+public class CephDeleteVolumeSnapshotGC extends TimeBasedGarbageCollector {
+    @GC
+    public String primaryStorageUuid;
+    @GC
+    public VolumeSnapshotInventory volumeSnapshot;
+
+    private static final CLogger logger = Utils.getLogger(CephDeleteVolumeSnapshotGC.class);
+
+    @Override
+    protected void triggerNow(GCCompletion completion) {
+        if (!dbf.isExist(primaryStorageUuid, PrimaryStorageVO.class)) {
+            completion.cancel();
+            return;
+        }
+
+        DeleteSnapshotOnPrimaryStorageMsg msg = new DeleteSnapshotOnPrimaryStorageMsg();
+        msg.setSnapshot(volumeSnapshot);
+        bus.makeTargetServiceIdByResourceUuid(msg, PrimaryStorageConstant.SERVICE_ID, primaryStorageUuid);
+        bus.send(msg, new CloudBusCallBack(completion) {
+            @Override
+            public void run(MessageReply reply) {
+                if (!reply.isSuccess()) {
+                    completion.fail(reply.getError());
+                    return;
+                }
+
+                completion.success();
+            }
+        });
+    }
+}
+

--- a/plugin/ceph/src/main/java/org/zstack/storage/ceph/primary/CephPrimaryStorageBase.java
+++ b/plugin/ceph/src/main/java/org/zstack/storage/ceph/primary/CephPrimaryStorageBase.java
@@ -1011,6 +1011,7 @@ public class CephPrimaryStorageBase extends PrimaryStorageBase {
     }
 
     public static class DeleteVolumeChainRsp extends AgentResponse {
+        public List<String> undeletedInstallPaths;
     }
 
     public static class CleanTrashCmd extends AgentCommand {
@@ -1742,7 +1743,7 @@ public class CephPrimaryStorageBase extends PrimaryStorageBase {
         cmd.format = msg.hasSystemTag(VolumeSystemTags.FORMAT_QCOW2.getTagFormat()) ? VolumeConstant.VOLUME_FORMAT_QCOW2 : VolumeConstant.VOLUME_FORMAT_RAW ;
 
         final InstantiateVolumeOnPrimaryStorageReply reply = new InstantiateVolumeOnPrimaryStorageReply();
-        
+
         httpCall(CREATE_VOLUME_PATH, cmd, CreateEmptyVolumeRsp.class, new ReturnValueCompletion<CreateEmptyVolumeRsp>(msg) {
             @Override
             public void fail(ErrorCode err) {
@@ -5280,6 +5281,11 @@ public class CephPrimaryStorageBase extends PrimaryStorageBase {
 
             @Override
             public void fail(ErrorCode errorCode) {
+                CephDeleteVolumeSnapshotGC snapshotGC = new CephDeleteVolumeSnapshotGC();
+                snapshotGC.NAME = String.format("gc-ceph-%s-volumesnapshot-path-%s", self.getUuid(), cmd.snapshotPath);
+                snapshotGC.primaryStorageUuid = self.getUuid();
+                snapshotGC.volumeSnapshot = msg.getSnapshot();
+                snapshotGC.deduplicateSubmit(CephGlobalConfig.GC_INTERVAL.value(Long.class), TimeUnit.SECONDS);
                 reply.setError(errorCode);
                 bus.reply(msg, reply);
                 completion.done();
@@ -5859,14 +5865,31 @@ public class CephPrimaryStorageBase extends PrimaryStorageBase {
         DeleteVolumeChainOnPrimaryStorageReply reply = new DeleteVolumeChainOnPrimaryStorageReply();
         DeleteVolumeChainCmd cmd = new DeleteVolumeChainCmd();
         cmd.installPaths = msg.getInstallPaths();
-        new HttpCaller<>(DELETE_VOLUME_CHAIN_PATH, cmd, AgentResponse.class, new ReturnValueCompletion<AgentResponse>(msg) {
+        new HttpCaller<>(DELETE_VOLUME_CHAIN_PATH, cmd, DeleteVolumeChainRsp.class, new ReturnValueCompletion<DeleteVolumeChainRsp>(msg) {
+            private void submitGcForUndeletedInstallPaths(List<String> undeletedInstallPaths) {
+                CephDeleteVolumeChainGC volumeChainGC = new CephDeleteVolumeChainGC();
+                volumeChainGC.primaryStorageUuid = self.getUuid();
+                volumeChainGC.installPaths = undeletedInstallPaths;
+                volumeChainGC.NAME = String.format("gc-ceph-%s-volume-chain-%s", self.getUuid(), msg.getChainTop());
+                volumeChainGC.chainTop = msg.getChainTop();
+                volumeChainGC.deduplicateSubmit(CephGlobalConfig.GC_INTERVAL.value(Long.class), TimeUnit.SECONDS);
+                logger.debug(String.format("unable to delete installPaths %s, now add GC to delete", undeletedInstallPaths));
+            }
+
             @Override
-            public void success(AgentResponse rsp) {
+            public void success(DeleteVolumeChainRsp rsp) {
+                if (CollectionUtils.isEmpty(rsp.undeletedInstallPaths)) {
+                    bus.reply(msg, reply);
+                    return;
+                }
+                submitGcForUndeletedInstallPaths(rsp.undeletedInstallPaths);
+                reply.setUndeletedInstallPaths(rsp.undeletedInstallPaths);
                 bus.reply(msg, reply);
             }
 
             @Override
             public void fail(ErrorCode errorCode) {
+                submitGcForUndeletedInstallPaths(cmd.installPaths);
                 reply.setError(errorCode);
                 bus.reply(msg, reply);
             }

--- a/test/src/test/groovy/org/zstack/test/integration/storage/primary/ceph/CephGCCase.groovy
+++ b/test/src/test/groovy/org/zstack/test/integration/storage/primary/ceph/CephGCCase.groovy
@@ -1,15 +1,23 @@
 package org.zstack.test.integration.storage.primary.ceph
 
+import org.springframework.http.HttpEntity
+import org.zstack.core.db.SQL
 import org.zstack.core.gc.GCStatus
+import org.zstack.core.gc.GarbageCollectorVO
+import org.zstack.core.gc.GarbageCollectorVO_
 import org.zstack.header.volume.VolumeDeletionPolicyManager
 import org.zstack.sdk.DiskOfferingInventory
 import org.zstack.sdk.GarbageCollectorInventory
 import org.zstack.sdk.PrimaryStorageInventory
 import org.zstack.sdk.VolumeInventory
+import org.zstack.sdk.VolumeSnapshotInventory
 import org.zstack.storage.ceph.CephGlobalConfig
+import org.zstack.storage.ceph.primary.CephDeleteVolumeChainGC
 import org.zstack.storage.ceph.primary.CephDeleteVolumeGC
+import org.zstack.storage.ceph.primary.CephDeleteVolumeSnapshotGC
 import org.zstack.storage.ceph.primary.CephPrimaryStorageBase
 import org.zstack.storage.volume.VolumeGlobalConfig
+import org.zstack.storage.volume.VolumeSystemTags
 import org.zstack.test.integration.storage.CephEnv
 import org.zstack.test.integration.storage.StorageTest
 import org.zstack.testlib.ClusterSpec
@@ -18,6 +26,8 @@ import org.zstack.testlib.EnvSpec
 import org.zstack.testlib.HttpError
 import org.zstack.testlib.PrimaryStorageSpec
 import org.zstack.testlib.SubCase
+import org.zstack.testlib.vfs.VFS
+import org.zstack.utils.gson.JSONObjectUtil
 
 import java.util.concurrent.TimeUnit
 
@@ -137,6 +147,213 @@ class CephGCCase extends SubCase {
         }
     }
 
+    void testVolumeSnapshotGC() {
+        env.cleanSimulatorAndMessageHandlers()
+        VolumeInventory vol = createDataVolume {
+            name = "data"
+            diskOfferingUuid = diskOffering.uuid
+            primaryStorageUuid = ceph.uuid
+        }
+
+        def sp = createVolumeSnapshot {
+            name = "test-gc"
+            volumeUuid = vol.uuid
+        } as VolumeSnapshotInventory
+
+        def deleteFailed = true
+        def deleteSucVol = []
+        env.simulator(CephPrimaryStorageBase.DELETE_SNAPSHOT_PATH) { HttpEntity<String> e, EnvSpec spec ->
+            def rsp = new CephPrimaryStorageBase.DeleteSnapshotRsp()
+            if (deleteFailed) {
+                rsp.setError("it's children in trash, cannot delete")
+            }
+            return rsp
+        }
+        env.simulator(CephPrimaryStorageBase.DELETE_PATH) { HttpEntity<String> e, EnvSpec spec ->
+            def rsp = new CephPrimaryStorageBase.DeleteRsp()
+            def cmd = JSONObjectUtil.toObject(e.body, CephPrimaryStorageBase.DeleteCmd.class)
+            if (deleteSucVol.contains(cmd.installPath)) {
+                return rsp
+            }
+            if (deleteFailed) {
+                rsp.setError("snapshot exists")
+            }
+            return rsp
+        }
+        def callGc = false
+        def undeletedInstallPaths = []
+        env.hijackSimulator(CephPrimaryStorageBase.DELETE_VOLUME_CHAIN_PATH) { CephPrimaryStorageBase.DeleteVolumeChainRsp rsp, HttpEntity<String> e ->
+            def cmd = JSONObjectUtil.toObject(e.body, CephPrimaryStorageBase.DeleteVolumeChainCmd.class)
+            // mock install path not clean
+            rsp.undeletedInstallPaths = cmd.installPaths
+
+            if (callGc) {
+                rsp.undeletedInstallPaths = undeletedInstallPaths
+            }
+            return rsp
+        }
+        def backingChain = []
+        env.hijackSimulator(CephPrimaryStorageBase.GET_BACKING_CHAIN_PATH) { CephPrimaryStorageBase.GetBackingChainRsp rsp, HttpEntity<String> e ->
+            rsp.backingChain = backingChain
+            return rsp
+        }
+
+        deleteDataVolume {
+            uuid = vol.uuid
+        }
+        expungeDataVolume {
+            uuid = vol.uuid
+        }
+
+        def spGC = queryGCJob {
+            conditions = ["runnerClass=${CephDeleteVolumeSnapshotGC.class.name}".toString(), "context~=%${sp.primaryStorageInstallPath}%".toString()]
+        } as List<GarbageCollectorInventory>
+        assert spGC.size() == 1
+        assert spGC[0].status != GCStatus.Done.toString()
+
+        def volGC = queryGCJob {
+            conditions = ["runnerClass=${CephDeleteVolumeGC.class.name}".toString(), "context~=%${vol.installPath}%".toString()]
+        } as List<GarbageCollectorInventory>
+        assert volGC.size() == 1
+        assert volGC[0].status != GCStatus.Done.toString()
+
+        deleteFailed = false
+        triggerGCJob {
+            uuid = spGC[0].uuid
+        }
+
+        triggerGCJob {
+            uuid = volGC[0].uuid
+        }
+
+        retryInSecs {
+            assert queryGCJob {
+                conditions = ["runnerClass=${CephDeleteVolumeSnapshotGC.class.name}".toString(), "context~=%${sp.primaryStorageInstallPath}%".toString()]
+            }[0].status == GCStatus.Done.toString()
+            assert queryGCJob {
+                conditions = ["runnerClass=${CephDeleteVolumeGC.class.name}".toString(), "context~=%${vol.installPath}%".toString()]
+            }[0].status == GCStatus.Done.toString()
+        }
+        SQL.New(GarbageCollectorVO.class).in(GarbageCollectorVO_.uuid, [volGC[0].uuid, spGC[0].uuid]).hardDelete()
+        vol = createDataVolume {
+            name = "data"
+            diskOfferingUuid = diskOffering.uuid
+            primaryStorageUuid = ceph.uuid
+        }
+
+        sp = createVolumeSnapshot {
+            name = "test-gc"
+            volumeUuid = vol.uuid
+        } as VolumeSnapshotInventory
+
+        VolumeInventory incVol = createDataVolumeFromVolumeSnapshot {
+            volumeSnapshotUuid = sp.uuid
+            name = "incVol"
+            systemTags = [VolumeSystemTags.FAST_CREATE.tagFormat]
+        }
+
+        def sp2 = createVolumeSnapshot {
+            name = "test-gc2"
+            volumeUuid = incVol.uuid
+        } as VolumeSnapshotInventory
+
+        VolumeInventory incVol2 = createDataVolumeFromVolumeSnapshot {
+            volumeSnapshotUuid = sp2.uuid
+            name = "incVol2"
+            systemTags = [VolumeSystemTags.FAST_CREATE.tagFormat]
+        }
+
+        deleteFailed = true
+        deleteSucVol = [incVol2.installPath]
+        backingChain = [sp.primaryStorageInstallPath]
+        deleteDataVolume {
+            uuid = vol.uuid
+        }
+        expungeDataVolume {
+            uuid = vol.uuid
+        }
+        deleteDataVolume {
+            uuid = incVol.uuid
+        }
+        expungeDataVolume {
+            uuid = incVol.uuid
+        }
+        deleteDataVolume {
+            uuid = incVol2.uuid
+        }
+        expungeDataVolume {
+            uuid = incVol2.uuid
+        }
+
+        retryInSecs {
+            spGC = queryGCJob {
+                conditions = ["runnerClass=${CephDeleteVolumeChainGC.class.name}".toString()]
+            } as List<GarbageCollectorInventory>
+            assert spGC.size() == 1
+            assert spGC[0].status != GCStatus.Done.toString()
+            assert spGC[0].context.contains(sp2.primaryStorageInstallPath)
+            assert spGC[0].context.contains(sp.primaryStorageInstallPath)
+        }
+
+        deleteFailed = false
+        callGc = true
+        undeletedInstallPaths = [sp2.primaryStorageInstallPath, sp.primaryStorageInstallPath]
+        triggerGCJob {
+            uuid = spGC[0].uuid
+        }
+        triggerGCJob {
+            uuid = spGC[0].uuid
+        }
+
+        assert !retryInSecs(2) {
+            def jobs = queryGCJob {
+                conditions = ["runnerClass=${CephDeleteVolumeChainGC.class.name}".toString()]
+            } as List<GarbageCollectorInventory>
+            // no duplicate gc
+            return jobs.size() != 1 || jobs[0].uuid != spGC[0].uuid || jobs[0].context != spGC[0].context
+        }
+
+        env.cleanSimulatorAndMessageHandlers()
+
+        SQL.New(GarbageCollectorVO.class).in(GarbageCollectorVO_.uuid, [spGC[0].uuid]).hardDelete()
+        vol = createDataVolume {
+            name = "data"
+            diskOfferingUuid = diskOffering.uuid
+            primaryStorageUuid = ceph.uuid
+        }
+
+        sp = createVolumeSnapshot {
+            name = "test-gc"
+            volumeUuid = vol.uuid
+        } as VolumeSnapshotInventory
+
+        incVol = createDataVolumeFromVolumeSnapshot {
+            volumeSnapshotUuid = sp.uuid
+            name = "incVol"
+            systemTags = [VolumeSystemTags.FAST_CREATE.tagFormat]
+        }
+
+        deleteDataVolume {
+            uuid = vol.uuid
+        }
+        expungeDataVolume {
+            uuid = vol.uuid
+        }
+        deleteDataVolume {
+            uuid = incVol.uuid
+        }
+        expungeDataVolume {
+            uuid = incVol.uuid
+        }
+
+        assert !retryInSecs(2) {
+            spGC = queryGCJob {
+                conditions = ["runnerClass=${CephDeleteVolumeChainGC.class.name}".toString(), "context~=%${sp.primaryStorageInstallPath}%".toString()]
+            } as List<GarbageCollectorInventory>
+            return spGC.size() > 0
+        }
+    }
+
     void prepareEnv() {
         env.preSimulator(CephPrimaryStorageBase.DELETE_PATH) {
             if (deleteFail) {
@@ -157,6 +374,7 @@ class CephGCCase extends SubCase {
             CephGlobalConfig.GC_INTERVAL.updateValue(TimeUnit.DAYS.toSeconds(1))
             VolumeGlobalConfig.VOLUME_DELETION_POLICY.updateValue(VolumeDeletionPolicyManager.VolumeDeletionPolicy.Direct.toString())
 
+            testVolumeSnapshotGC()
             prepareEnv()
             testVolumeGCSuccess()
             testVolumeGCCancelledAfterPrimaryStorageDeleted()

--- a/testlib/src/main/java/org/zstack/testlib/CephPrimaryStorageSpec.groovy
+++ b/testlib/src/main/java/org/zstack/testlib/CephPrimaryStorageSpec.groovy
@@ -559,7 +559,7 @@ class CephPrimaryStorageSpec extends PrimaryStorageSpec {
                         return
                     }
 
-                    if (f.parent?.pathString() == snapshotPath) {
+                    if (f.parent?.setVolumeChainInstallPaths() == snapshotPath) {
                         children.add(f.pathString())
                     }
                 }
@@ -730,12 +730,17 @@ class CephPrimaryStorageSpec extends PrimaryStorageSpec {
             }
 
             simulator(CephPrimaryStorageBase.DELETE_VOLUME_CHAIN_PATH) { HttpEntity<String> e, EnvSpec spec ->
-                return new CephPrimaryStorageBase.GetBackingChainRsp()
+                def cmd = JSONObjectUtil.toObject(e.body, CephPrimaryStorageBase.DeleteVolumeChainCmd.class)
+                def rsp = new CephPrimaryStorageBase.DeleteVolumeChainRsp()
+                rsp.undeletedInstallPaths = []
+                return rsp
             }
 
-            VFS.vfsHook(CephPrimaryStorageBase.DELETE_VOLUME_CHAIN_PATH, espec) { CephPrimaryStorageBase.AgentResponse rsp, HttpEntity<String> e, EnvSpec spec ->
+            // TODO Need to implement ceph trash in VFS
+            VFS.vfsHook(CephPrimaryStorageBase.DELETE_VOLUME_CHAIN_PATH, espec) { CephPrimaryStorageBase.DeleteVolumeChainRsp rsp, HttpEntity<String> e, EnvSpec spec ->
                 def cmd = JSONObjectUtil.toObject(e.body, CephPrimaryStorageBase.DeleteVolumeChainCmd.class)
                 VFS vfs = vfs(cmd, spec)
+                rsp.undeletedInstallPaths = []
 
                 for (String path : cmd.installPaths) {
                     String vfsPath = cephPathToVFSPath(path)


### PR DESCRIPTION
If children are still stored in the trash, it will prevent the parent from being completely deleted. At this time, add GC to continuously delete the parent. When child are deleted from the trash, the parent will also be deleted by GC.

Resolves/Related: ZSTAC-73269
Resolves/Related: ZSV-9206

Change-Id: I900f6570657a65767978646d6d6e7365796e7990

sync from gitlab !8705