### PR TITLE
<fix>[conf]: support comparing remote and local quota info in RegisterLicenseServer

### DIFF
--- a/conf/errorCodes/license.xml
+++ b/conf/errorCodes/license.xml
@@ -77,6 +77,21 @@
     </code>
 
     <code>
+        <id>3005</id>
+        <description>The remote license has expired</description>
+    </code>
+
+    <code>
+        <id>3006</id>
+        <description>The remote license expires earlier than the local license</description>
+    </code>
+
+    <code>
+        <id>3007</id>
+        <description>The remote license available capacity is lower than the local license</description>
+    </code>
+
+    <code>
         <id>3100</id>
         <description>License server generic error</description>
     </code>


### PR DESCRIPTION
Resolves: ZSTAC-79953

Change-Id: I646379953a7923767067706e7a6e667a796f686d

sync from gitlab !8784