### PR TITLE
<fix>[ldap]: fix ldap sync with uncommon username property

### DIFF
--- a/plugin/ldap/src/main/java/org/zstack/ldap/compute/LdapSyncHelper.java
+++ b/plugin/ldap/src/main/java/org/zstack/ldap/compute/LdapSyncHelper.java
@@ -1,5 +1,6 @@
 package org.zstack.ldap.compute;
 
+import org.apache.commons.lang.StringUtils;
 import org.springframework.beans.factory.annotation.Autowire;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Configurable;
@@ -378,6 +379,9 @@ public class LdapSyncHelper {
     private String[] buildReturnAttribute() {
         Set<String> attributeSet = new HashSet<>(Arrays.asList(LdapConstant.QUERY_LDAP_ENTRY_MUST_RETURN_ATTRIBUTES));
         attributeSet.add(findGlobalUuidKey());
+        if (StringUtils.isNotEmpty(taskSpec.getUsernameProperty())) {
+            attributeSet.add(taskSpec.getUsernameProperty());
+        }
         return attributeSet.toArray(new String[0]);
     }
 


### PR DESCRIPTION
This patch is for zsv_4.10.28, and cherry-pick to zsv_4.10.25

Resolves: ZSV-10572
Related: ZSV-10566
Related: ZSV-5531

Change-Id: I7a6e7070746972616a6862626b72637472736a6c
(cherry picked from commit 21012485cb7ea6b5cc452c98d937fa6fa6a686de)

sync from gitlab !8815