### PR TITLE
<fix>[snapshot]: fix UndoSnapshotCreation error on sblk

### DIFF
--- a/plugin/kvm/src/main/java/org/zstack/kvm/KVMAgentCommands.java
+++ b/plugin/kvm/src/main/java/org/zstack/kvm/KVMAgentCommands.java
@@ -3840,6 +3840,15 @@ public class KVMAgentCommands {
         private VolumeTO volume;
         private String top;
         private String base;
+        private boolean live;
+
+        public boolean isLive() {
+            return live;
+        }
+
+        public void setLive(boolean live) {
+            this.live = live;
+        }
 
         public String getVmUuid() {
             return vmUuid;

--- a/plugin/kvm/src/main/java/org/zstack/kvm/KVMHost.java
+++ b/plugin/kvm/src/main/java/org/zstack/kvm/KVMHost.java
@@ -1025,6 +1025,8 @@ public class KVMHost extends HostBase implements Host {
             if (state != VmInstanceState.Running && state != VmInstanceState.Stopped && state != VmInstanceState.Paused) {
                 throw new OperationFailureException(operr("vm[uuid:%s] is not Running or Stopped, current state[%s]", msg.getVmUuid(), state));
             }
+
+            cmd.setLive(state == VmInstanceState.Running || state == VmInstanceState.Paused);
         }
 
         cmd.setVmUuid(msg.getVmUuid());


### PR DESCRIPTION
1.deactive snapshot lv on other host before committing volume.
2.do not resize qcow2, only resize snapshot lv before committing volume.

Resolves/Related: ZSTAC-77942

Change-Id: I767861677267636b677578636267746c62777479

sync from gitlab !8834