### PR TITLE
<fix>[compute]: fix DiskAO usage

### DIFF
--- a/plugin/localstorage/src/main/java/org/zstack/storage/primary/local/LocalStorageDefaultAllocateCapacityFlow.java
+++ b/plugin/localstorage/src/main/java/org/zstack/storage/primary/local/LocalStorageDefaultAllocateCapacityFlow.java
@@ -261,7 +261,7 @@ public class LocalStorageDefaultAllocateCapacityFlow implements Flow {
         rmsg.setRequiredPrimaryStorageUuid(localStorageUuid);
         rmsg.setPossiblePrimaryStorageTypes(primaryStorageTypes);
         rmsg.setRequiredHostUuid(spec.getDestHost().getUuid());
-        rmsg.setSize(spec.getRootDiskAllocateSize());
+        rmsg.setSize(spec.getRootDisk().getSize() > 0 ? spec.getRootDisk().getSize() : spec.getRootDiskAllocateSize());
         if (spec.getRootDiskOffering() != null) {
             rmsg.setDiskOfferingUuid(spec.getRootDiskOffering().getUuid());
         }

--- a/plugin/localstorage/src/main/java/org/zstack/storage/primary/local/LocalStorageDesignatedAllocateCapacityFlow.java
+++ b/plugin/localstorage/src/main/java/org/zstack/storage/primary/local/LocalStorageDesignatedAllocateCapacityFlow.java
@@ -165,7 +165,7 @@ public class LocalStorageDesignatedAllocateCapacityFlow implements Flow {
         }
 
         rmsg.setRequiredHostUuid(spec.getDestHost().getUuid());
-        rmsg.setSize(spec.getRootDiskAllocateSize());
+        rmsg.setSize(spec.getRootDisk().getSize() > 0 ? spec.getRootDisk().getSize() : spec.getRootDiskAllocateSize());
         if (spec.getRootDiskOffering() != null) {
             rmsg.setDiskOfferingUuid(spec.getRootDiskOffering().getUuid());
         }


### PR DESCRIPTION
fix DiskAO usage in LocalStorageDesignatedAllocateCapacityFlow

If the DiskAO.size of the root disk is specified,
Directly use DiskAO.size as the root volume size

Resolves: ZSV-10610

Change-Id: I766d6762657a73666e667a706e75777561796264

sync from gitlab !8849