### PR TITLE
<fix>[ovnha]: ovn-controller didn't clear cache properly.

### DIFF
--- a/plugin/kvm/src/main/java/org/zstack/kvm/KVMAgentCommands.java
+++ b/plugin/kvm/src/main/java/org/zstack/kvm/KVMAgentCommands.java
@@ -4890,6 +4890,7 @@ public class KVMAgentCommands {
     }
 
     public static class OvsSetDbConnectionCmd extends AgentCommand {
+        public boolean refreshCache;
         public List<String> nodes;
     }
 


### PR DESCRIPTION
ovn-controller didn't clear the cache.

APIImpact/GlobalConfigImpact/GlobalPropertyImpact/DBImpact/ZQLImpact

Resolves/Related: ZSTAC-80312
Change-Id: 2d56f757-32cf-41b4-b636-dc006911c4d3

sync from gitlab !8874