### PR TITLE
<chore>[compute]: replace operr with cause args by withCause methods

### DIFF
--- a/compute/src/main/java/org/zstack/compute/allocator/HostAllocatorChain.java
+++ b/compute/src/main/java/org/zstack/compute/allocator/HostAllocatorChain.java
@@ -163,7 +163,7 @@ public class HostAllocatorChain implements HostAllocatorTrigger, HostAllocatorSt
         context.spec = allocationSpec;
         context.paginationInfo = paginationInfo;
         context.hostConsumer = hosts::addAll;
-        context.errorReporter = errorCode -> fail(operr(errorCode, "failed to allocate hosts"));
+        context.errorReporter = errorCode -> fail(operr("failed to allocate hosts").withCause(errorCode));
 
         if (producerInUse == null) {
             for (HostCandidateProducer producer : producers) {
@@ -257,16 +257,9 @@ public class HostAllocatorChain implements HostAllocatorTrigger, HostAllocatorSt
         result = null;
         this.errorCode = err(HostAllocatorError.NO_AVAILABLE_HOST, "[Host Allocation] no host meet the requirements");
         this.errorCode.setOpaque(buildOpaque());
-
-        ErrorCode errors = new ErrorCode();
-        errors.setDetails("pagination error list in causes fields");
-        this.errorCode.setCause(errors);
-
-        errors.setCauses(new ArrayList<>());
-        errors.getCauses().add(errorCode);
-
+        this.errorCode.withCause(errorCode);
         if (!seriesErrorWhenPagination.isEmpty()) {
-            errors.getCauses().addAll(seriesErrorWhenPagination);
+            this.errorCode.withCause(seriesErrorWhenPagination);
         }
 
         done();

--- a/compute/src/main/java/org/zstack/compute/vm/VmInstanceBase.java
+++ b/compute/src/main/java/org/zstack/compute/vm/VmInstanceBase.java
@@ -2809,8 +2809,9 @@ public class VmInstanceBase extends AbstractVmInstance {
                     msg.getRootVolumeInventory().getPrimaryStorageUuid());
             bus.send(cmsg, new CloudBusCallBack(chain) {
                 private void fail(ErrorCode errorCode) {
-                    reply.setError(operr(errorCode, "failed to create template from root volume[uuid:%s] on primary storage[uuid:%s]",
-                            msg.getRootVolumeInventory().getUuid(), msg.getRootVolumeInventory().getPrimaryStorageUuid()));
+                    reply.setError(operr("failed to create template from root volume[uuid:%s] on primary storage[uuid:%s]",
+                            msg.getRootVolumeInventory().getUuid(), msg.getRootVolumeInventory().getPrimaryStorageUuid())
+                            .withCause(errorCode));
                     logger.warn(reply.getError().getDetails());
                     bus.reply(msg, reply);
                 }
@@ -5833,8 +5834,8 @@ public class VmInstanceBase extends AbstractVmInstance {
             @Override
             public void run(MessageReply innerReply) {
                 if (!innerReply.isSuccess()) {
-                    completion.fail(Platform.operr(innerReply.getError(),
-                            "Failed to update vm[uuid=%s] on hypervisor.", self.getUuid()));
+                    completion.fail(Platform.operr("failed to update vm[uuid=%s] on hypervisor.", self.getUuid())
+                            .withCause(innerReply.getError()));
                     return;
                 }
                 final UpdateVmOnHypervisorReply casedReply = innerReply.castReply();
@@ -5985,8 +5986,8 @@ public class VmInstanceBase extends AbstractVmInstance {
                     @Override
                     public void run(MessageReply innerReply) {
                         if (!innerReply.isSuccess()) {
-                            trigger.fail(Platform.operr(innerReply.getError(),
-                                    "failed to update vm[uuid=%s] on hypervisor", self.getUuid()));
+                            trigger.fail(Platform.operr("failed to update vm[uuid=%s] on hypervisor", self.getUuid())
+                                    .withCause(innerReply.getError()));
                             return;
                         }
                         final UpdateVmOnHypervisorReply casedReply = innerReply.castReply();
@@ -7171,8 +7172,8 @@ public class VmInstanceBase extends AbstractVmInstance {
         }).error(new FlowErrorHandler(completion) {
             @Override
             public void handle(ErrorCode errCode, Map data) {
-                completion.fail(operr(errCode, "Failed to detach volume[uuid=%s] of VM[uuid=%s]",
-                        msg.getVolume().getUuid(), self.getUuid()));
+                completion.fail(operr("failed to detach volume[uuid=%s] of VM[uuid=%s]",
+                        msg.getVolume().getUuid(), self.getUuid()).withCause(errCode));
             }
         }).start();
     }
@@ -7890,7 +7891,7 @@ public class VmInstanceBase extends AbstractVmInstance {
                     logger.warn(e.getMessage());
                 }
 
-                completion.fail(operr(errCode, errCode.getDetails()));
+                completion.fail(errCode);
             }
         }).start();
     }

--- a/identity/src/main/java/org/zstack/identity/AccountManagerImpl.java
+++ b/identity/src/main/java/org/zstack/identity/AccountManagerImpl.java
@@ -1098,7 +1098,8 @@ public class AccountManagerImpl extends AbstractService implements AccountManage
             ErrorCode errorCode = checker.check(quota, msg.getValue());
             if (errorCode != null) {
                 throw new ApiMessageInterceptionException(
-                        operr(errorCode, "cannot update Quota[name: %s] for the account[uuid: %s]", msg.getName(), msg.getIdentityUuid()));
+                        operr("cannot update Quota[name: %s] for the account[uuid: %s]", msg.getName(), msg.getIdentityUuid())
+                                .withCause(errorCode));
             }
         }
 

--- a/plugin/account-import/src/main/java/org/zstack/identity/imports/source/AbstractAccountSourceBase.java
+++ b/plugin/account-import/src/main/java/org/zstack/identity/imports/source/AbstractAccountSourceBase.java
@@ -471,8 +471,9 @@ public abstract class AbstractAccountSourceBase {
         }).error(new FlowErrorHandler(completion) {
             @Override
             public void handle(ErrorCode errCode, Map data) {
-                completion.fail(operr(errCode, "failed to import account from source[uuid=%s, type=%s]",
-                        spec.getSourceUuid(), spec.getSourceType()));
+                completion.fail(operr("failed to import account from source[uuid=%s, type=%s]",
+                        spec.getSourceUuid(), spec.getSourceType())
+                                .withCause(errCode));
             }
         }).start();
     }
@@ -684,8 +685,9 @@ public abstract class AbstractAccountSourceBase {
         }).error(new FlowErrorHandler(completion) {
             @Override
             public void handle(ErrorCode errCode, Map data) {
-                completion.fail(operr(errCode, "failed to unbinding accounts from source[uuid=%s, type=%s]",
-                        self.getUuid(), self.getType()));
+                completion.fail(operr("failed to unbinding accounts from source[uuid=%s, type=%s]",
+                        self.getUuid(), self.getType())
+                                .withCause(errCode));
             }
         }).start();
     }
@@ -894,8 +896,8 @@ public abstract class AbstractAccountSourceBase {
         }).error(new FlowErrorHandler(completion) {
             @Override
             public void handle(ErrorCode errCode, Map data) {
-                completion.fail(operr(errCode, "failed to delete source[uuid=%s, type=%s]",
-                        self.getUuid(), self.getType()));
+                completion.fail(operr("failed to delete source[uuid=%s, type=%s]", self.getUuid(), self.getType())
+                                .withCause(errCode));
             }
         }).start();
     }

--- a/plugin/kvm/src/main/java/org/zstack/kvm/hypervisor/KvmHypervisorInfoExtensions.java
+++ b/plugin/kvm/src/main/java/org/zstack/kvm/hypervisor/KvmHypervisorInfoExtensions.java
@@ -122,7 +122,7 @@ public class KvmHypervisorInfoExtensions implements
                         if (reply.isSuccess()) {
                             trigger.next();
                         } else {
-                            trigger.fail(operr(reply.getError(), "failed to collect host virtualizer info"));
+                            trigger.fail(operr("failed to collect host virtualizer info").withCause(reply.getError()));
                         }
                     }
                 });

--- a/storage/src/main/java/org/zstack/storage/snapshot/VolumeSnapshotManagerImpl.java
+++ b/storage/src/main/java/org/zstack/storage/snapshot/VolumeSnapshotManagerImpl.java
@@ -1074,9 +1074,8 @@ public class VolumeSnapshotManagerImpl extends AbstractService implements
                         bus.makeTargetServiceIdByResourceUuid(askMsg, PrimaryStorageConstant.SERVICE_ID, primaryStorageUuid);
                         MessageReply reply = bus.call(askMsg);
                         if (!reply.isSuccess()) {
-                            ret.setError(operr(reply.getError(),
-                                    "cannot ask primary storage[uuid:%s] for volume snapshot capability",
-                                    vol.getUuid()));
+                            ret.setError(operr("cannot ask primary storage[uuid:%s] for volume snapshot capability",
+                                    vol.getUuid()).withCause(reply.getError()));
                             bus.reply(msg, ret);
                             trigger.fail(ret.getError());
                             return;


### PR DESCRIPTION
operr with cause args will not be scanned by I18nGenerator

This patch is for zsv_4.10.28

Resolves: ZSV-10663
Related: ZSV-10444

Change-Id: I73646a706b71627968736a676c786b766461626f

sync from gitlab !8890