### PR TITLE
<fix>[hygon]: Fix APIGenerateHygonMdevDevicesMsg to ungenerate before generate

### DIFF
--- a/sdk/src/main/java/org/zstack/sdk/SetVmInstanceHygonMdevAction.java
+++ b/sdk/src/main/java/org/zstack/sdk/SetVmInstanceHygonMdevAction.java
@@ -1,0 +1,104 @@
+package org.zstack.sdk;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.zstack.sdk.*;
+
+public class SetVmInstanceHygonMdevAction extends AbstractAction {
+
+    private static final HashMap<String, Parameter> parameterMap = new HashMap<>();
+
+    private static final HashMap<String, Parameter> nonAPIParameterMap = new HashMap<>();
+
+    public static class Result {
+        public ErrorCode error;
+        public org.zstack.sdk.SetVmInstanceHygonMdevResult value;
+
+        public Result throwExceptionIfError() {
+            if (error != null) {
+                throw new ApiException(
+                    String.format("error[code: %s, description: %s, details: %s]", error.code, error.description, error.details)
+                );
+            }
+            
+            return this;
+        }
+    }
+
+    @Param(required = true, nonempty = false, nullElements = false, emptyString = true, noTrim = false)
+    public java.lang.String uuid;
+
+    @Param(required = true, validValues = {"true","false"}, nonempty = false, nullElements = false, emptyString = true, noTrim = false)
+    public java.lang.String hygonSecurityElementEnable;
+
+    @Param(required = false)
+    public java.util.List systemTags;
+
+    @Param(required = false)
+    public java.util.List userTags;
+
+    @Param(required = false)
+    public String sessionId;
+
+    @Param(required = false)
+    public String accessKeyId;
+
+    @Param(required = false)
+    public String accessKeySecret;
+
+    @Param(required = false)
+    public String requestIp;
+
+    @NonAPIParam
+    public long timeout = -1;
+
+    @NonAPIParam
+    public long pollingInterval = -1;
+
+
+    private Result makeResult(ApiResult res) {
+        Result ret = new Result();
+        if (res.error != null) {
+            ret.error = res.error;
+            return ret;
+        }
+        
+        org.zstack.sdk.SetVmInstanceHygonMdevResult value = res.getResult(org.zstack.sdk.SetVmInstanceHygonMdevResult.class);
+        ret.value = value == null ? new org.zstack.sdk.SetVmInstanceHygonMdevResult() : value; 
+
+        return ret;
+    }
+
+    public Result call() {
+        ApiResult res = ZSClient.call(this);
+        return makeResult(res);
+    }
+
+    public void call(final Completion<Result> completion) {
+        ZSClient.call(this, new InternalCompletion() {
+            @Override
+            public void complete(ApiResult res) {
+                completion.complete(makeResult(res));
+            }
+        });
+    }
+
+    protected Map<String, Parameter> getParameterMap() {
+        return parameterMap;
+    }
+
+    protected Map<String, Parameter> getNonAPIParameterMap() {
+        return nonAPIParameterMap;
+    }
+
+    protected RestInfo getRestInfo() {
+        RestInfo info = new RestInfo();
+        info.httpMethod = "POST";
+        info.path = "/vm-instances/{uuid}/hygon-mdev";
+        info.needSession = true;
+        info.needPoll = true;
+        info.parameterName = "params";
+        return info;
+    }
+
+}

--- a/sdk/src/main/java/org/zstack/sdk/SetVmInstanceHygonMdevResult.java
+++ b/sdk/src/main/java/org/zstack/sdk/SetVmInstanceHygonMdevResult.java
@@ -1,0 +1,7 @@
+package org.zstack.sdk;
+
+
+
+public class SetVmInstanceHygonMdevResult {
+
+}

--- a/testlib/src/main/java/org/zstack/testlib/ApiHelper.groovy
+++ b/testlib/src/main/java/org/zstack/testlib/ApiHelper.groovy
@@ -39527,6 +39527,33 @@ abstract class ApiHelper {
     }
 
 
+    def setVmInstanceHygonMdev(@DelegatesTo(strategy = Closure.OWNER_FIRST, value = org.zstack.sdk.SetVmInstanceHygonMdevAction.class) Closure c) {
+        def a = new org.zstack.sdk.SetVmInstanceHygonMdevAction()
+        a.sessionId = Test.currentEnvSpec?.session?.uuid
+        c.resolveStrategy = Closure.OWNER_FIRST
+        c.delegate = a
+        c()
+        
+
+        if (System.getProperty("apipath") != null) {
+            if (a.apiId == null) {
+                a.apiId = Platform.uuid
+            }
+    
+            def tracker = new ApiPathTracker(a.apiId)
+            def out = errorOut(a.call())
+            def path = tracker.getApiPath()
+            if (!path.isEmpty()) {
+                Test.apiPaths[a.class.name] = path.join(" --->\n")
+            }
+        
+            return out
+        } else {
+            return errorOut(a.call())
+        }
+    }
+
+
     def setVmMonitorNumber(@DelegatesTo(strategy = Closure.OWNER_FIRST, value = org.zstack.sdk.SetVmMonitorNumberAction.class) Closure c) {
         def a = new org.zstack.sdk.SetVmMonitorNumberAction()
         a.sessionId = Test.currentEnvSpec?.session?.uuid


### PR DESCRIPTION
Use FlowChain to ensure ungenerateHygonMdevDevices completes before
generateHygonMdevDevices. Update interceptor to check running VMs.

Resolves: ZSTAC-79099

Change-Id: I777774646773776a6a696a71786b77756c6e6d69

sync from gitlab !8894