### PR TITLE
<fix>[ovnha]: resolve ambiguous 'type' column in OVN L2 network query

### DIFF
--- a/network/src/main/java/org/zstack/network/l2/L2NoVlanNetwork.java
+++ b/network/src/main/java/org/zstack/network/l2/L2NoVlanNetwork.java
@@ -953,7 +953,7 @@ public class L2NoVlanNetwork implements L2Network {
                                         " from L2NetworkVO l2, L2NetworkClusterRefVO ref, SystemTagVO tag" +
                                         " where l2.uuid = ref.l2NetworkUuid" +
                                         " and ref.clusterUuid = :clusterUuid" +
-                                        " and type = 'L2NoVlanNetwork'" +
+                                        " and l2.type = 'L2NoVlanNetwork'" +
                                         " and tag.resourceUuid=l2.uuid " +
                                         " and tag.resourceType='L2NetworkVO' " +
                                         " and tag.tag=:tag")


### PR DESCRIPTION
This is a regression bug. The query for L2 networks associated with an OVN controller recently introduced a join with the SystemTagVO table. Since both SystemTagVO and L2NetworkVO contain a type column, the SQL query failed with an "ambiguous column" error as the source table was not specified.
This patch fixes the issue by explicitly qualifying the type column with the correct table alias in the SQL query.

APIImpact/GlobalConfigImpact/GlobalPropertyImpact/DBImpact/ZQLImpact

Resolves/Related: ZSTAC-80696
Change-Id: cc998546-bc69-4e6c-9e47-fcadf9aebc6e

sync from gitlab !8897