### PR TITLE
<fix>[vhost]:fix start vm failed

### DIFF
--- a/compute/src/main/java/org/zstack/compute/vm/VmGlobalConfig.java
+++ b/compute/src/main/java/org/zstack/compute/vm/VmGlobalConfig.java
@@ -133,4 +133,8 @@ public class VmGlobalConfig {
     @GlobalConfigValidation(validValues = {"None", "AuthenticAMD"})
     @BindResourceConfig(value = {VmInstanceVO.class})
     public static GlobalConfig VM_CPUID_VENDOR = new GlobalConfig(CATEGORY, "vm.cpuid.vendor");
+
+    @GlobalConfigValidation(validValues = {"true", "false", "auto"})
+    @GlobalConfigDef(defaultValue = "false", type = String.class, description = "generate config required for vhost primary storage")
+    public static GlobalConfig GENERATE_CONFIG_VHOST_REQUIRED = new GlobalConfig(CATEGORY, "generate.config.vhost.required");
 }

--- a/plugin/vhost/src/main/java/org/zstack/vhost/kvm/KvmVhostNodeServer.java
+++ b/plugin/vhost/src/main/java/org/zstack/vhost/kvm/KvmVhostNodeServer.java
@@ -1,8 +1,10 @@
 package org.zstack.vhost.kvm;
 
+import javax.persistence.TypedQuery;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
+import org.zstack.compute.vm.VmGlobalConfig;
 import org.zstack.core.componentloader.PluginRegistry;
+import org.zstack.core.db.DatabaseFacade;
 import org.zstack.header.Component;
 import org.zstack.header.errorcode.ErrorCode;
 import org.zstack.header.errorcode.OperationFailureException;
@@ -15,6 +17,7 @@ import org.zstack.header.volume.VolumeInventory;
 import org.zstack.header.volume.VolumeProtocol;
 import org.zstack.header.volume.VolumeProtocolCapability;
 import org.zstack.kvm.*;
+import org.zstack.resourceconfig.ResourceConfigFacade;
 import org.zstack.storage.addon.primary.ExternalPrimaryStorageFactory;
 
 import java.util.ArrayList;
@@ -27,6 +30,10 @@ public class KvmVhostNodeServer implements Component, KVMStartVmExtensionPoint,
         KVMConvertVolumeExtensionPoint, KVMDetachVolumeExtensionPoint, KVMAttachVolumeExtensionPoint {
     @Autowired
     private ExternalPrimaryStorageFactory extPsFactory;
+    @Autowired
+    private DatabaseFacade dbf;
+    @Autowired
+    private ResourceConfigFacade rcf;
 
     private PluginRegistry pluginRgty;
 
@@ -39,6 +46,21 @@ public class KvmVhostNodeServer implements Component, KVMStartVmExtensionPoint,
         capability.setSupportReadonly(false);
     }
 
+    private boolean needSupportVhostPrimaryStorage(String clusterUuid) {
+        String generateVhostConfig = VmGlobalConfig.GENERATE_CONFIG_VHOST_REQUIRED.value(String.class);
+        if (!"auto".equals(generateVhostConfig)) {
+            return Boolean.parseBoolean(generateVhostConfig);
+        }
+        String sql = "select count(ref) from PrimaryStorageClusterRefVO ref, PrimaryStorageOutputProtocolRefVO protoRef" +
+                " where ref.primaryStorageUuid = protoRef.primaryStorageUuid" +
+                " and ref.clusterUuid = :clusterUuid" +
+                " and protoRef.outputProtocol = :outputProtocol";
+        TypedQuery<Long> q = dbf.getEntityManager().createQuery(sql, Long.class);
+        q.setParameter("clusterUuid", clusterUuid);
+        q.setParameter("outputProtocol", VolumeProtocol.Vhost.name());
+        Long count = q.getSingleResult();
+        return count != null && count > 0;
+    }
 
     @Override
     public void beforeStartVmOnKvm(KVMHostInventory host, VmInstanceSpec spec, KVMAgentCommands.StartVmCmd cmd) {
@@ -54,12 +76,14 @@ public class KvmVhostNodeServer implements Component, KVMStartVmExtensionPoint,
             }
         }
 
-        cmd.setDataVolumes(dtos);
         if (VolumeProtocol.Vhost.name().equals(spec.getDestRootVolume().getProtocol()) ||
-                spec.getDestDataVolumes().stream().anyMatch(v -> VolumeProtocol.Vhost.name().equals(v.getProtocol()))) {
+                spec.getDestDataVolumes().stream().anyMatch(v -> VolumeProtocol.Vhost.name().equals(v.getProtocol())) ||
+                needSupportVhostPrimaryStorage(host.getClusterUuid())) {
             cmd.setUseHugePage(true);
             cmd.setMemAccess("shared");
         }
+
+        cmd.setDataVolumes(dtos);
 
         // vhostuser disk not support readonly mode, so no iso.
     }

--- a/test/src/test/groovy/org/zstack/test/integration/storage/primary/addon/expon/ExponPrimaryStorageCase.groovy
+++ b/test/src/test/groovy/org/zstack/test/integration/storage/primary/addon/expon/ExponPrimaryStorageCase.groovy
@@ -1,6 +1,8 @@
 package org.zstack.test.integration.storage.primary.addon.expon
 
 import org.springframework.http.HttpEntity
+import org.zstack.compute.cluster.ClusterGlobalConfig
+import org.zstack.compute.vm.VmGlobalConfig
 import org.zstack.core.Platform
 import org.zstack.core.cloudbus.CloudBus
 import org.zstack.core.db.Q
@@ -49,6 +51,7 @@ import org.zstack.utils.data.SizeUnit
 import org.zstack.utils.gson.JSONObjectUtil
 
 import static java.util.Arrays.asList
+import static java.util.UUID.randomUUID
 import static org.zstack.expon.ExponIscsiHelper.iscsiExportTargetName
 import static org.zstack.expon.ExponNameHelper.getVolIdFromPath
 
@@ -204,7 +207,7 @@ class ExponPrimaryStorageCase extends SubCase {
             reconnectPrimaryStorage {
                 uuid = ps.uuid
             }
-
+            testCreateVmWhenSpecifiedSblk()
             testDeletePs()
         }
     }
@@ -711,6 +714,70 @@ class ExponPrimaryStorageCase extends SubCase {
             assert Q.New(ImageCacheVO.class).eq(ImageCacheVO_.imageUuid, image.uuid).count() == 0
             assert Q.New(ImageCacheShadowVO.class).eq(ImageCacheShadowVO_.imageUuid, image.uuid).count() == 0
         }
+    }
+
+    void testCreateVmWhenSpecifiedSblk() {
+        def sblk = addSharedBlockGroupPrimaryStorage {
+            name = "sblk"
+            diskUuids = [randomUUID() as String]
+            zoneUuid = cluster.getZoneUuid()
+        } as PrimaryStorageInventory
+
+        attachPrimaryStorageToCluster {
+            primaryStorageUuid = sblk.uuid
+            clusterUuid = cluster.getUuid()
+        }
+
+        env.afterSimulator(KVMConstant.KVM_START_VM_PATH) { rsp, HttpEntity<String> e ->
+            def cmd = JSONObjectUtil.toObject(e.body, KVMAgentCommands.StartVmCmd.class)
+            assert cmd.useHugePage
+            assert cmd.memAccess == "shared"
+            return rsp
+        }
+
+        VmGlobalConfig.GENERATE_CONFIG_VHOST_REQUIRED.updateValue("auto")
+
+        def vm1 = createVmInstance {
+            name = "vm"
+            instanceOfferingUuid = instanceOffering.uuid
+            rootDiskOfferingUuid = diskOffering.uuid
+            imageUuid = image.uuid
+            l3NetworkUuids = [l3.uuid]
+            primaryStorageUuidForRootVolume = sblk.uuid
+        } as VmInstanceInventory
+
+        VmGlobalConfig.GENERATE_CONFIG_VHOST_REQUIRED.updateValue("true")
+
+        def vm2 = createVmInstance {
+            name = "vm"
+            instanceOfferingUuid = instanceOffering.uuid
+            rootDiskOfferingUuid = diskOffering.uuid
+            imageUuid = image.uuid
+            l3NetworkUuids = [l3.uuid]
+            primaryStorageUuidForRootVolume = sblk.uuid
+        } as VmInstanceInventory
+
+        detachPrimaryStorageFromCluster {
+            primaryStorageUuid = sblk.uuid
+            clusterUuid = cluster.getUuid()
+        }
+
+        deletePrimaryStorage {
+            uuid = sblk.uuid
+        }
+
+        VmGlobalConfig.GENERATE_CONFIG_VHOST_REQUIRED.updateValue("false")
+        def vm3 = createVmInstance {
+            name = "vm"
+            instanceOfferingUuid = instanceOffering.uuid
+            rootDiskOfferingUuid = diskOffering.uuid
+            imageUuid = image.uuid
+            l3NetworkUuids = [l3.uuid]
+        } as VmInstanceInventory
+
+        deleteVm(vm1.uuid)
+        deleteVm(vm2.uuid)
+        deleteVm(vm3.uuid)
     }
 
     void testDeletePs() {


### PR DESCRIPTION
1.When the cluster where the vm is located has attached vhost primary storage, regardless of whether vhost volume is currently attached for vm, we will enable hugepage memory and set the memory access mode to shared.
2.Check hugepage and shared memory before attaching vhost volume to vm online.

Resolves/Related: ZSTAC-80546

Change-Id: I74716b65706f6f717a6d626a62757265796c7875

sync from gitlab !8908