### PR TITLE
<fix>[conf]: Fix V5.4.6__schema.sql when upgrade templates

### DIFF
--- a/conf/db/upgrade/V5.4.6__schema.sql
+++ b/conf/db/upgrade/V5.4.6__schema.sql
@@ -291,8 +291,8 @@ BEGIN
                 WHERE `modelServiceUuid` = service_uuid;
                 SELECT CONCAT('INFO: Updated ModelServiceTemplateVO for service_uuid=', service_uuid, ', updated_rows=', ROW_COUNT()) AS msg;
             ELSE
-                INSERT INTO `zstack`.`ModelServiceTemplateVO` (`uuid`, `modelServiceUuid`, `pythonVersionSemver`, `cudaVersion`, `cannVersion`, `frameworkVersionSemver`, `gpuVendor`)
-                VALUES (REPLACE(UUID(),'-',''), service_uuid, py_version, cuda_version, cann_version, fw_version, gpu_vendor_name);
+                INSERT INTO `zstack`.`ModelServiceTemplateVO` (`uuid`, `modelServiceUuid`, `cpuArchitecture`, `pythonVersionSemver`, `cudaVersion`, `cannVersion`, `frameworkVersionSemver`, `gpuVendor`, `createDate`, `lastOpDate`)
+                    VALUES (REPLACE(UUID(),'-',''), service_uuid, 'x86_64', py_version, cuda_version, cann_version, fw_version, gpu_vendor_name, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
                 SELECT CONCAT('INFO: Inserted ModelServiceTemplateVO for service_uuid=', service_uuid, ', inserted_rows=', ROW_COUNT()) AS msg;
             END IF;
 

--- a/conf/db/upgrade/beforeValidate.sql
+++ b/conf/db/upgrade/beforeValidate.sql
@@ -39,7 +39,7 @@ BEGIN
         update `zstack`.`schema_version` set `checksum`=613548663   where `script`='V5.3.6__schema.sql' and `checksum` <> 613548663;
         update `zstack`.`schema_version` set `checksum`=1489363540   where `script`='V5.3.22__schema.sql' and `checksum` <> 1489363540;
         update `zstack`.`schema_version` set `checksum`=1648524318   where `script`='V4.4.0__schema.sql' and `checksum` <> 1648524318;
-        update `zstack`.`schema_version` set `checksum`=-1622195975   where `script`='V5.4.6__schema.sql' and `checksum` <> 1381616852;
+        update `zstack`.`schema_version` set `checksum`=-3265430   where `script`='V5.4.6__schema.sql' and `checksum` <> -3265430;
     END IF;
 END $$
 

--- a/conf/db/upgrade/beforeValidate.sql
+++ b/conf/db/upgrade/beforeValidate.sql
@@ -39,6 +39,7 @@ BEGIN
         update `zstack`.`schema_version` set `checksum`=613548663   where `script`='V5.3.6__schema.sql' and `checksum` <> 613548663;
         update `zstack`.`schema_version` set `checksum`=1489363540   where `script`='V5.3.22__schema.sql' and `checksum` <> 1489363540;
         update `zstack`.`schema_version` set `checksum`=1648524318   where `script`='V4.4.0__schema.sql' and `checksum` <> 1648524318;
+        update `zstack`.`schema_version` set `checksum`=-1622195975   where `script`='V5.4.6__schema.sql' and `checksum` <> 1381616852;
     END IF;
 END $$
 


### PR DESCRIPTION
- Fix default value of cpuArch when upgrade existing records
- Set date to valid value to avoid zero date failed to start
  mn

DBImpact

Resolves: ZSTAC-80776

Change-Id: I6873776363706d6b76726679666d6c6663676d6e
(cherry picked from commit fbb2eaee5c41afe48fa92df496877409626d0ab9)

sync from gitlab !8944