### PR TITLE
<fix>[compute]: sub hugepage memory used by ovs-dpdk

### DIFF
--- a/compute/src/main/java/org/zstack/compute/allocator/HostAllocatorManagerImpl.java
+++ b/compute/src/main/java/org/zstack/compute/allocator/HostAllocatorManagerImpl.java
@@ -213,6 +213,15 @@ public class HostAllocatorManagerImpl extends AbstractService implements HostAll
                     }
 
                     s.usedMemory = ratioMgr.calculateMemoryByRatio(s.hostUuid, t.get(0, Long.class));
+                    long usedMemBySysCom = 0L;
+                    final List<SysComponentMemUsageExtensionPoint> extps =
+                            pluginRgty.getExtensionList(SysComponentMemUsageExtensionPoint.class);
+                    for (SysComponentMemUsageExtensionPoint extp : extps) {
+                        long hugePageMemUsage = Math.max(0L, extp.getHugePageMemoryUsage(s.hostUuid));
+                        long normalMemUsage = Math.max(0L, extp.getNormalMemoryUsage(s.hostUuid));
+                        usedMemBySysCom += hugePageMemUsage + normalMemUsage;
+                    }
+                    s.usedMemory = usedMemBySysCom + ratioMgr.calculateMemoryByRatio(s.hostUuid, t.get(0, Long.class));
                     s.usedCpu = t.get(2, Long.class);
                     ret.add(s);
                 }


### PR DESCRIPTION
Resolves: ZSTAC-80934

Change-Id: I6f787462786f62706a6d6e667679636e63656d67

Signed-off-by: zhangjianjun <jianjun.zhang@zstack.io>

sync from gitlab !8978