### PR TITLE
<fix>[compute]: vm lacks state transition handling

### DIFF
--- a/compute/src/main/java/org/zstack/compute/vm/VmInstanceBase.java
+++ b/compute/src/main/java/org/zstack/compute/vm/VmInstanceBase.java
@@ -1511,7 +1511,8 @@ public class VmInstanceBase extends AbstractVmInstance {
             return;
         } else if (operation == VmAbnormalLifeCycleOperation.VmNoStateFromRunningStateHostNotChanged
                 || operation == VmAbnormalLifeCycleOperation.VmNoStateFromCrashedStateHostNotChanged
-                || operation == VmAbnormalLifeCycleOperation.VmNoStateFromUnknownStateHostNotChanged) {
+                || operation == VmAbnormalLifeCycleOperation.VmNoStateFromUnknownStateHostNotChanged
+                || operation == VmAbnormalLifeCycleOperation.VmNoStateFromPausedStateHostNotChanged) {
             // the vm is detected on the host again. It's largely because the host disconnected before
             // and now reconnected
             changeVmStateInDb(VmInstanceStateEvent.noState, () -> self.setHostUuid(msg.getHostUuid()));

--- a/header/src/main/java/org/zstack/header/vm/VmAbnormalLifeCycleStruct.java
+++ b/header/src/main/java/org/zstack/header/vm/VmAbnormalLifeCycleStruct.java
@@ -171,6 +171,14 @@ public class VmAbnormalLifeCycleStruct {
                         && Objects.equals(struct.getCurrentHostUuid(), struct.getOriginalHostUuid());
             }
         },
+        VmNoStateFromPausedStateHostNotChanged {
+            @Override
+            boolean match(VmAbnormalLifeCycleStruct struct) {
+                return struct.getOriginalState() == VmInstanceState.Paused
+                        && struct.getCurrentState() == VmInstanceState.NoState
+                        && Objects.equals(struct.getCurrentHostUuid(), struct.getOriginalHostUuid());
+            }
+        },
         VmNoStateFromCrashedStateHostNotChanged {
             @Override
             boolean match(VmAbnormalLifeCycleStruct struct) {

--- a/test/src/test/groovy/org/zstack/test/integration/kvm/vm/CreateVmWithSameHostnameCase.groovy
+++ b/test/src/test/groovy/org/zstack/test/integration/kvm/vm/CreateVmWithSameHostnameCase.groovy
@@ -1,5 +1,13 @@
 package org.zstack.test.integration.kvm.vm
 
+import org.zstack.core.cloudbus.CloudBus
+import org.zstack.core.cloudbus.EventCallback
+import org.zstack.core.cloudbus.EventFacade
+import org.zstack.header.vm.VmInstanceConstant
+import org.zstack.header.vm.VmInstanceState
+import org.zstack.header.vm.VmInstanceVO
+import org.zstack.header.vm.VmStateChangedOnHostMsg
+import org.zstack.header.vm.VmTracerCanonicalEvents
 import org.zstack.sdk.ImageInventory
 import org.zstack.sdk.InstanceOfferingInventory
 import org.zstack.sdk.L3NetworkInventory
@@ -8,6 +16,8 @@ import org.zstack.test.integration.kvm.Env
 import org.zstack.test.integration.kvm.KvmTest
 import org.zstack.testlib.EnvSpec
 import org.zstack.testlib.SubCase
+
+import java.util.concurrent.atomic.AtomicBoolean
 
 /**
  * @Author: fubang
@@ -35,6 +45,7 @@ class CreateVmWithSameHostnameCase extends SubCase{
     void test() {
         env.create {
             testCreateVmWithSameHostname()
+            testVmStateChangedFromPausedToNoState()
         }
     }
 
@@ -66,5 +77,47 @@ class CreateVmWithSameHostnameCase extends SubCase{
             conditions = ["type=UserVm"]
         }
         assert vms.size() == 2
+    }
+
+    void testVmStateChangedFromPausedToNoState() {
+        VmInstanceInventory vm = env.inventoryByName("vm") as VmInstanceInventory
+        String hostUuid = vm.getHostUuid()
+        assert hostUuid != null
+        pauseVmInstance {
+            uuid = vm.uuid
+        }
+        VmInstanceVO vmVO = dbFindByUuid(vm.uuid, VmInstanceVO.class)
+        assert vmVO.state == VmInstanceState.Paused
+        assert vmVO.hostUuid == hostUuid
+        AtomicBoolean eventReceived = new AtomicBoolean(false)
+        EventFacade evtf = bean(EventFacade.class)
+        evtf.on(VmTracerCanonicalEvents.VM_STATE_CHANGED_PATH, new EventCallback() {
+            @Override
+            void run(Map tokens, Object data) {
+                VmTracerCanonicalEvents.VmStateChangedOnHostData d = (VmTracerCanonicalEvents.VmStateChangedOnHostData) data
+                if (d.getVmUuid().equals(vm.uuid)
+                        && d.getFrom() == VmInstanceState.Paused
+                        && d.getTo() == VmInstanceState.NoState
+                        && d.getOriginalHostUuid().equals(hostUuid)
+                        && d.getCurrentHostUuid().equals(hostUuid)) {
+                    eventReceived.set(true)
+                }
+            }
+        })
+        CloudBus bus = bean(CloudBus.class)
+        VmStateChangedOnHostMsg msg = new VmStateChangedOnHostMsg()
+        msg.setVmStateAtTracingMoment(VmInstanceState.Paused)
+        msg.setVmInstanceUuid(vm.uuid)
+        msg.setStateOnHost(VmInstanceState.NoState)
+        msg.setHostUuid(hostUuid)
+        msg.setFromSync(true)
+        bus.makeTargetServiceIdByResourceUuid(msg, VmInstanceConstant.SERVICE_ID, vm.uuid)
+        bus.send(msg)
+        retryInSecs {
+            vmVO = dbFindByUuid(vm.uuid, VmInstanceVO.class)
+            assert vmVO.state == VmInstanceState.NoState
+            assert vmVO.hostUuid == hostUuid
+            assert eventReceived.get() : "VmStateChangedOnHostData event should be fired"
+        }
     }
 }


### PR DESCRIPTION
vm is displayed as "Paused"
and the control plane is missing
the state transition logic from "Paused" to "NoState"

Resolves: ZSTAC-80897

Change-Id: I697465636f646b6368686d71696d706b6e676e67

sync from gitlab !9004