### PR TITLE
<fix>[kvm]: add VM edk tags

### DIFF
--- a/compute/src/main/java/org/zstack/compute/vm/VmInstanceApiInterceptor.java
+++ b/compute/src/main/java/org/zstack/compute/vm/VmInstanceApiInterceptor.java
@@ -1012,7 +1012,8 @@ public class VmInstanceApiInterceptor implements ApiMessageInterceptor {
                 }
 
                 if (msg.getRootDiskSize() <= 0) {
-                    throw new ApiMessageInterceptionException(operr("Unexpected root disk settings"));
+                    throw new ApiMessageInterceptionException(operr("Unexpected root disk settings")
+                            .withException("DiskAO[0].size is mandatory when image format is ISO"));
                 }
             }
         }

--- a/conf/springConfigXml/Kvm.xml
+++ b/conf/springConfigXml/Kvm.xml
@@ -165,9 +165,10 @@
         </zstack:plugin>
     </bean>
 
-    <bean id="BootOrderKvmStartVmExtension" class="org.zstack.kvm.BootOrderKvmStartVmExtension">
+    <bean id="BootOrderKvmStartVmExtension" class="org.zstack.kvm.BootKvmStartVmExtension">
         <zstack:plugin>
             <zstack:extension interface="org.zstack.kvm.KVMStartVmExtensionPoint" />
+            <zstack:extension interface="org.zstack.kvm.KVMSyncVmDeviceInfoExtensionPoint" />
         </zstack:plugin>
     </bean>
 

--- a/plugin/kvm/src/main/java/org/zstack/kvm/BootKvmStartVmExtension.java
+++ b/plugin/kvm/src/main/java/org/zstack/kvm/BootKvmStartVmExtension.java
@@ -2,14 +2,21 @@ package org.zstack.kvm;
 
 import org.zstack.compute.vm.VmSystemTags;
 import org.zstack.header.errorcode.ErrorCode;
+import org.zstack.header.vm.VmInstanceInventory;
 import org.zstack.header.vm.VmInstanceSpec;
 import org.zstack.header.vm.VmInstanceVO;
+import org.zstack.tag.SystemTagCreator;
+
+import static org.zstack.kvm.KVMSystemTags.EDK_RPM_TOKEN;
+import static org.zstack.kvm.KVMSystemTags.VM_EDK;
+import static org.zstack.utils.CollectionDSL.e;
+import static org.zstack.utils.CollectionDSL.map;
 
 /**
  * author:kaicai.hu
  * Date:2019/12/25
  */
-public class BootOrderKvmStartVmExtension implements KVMStartVmExtensionPoint {
+public class BootKvmStartVmExtension implements KVMStartVmExtensionPoint, KVMSyncVmDeviceInfoExtensionPoint {
 
     @Override
     public void startVmOnKvmSuccess(KVMHostInventory host, VmInstanceSpec spec) {
@@ -31,5 +38,24 @@ public class BootOrderKvmStartVmExtension implements KVMStartVmExtensionPoint {
     @Override
     public void beforeStartVmOnKvm(KVMHostInventory host, VmInstanceSpec spec, KVMAgentCommands.StartVmCmd cmd) {
 
+    }
+
+    @Override
+    public void afterReceiveVmDeviceInfoResponse(VmInstanceInventory vm, KVMAgentCommands.VmDevicesInfoResponse rsp, VmInstanceSpec spec) {
+        saveVmEdkStatesFromCommand(spec.getVmInventory().getUuid(), rsp);
+    }
+
+    @SuppressWarnings("unchecked")
+    private void saveVmEdkStatesFromCommand(String vmUuid, KVMAgentCommands.VmDevicesInfoResponse rsp) {
+        if (rsp.getEdkRpm() == null) {
+            VM_EDK.deleteInherentTag(vmUuid);
+            return;
+        }
+
+        SystemTagCreator creator = VM_EDK.newSystemTagCreator(vmUuid);
+        creator.setTagByTokens(map(e(EDK_RPM_TOKEN, rsp.getEdkRpm())));
+        creator.inherent = true;
+        creator.recreate = true;
+        creator.create();
     }
 }

--- a/plugin/kvm/src/main/java/org/zstack/kvm/KVMAgentCommands.java
+++ b/plugin/kvm/src/main/java/org/zstack/kvm/KVMAgentCommands.java
@@ -2703,6 +2703,7 @@ public class KVMAgentCommands {
         private List<VirtualDeviceInfo> virtualDeviceInfoList;
         private VirtualDeviceInfo memBalloonInfo;
         private VirtualizerInfoTO virtualizerInfo;
+        private String edkRpm;
         @NoLogging
         private String vmXml;
 
@@ -2736,6 +2737,14 @@ public class KVMAgentCommands {
 
         public void setVirtualizerInfo(VirtualizerInfoTO virtualizerInfo) {
             this.virtualizerInfo = virtualizerInfo;
+        }
+
+        public String getEdkRpm() {
+            return edkRpm;
+        }
+
+        public void setEdkRpm(String edkRpm) {
+            this.edkRpm = edkRpm;
         }
 
         public String getVmXml() {

--- a/plugin/kvm/src/main/java/org/zstack/kvm/KVMSystemTags.java
+++ b/plugin/kvm/src/main/java/org/zstack/kvm/KVMSystemTags.java
@@ -67,4 +67,8 @@ public class KVMSystemTags {
 
 
     public static SystemTag FORCE_DEPLOYMENT_ONCE = new SystemTag("force::deployment::once", HostVO.class);
+
+    public static final String EDK_RPM_TOKEN = "edkRpm";
+    public static PatternedSystemTag VM_EDK =
+            new PatternedSystemTag(String.format("vm::edk::{%s}", EDK_RPM_TOKEN), VmInstanceVO.class);
 }

--- a/test/src/test/resources/springConfigXml/Kvm.xml
+++ b/test/src/test/resources/springConfigXml/Kvm.xml
@@ -159,9 +159,10 @@
         </zstack:plugin>
     </bean>
 
-    <bean id="BootOrderKvmStartVmExtension" class="org.zstack.kvm.BootOrderKvmStartVmExtension">
+    <bean id="BootOrderKvmStartVmExtension" class="org.zstack.kvm.BootKvmStartVmExtension">
         <zstack:plugin>
             <zstack:extension interface="org.zstack.kvm.KVMStartVmExtensionPoint"/>
+            <zstack:extension interface="org.zstack.kvm.KVMSyncVmDeviceInfoExtensionPoint" />
         </zstack:plugin>
     </bean>
 

--- a/testlib/src/main/java/org/zstack/testlib/KVMSimulator.groovy
+++ b/testlib/src/main/java/org/zstack/testlib/KVMSimulator.groovy
@@ -489,6 +489,7 @@ class KVMSimulator implements Simulator {
             rsp.virtualizerInfo.uuid = cmd.vmInstanceUuid
             rsp.virtualizerInfo.virtualizer = "qemu-kvm"
             rsp.virtualizerInfo.version = "4.2.0-632.g6a6222b.el7"
+            rsp.edkRpm = "edk2-ovmf-20220126gitbb1bba3d77-3.el8.noarch"
 
             return rsp
         }


### PR DESCRIPTION
VM edk tag use to save the EDK version the VM used

Resolves: ZSV-11010

Change-Id: I797770686172776472746b79767876697062747a

sync from gitlab !9019