### PR TITLE
<fix>[kvm]: force virtio driver for windows vhostuser nic to fix boot failure

### DIFF
--- a/plugin/kvm/src/main/java/org/zstack/kvm/KVMHost.java
+++ b/plugin/kvm/src/main/java/org/zstack/kvm/KVMHost.java
@@ -4517,6 +4517,21 @@ public class KVMHost extends HostBase implements Host {
         }
         nics = nics.stream().sorted(Comparator.comparing(NicTO::getDeviceId)).collect(Collectors.toList());
         cmd.setNics(nics);
+        if ((platform.equals(ImagePlatform.Windows.toString()) ||
+             platform.equals(ImagePlatform.WindowsVirtio.toString()))) {
+            if (cmd.getNics() != null) {
+                for (NicTO nicTo : cmd.getNics()) {
+                    if (nicTo.getType() != null &&
+                        nicTo.getType().toLowerCase().contains(VmNicType.VmNicSubType.VHOSTUSER.toString().toLowerCase()) &&
+                        !VmNicDriverType.VIRTIO.toString().equalsIgnoreCase(nicTo.getDriverType())) {
+                        logger.warn(String.format("Force updating nic[%s] driver from [%s] to [virtio] for " +
+                                        "Windows vhostuser compatibility.",
+                                nicTo.getUuid(), nicTo.getDriverType()));
+                        nicTo.setDriverType(VmNicDriverType.VIRTIO.toString());
+                    }
+                }
+            }
+        }
 
         for (VmInstanceSpec.CdRomSpec cdRomSpec : spec.getCdRomSpecs()) {
             CdRomTO cdRomTO = new CdRomTO();


### PR DESCRIPTION
The vhost-user interface (used by OVS-DPDK) strictly requires the 'virtio-net' frontend driver in Libvirt/QEMU. However, ZStack defaults Windows NIC drivers to 'e1000' (or other emulated models) when the image platform is 'Windows', causing VM start failure with Libvirt error: "vhostuser requires the virtio-net* frontend".

This fix forces the NIC driver to 'virtio' specifically when the interface type is 'vhostuser' on Windows platforms, regardless of the default platform settings. Satisfying both the legacy boot requirements of Windows and the vhost-user network requirements.

Resolves: ZSTAC-76013

Change-Id: I737a6e637273796d776e726e7969786c7a6a6478

sync from gitlab !9032