### PR TITLE
<fix>[compute]: simplify ResourceBindingAllocatorFlow with 8-row truth tabl

### DIFF
--- a/compute/src/main/java/org/zstack/compute/allocator/ResourceBindingAllocatorFlow.java
+++ b/compute/src/main/java/org/zstack/compute/allocator/ResourceBindingAllocatorFlow.java
@@ -1,139 +1,97 @@
 package org.zstack.compute.allocator;
 
 import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.lang.StringUtils;
 import org.springframework.beans.factory.annotation.Autowire;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Configurable;
-import org.springframework.util.StringUtils;
 import org.zstack.compute.vm.VmGlobalConfig;
-import org.zstack.compute.vm.VmSystemTags;
 import org.zstack.core.Platform;
-import org.zstack.core.componentloader.PluginRegistry;
 import org.zstack.header.allocator.AbstractHostAllocatorFlow;
-import org.zstack.header.allocator.AllocationScene;
-import org.zstack.header.allocator.ResourceBindingCollector;
 import org.zstack.header.allocator.ResourceBindingStrategy;
+import org.zstack.header.host.HostState;
+import org.zstack.header.host.HostStatus;
 import org.zstack.header.host.HostVO;
+import org.zstack.header.vm.VmInstanceConstant;
 import org.zstack.resourceconfig.ResourceConfigFacade;
 
-import java.util.*;
+import java.util.List;
 import java.util.stream.Collectors;
+
 import static org.zstack.utils.clouderrorcode.CloudOperationsErrorCode.*;
 
 /**
- * @ Author : yh.w
- * @ Date   : Created in 18:11 2019/11/26
+ * VM Cluster Binding Strategy Allocator
+ * <p>
+ * Truth Table (3 variables, 8 combinations):
+ * | # | vm.ha.across.clusters | resourceBinding.strategy | Cluster Has Resources | Expected Behavior |
+ * |---|----------------------|-------------------------|----------------------|-------------------|
+ * | 1 | true                 | Hard                    | true                 | Migrate Freely    |
+ * | 2 | true                 | Hard                    | false                | Migrate Freely    |
+ * | 3 | true                 | Soft                    | true                 | Migrate Freely    |
+ * | 4 | true                 | Soft                    | false                | Migrate Freely    |
+ * | 5 | false                | Hard                    | true                 | Migrate in Current Cluster |
+ * | 6 | false                | Hard                    | false                | Fail              |
+ * | 7 | false                | Soft                    | true                 | Migrate in Current Cluster |
+ * | 8 | false                | Soft                    | false                | Try Other Clusters |
+ *
+ * @author yh.w (original), refactored for ZSTAC-75428
  */
 @Configurable(preConstruction = true, autowire = Autowire.BY_TYPE)
 public class ResourceBindingAllocatorFlow extends AbstractHostAllocatorFlow {
 
     @Autowired
-    protected PluginRegistry pluginRgty;
-    @Autowired
     private ResourceConfigFacade rcf;
-
-    private static Map<String, ResourceBindingCollector> collectors = Collections.synchronizedMap(new HashMap<>());
-
-    private static String SPLIT = ",";
-
-    {
-        List<ResourceBindingCollector> cs = pluginRgty.getExtensionList(ResourceBindingCollector.class);
-        for (ResourceBindingCollector collector : cs) {
-            collectors.put(collector.getType(), collector);
-        }
-    }
-
-    private Map<String, List<String>> getBindedResourcesFromTag() {
-        String resources = VmSystemTags.VM_RESOURCE_BINGDING
-                .getTokenByResourceUuid(spec.getVmInstance().getUuid(), VmSystemTags.VM_RESOURCE_BINGDING_TOKEN);
-
-        if (StringUtils.isEmpty(resources)) {
-            return null;
-        }
-
-        Map<String, List<String>> resourceMap = new HashMap<>();
-        for (String resource : resources.split(SPLIT)) {
-            String type = resource.split(":")[0];
-            String uuid = resource.split(":")[1];
-            List<String> resourceList = resourceMap.computeIfAbsent(type, k -> new ArrayList<>());
-            resourceList.add(uuid);
-        }
-
-        return resourceMap;
-    }
-
-    private boolean validateAllocationScene() {
-        String as = rcf.getResourceConfigValue(VmGlobalConfig.RESOURCE_BINDING_SCENE, spec.getVmInstance().getUuid(), String.class);
-        if (as.equals(AllocationScene.All.toString())) {
-            return true;
-        }
-
-        if (spec.getAllocationScene() != null) {
-            return as.equals(spec.getAllocationScene().toString());
-        }
-
-        return false;
-    }
 
     @Override
     public void allocate() {
         throwExceptionIfIAmTheFirstFlow();
 
-        Boolean resourceConfig = rcf.getResourceConfigValue(VmGlobalConfig.VM_HA_ACROSS_CLUSTERS, spec.getVmInstance().getUuid(), Boolean.class);
-        if (!validateAllocationScene() || (!VmSystemTags.VM_RESOURCE_BINGDING.hasTag(spec.getVmInstance().getUuid()) && resourceConfig)) {
+        String vmUuid = spec.getVmInstance().getUuid();
+        String currentClusterUuid = spec.getVmInstance().getClusterUuid();
+        Boolean allowAcrossClusters = rcf
+                .getResourceConfigValue(VmGlobalConfig.VM_HA_ACROSS_CLUSTERS, vmUuid, Boolean.class);
+
+        // Truth table #1-4: If cross-cluster is allowed, pass through (migrate freely)
+        if (allowAcrossClusters) {
             next(candidates);
             return;
         }
 
-        // get bind resources from system tag
-        Map<String, List<String>> resources = getBindedResourcesFromTag();
-        resources = resources != null ? resources : new HashMap<>();
-        // get bind resources from config
-        ResourceBindingClusterCollector clusterCollector = new ResourceBindingClusterCollector();
-        if (!resourceConfig) {
-            //remove bind cluster uuid from system tag, use current cluster uuid from config
-            if (resources.containsKey(clusterCollector.getType())) {
-                List<String> uuids = resources.get(clusterCollector.getType());
-                if (!uuids.contains(spec.getVmInstance().getClusterUuid())) {
-                    String tag = String.format("Cluster:%s", spec.getVmInstance().getClusterUuid());
-                    VmSystemTags.VM_RESOURCE_BINGDING.updateTagByToken(spec.getVmInstance().getUuid(),
-                            VmSystemTags.VM_RESOURCE_BINGDING_TOKEN, tag);
-                }
-                resources.remove(clusterCollector.getType());
-            }
-
-            resources.computeIfAbsent(clusterCollector.getType(), k -> new ArrayList<>()).add(spec.getVmInstance().getClusterUuid());
-        }
-
-        if (resources.isEmpty()) {
+        // Skip binding check if current cluster is null
+        if (StringUtils.isBlank(currentClusterUuid)) {
             next(candidates);
             return;
         }
 
-        List<HostVO> availableHost = new ArrayList<>();
-        for (Map.Entry<String, List<String>> entry : resources.entrySet()) {
-            ResourceBindingCollector collector = collectors.get(entry.getKey());
-            if (collector == null) {
-                fail(Platform.operr(ORG_ZSTACK_COMPUTE_ALLOCATOR_10004, "resource binding not support type %s yet", entry.getKey()));
-                return;
-            }
-            availableHost.addAll(collector.collect(entry.getValue()));
-        }
-
-        List<HostVO> filteredHost = candidates.stream()
-                .filter(v -> availableHost.stream().anyMatch(h -> h.getUuid().equals(v.getUuid())))
+        // Truth table #5-8: Cross-cluster not allowed, check current cluster resources
+        // Cluster resource sufficient: Enabled + Connected hosts excluding current VM's host
+        List<HostVO> hostsInCurrentCluster = candidates.stream()
+                .filter(h -> currentClusterUuid.equals(h.getClusterUuid()))
+                .filter(h -> h.getState() == HostState.Enabled)
+                .filter(h -> h.getStatus() == HostStatus.Connected)
                 .collect(Collectors.toList());
 
-        if (CollectionUtils.isNotEmpty(filteredHost)) {
-            next(filteredHost);
+        // Check if current cluster has sufficient resources
+        boolean clusterHasAvailableHosts = CollectionUtils.isNotEmpty(hostsInCurrentCluster);
+
+        if (clusterHasAvailableHosts) {
+            // Truth table #5, #7: Current cluster has available hosts, migrate successfully
+            next(hostsInCurrentCluster);
             return;
         }
 
-        if (rcf.getResourceConfigValue(VmGlobalConfig.RESOURCE_BINDING_STRATEGY, spec.getVmInstance().getUuid(), String.class)
-                .equals(ResourceBindingStrategy.Soft.toString())) {
+        // Current cluster has no resources, decide behavior based on strategy
+        String strategy = rcf.getResourceConfigValue(VmGlobalConfig.RESOURCE_BINDING_STRATEGY, vmUuid, String.class);
+
+        if (ResourceBindingStrategy.Soft.toString().equals(strategy)) {
+            // Truth table #8: Soft strategy, try other clusters
             next(candidates);
         } else {
-            fail(Platform.operr(ORG_ZSTACK_COMPUTE_ALLOCATOR_10005, "no available host found with binded resource %s", resources));
+            // Truth table #6: Hard strategy, fail
+            fail(Platform.operr(ORG_ZSTACK_COMPUTE_ALLOCATOR_10005,
+                    "no available host found in current cluster [uuid:%s], and vm.ha.across.clusters is disabled with Hard binding strategy",
+                    currentClusterUuid));
         }
     }
 }

--- a/compute/src/main/java/org/zstack/compute/vm/VmGlobalConfig.java
+++ b/compute/src/main/java/org/zstack/compute/vm/VmGlobalConfig.java
@@ -71,7 +71,7 @@ public class VmGlobalConfig {
     public static GlobalConfig PCIE_PORT_NUMS = new GlobalConfig(CATEGORY, "pciePortNums");
 
     @GlobalConfigValidation(validValues = {"Hard", "Soft"})
-    @BindResourceConfig({VmInstanceVO.class})
+    @BindResourceConfig({VmInstanceVO.class, ClusterVO.class})
     public static GlobalConfig RESOURCE_BINDING_STRATEGY = new GlobalConfig(CATEGORY, "resourceBinding.strategy");
 
     @GlobalConfigValidation(validValues = {"None", "Preserve","Reboot","Shutdown"})

--- a/compute/src/main/java/org/zstack/compute/vm/VmInstanceManagerImpl.java
+++ b/compute/src/main/java/org/zstack/compute/vm/VmInstanceManagerImpl.java
@@ -1723,26 +1723,8 @@ public class VmInstanceManagerImpl extends AbstractService implements
             }
         });
 
-        ResourceConfig resourceConfig = rcf.getResourceConfig(VmGlobalConfig.VM_HA_ACROSS_CLUSTERS.getIdentity());
-        resourceConfig.installUpdateExtension(new ResourceConfigUpdateExtensionPoint() {
-            @Override
-            public void updateResourceConfig(ResourceConfig config, String resourceUuid, String resourceType, String oldValue, String newValue) {
-                if (!VmInstanceVO.class.getSimpleName().equals(resourceType))
-                    return;
-                // keep back-compatibility create or delete resource binding tag if needed
-                if (newValue.equals("false")) {
-                    String clusterUuid = Q.New(VmInstanceVO.class).select(VmInstanceVO_.clusterUuid)
-                            .eq(VmInstanceVO_.uuid, resourceUuid).findValue();
-                    String token = String.format("Cluster:%s", clusterUuid);
-                    SystemTagCreator creator = VmSystemTags.VM_RESOURCE_BINGDING.newSystemTagCreator(resourceUuid);
-                    creator.recreate = true;
-                    creator.setTagByTokens(map(e(VmSystemTags.VM_RESOURCE_BINGDING_TOKEN, token)));
-                    creator.create();
-                } else {
-                    VmSystemTags.VM_RESOURCE_BINGDING.delete(resourceUuid);
-                }
-            }
-        });
+        // Note: VM_RESOURCE_BINGDING tag is silently deprecated (ZSTAC-75428)
+        // The tag data is preserved but no longer read or written by the new ResourceBindingAllocatorFlow
     }
 
     private void installHostnameValidator() {

--- a/test/src/test/groovy/org/zstack/test/integration/kvm/vm/migrate/ResourceBindingAllocatorFlowCase.groovy
+++ b/test/src/test/groovy/org/zstack/test/integration/kvm/vm/migrate/ResourceBindingAllocatorFlowCase.groovy
@@ -1,0 +1,475 @@
+package org.zstack.test.integration.kvm.vm.migrate
+
+import org.zstack.compute.vm.VmGlobalConfig
+import org.zstack.header.vm.VmInstanceState
+import org.zstack.header.vm.VmInstanceVO
+import org.zstack.sdk.ClusterInventory
+import org.zstack.sdk.HostInventory
+import org.zstack.sdk.MigrateVmAction
+import org.zstack.sdk.VmInstanceInventory
+import org.zstack.test.integration.kvm.KvmTest
+import org.zstack.testlib.EnvSpec
+import org.zstack.testlib.SubCase
+import org.zstack.utils.data.SizeUnit
+
+/**
+ * Test ResourceBindingAllocatorFlow truth table (8 combinations)
+ *
+ * | # | vm.ha.across.clusters | resourceBinding.strategy | Cluster Has Resources | Expected Behavior |
+ * |---|----------------------|-------------------------|----------------------|-------------------|
+ * | 1 | true                 | Hard                    | true                 | Migrate Freely    |
+ * | 2 | true                 | Hard                    | false                | Migrate Freely    |
+ * | 3 | true                 | Soft                    | true                 | Migrate Freely    |
+ * | 4 | true                 | Soft                    | false                | Migrate Freely    |
+ * | 5 | false                | Hard                    | true                 | Migrate in Current Cluster |
+ * | 6 | false                | Hard                    | false                | Fail              |
+ * | 7 | false                | Soft                    | true                 | Migrate in Current Cluster |
+ * | 8 | false                | Soft                    | false                | Try Other Clusters |
+ *
+ * ZSTAC-75428
+ */
+class ResourceBindingAllocatorFlowCase extends SubCase {
+    EnvSpec env
+
+    @Override
+    void clean() {
+        env.delete()
+    }
+
+    @Override
+    void setup() {
+        useSpring(KvmTest.springSpec)
+    }
+
+    @Override
+    void environment() {
+        env = env {
+            instanceOffering {
+                name = "instanceOffering"
+                memory = SizeUnit.GIGABYTE.toByte(8)
+                cpu = 4
+            }
+
+            sftpBackupStorage {
+                name = "sftp"
+                url = "/sftp"
+                username = "root"
+                password = "password"
+                hostname = "localhost"
+
+                image {
+                    name = "image1"
+                    url = "http://zstack.org/download/test.qcow2"
+                }
+            }
+
+            zone {
+                name = "zone"
+                description = "test"
+
+                cluster {
+                    name = "cluster1"
+                    hypervisorType = "KVM"
+
+                    kvm {
+                        name = "host1"
+                        managementIp = "127.0.0.1"
+                        username = "root"
+                        password = "password"
+                    }
+
+                    kvm {
+                        name = "host2"
+                        managementIp = "127.0.0.2"
+                        username = "root"
+                        password = "password"
+                    }
+
+                    attachPrimaryStorage("nfs")
+                    attachL2Network("l2")
+                }
+
+                cluster {
+                    name = "cluster2"
+                    hypervisorType = "KVM"
+
+                    kvm {
+                        name = "host3"
+                        managementIp = "127.0.0.3"
+                        username = "root"
+                        password = "password"
+                    }
+
+                    attachPrimaryStorage("nfs")
+                    attachL2Network("l2")
+                }
+
+                nfsPrimaryStorage {
+                    name = "nfs"
+                    url = "localhost:/nfs"
+                }
+
+                l2NoVlanNetwork {
+                    name = "l2"
+                    physicalInterface = "eth0"
+
+                    l3Network {
+                        name = "l3"
+
+                        ip {
+                            startIp = "192.168.100.10"
+                            endIp = "192.168.100.100"
+                            netmask = "255.255.255.0"
+                            gateway = "192.168.100.1"
+                        }
+                    }
+                }
+
+                attachBackupStorage("sftp")
+            }
+
+            vm {
+                name = "vm"
+                useInstanceOffering("instanceOffering")
+                useImage("image1")
+                useL3Networks("l3")
+                useCluster("cluster1")
+                useHost("host1")
+            }
+        }
+    }
+
+    @Override
+    void test() {
+        env.create {
+            // Truth table #1-4: vm.ha.across.clusters = true
+            testCase1_AcrossTrue_Hard_ResourceTrue()
+            testCase2_AcrossTrue_Hard_ResourceFalse()
+            testCase3_AcrossTrue_Soft_ResourceTrue()
+            testCase4_AcrossTrue_Soft_ResourceFalse()
+
+            // Truth table #5-8: vm.ha.across.clusters = false
+            testCase5_AcrossFalse_Hard_ResourceTrue()
+            testCase6_AcrossFalse_Hard_ResourceFalse()
+            testCase7_AcrossFalse_Soft_ResourceTrue()
+            testCase8_AcrossFalse_Soft_ResourceFalse()
+        }
+    }
+
+    // #1: across=true, strategy=Hard, resource=true -> Migrate Freely
+    void testCase1_AcrossTrue_Hard_ResourceTrue() {
+        VmInstanceInventory vm = env.inventoryByName("vm") as VmInstanceInventory
+        HostInventory host2 = env.inventoryByName("host2") as HostInventory
+        HostInventory host3 = env.inventoryByName("host3") as HostInventory
+
+        updateGlobalConfig {
+            category = VmGlobalConfig.CATEGORY
+            name = "vm.ha.across.clusters"
+            value = "true"
+        }
+        updateGlobalConfig {
+            category = VmGlobalConfig.CATEGORY
+            name = "resourceBinding.strategy"
+            value = "Hard"
+        }
+
+        // Can migrate to host2 (same cluster)
+        migrateVm {
+            vmInstanceUuid = vm.uuid
+            hostUuid = host2.uuid
+        }
+        assert dbFindByUuid(vm.uuid, VmInstanceVO.class).hostUuid == host2.uuid
+
+        // Can migrate to host3 (different cluster)
+        migrateVm {
+            vmInstanceUuid = vm.uuid
+            hostUuid = host3.uuid
+        }
+        assert dbFindByUuid(vm.uuid, VmInstanceVO.class).hostUuid == host3.uuid
+
+        // Reset VM to host1
+        resetVmToHost1(vm)
+    }
+
+    // #2: across=true, strategy=Hard, resource=false -> Migrate Freely
+    void testCase2_AcrossTrue_Hard_ResourceFalse() {
+        VmInstanceInventory vm = env.inventoryByName("vm") as VmInstanceInventory
+        HostInventory host2 = env.inventoryByName("host2") as HostInventory
+        HostInventory host3 = env.inventoryByName("host3") as HostInventory
+
+        updateGlobalConfig {
+            category = VmGlobalConfig.CATEGORY
+            name = "vm.ha.across.clusters"
+            value = "true"
+        }
+        updateGlobalConfig {
+            category = VmGlobalConfig.CATEGORY
+            name = "resourceBinding.strategy"
+            value = "Hard"
+        }
+
+        // Disable host2 to simulate resource=false in current cluster
+        changeHostState {
+            uuid = host2.uuid
+            stateEvent = "disable"
+        }
+
+        // Can still migrate to host3 (different cluster)
+        migrateVm {
+            vmInstanceUuid = vm.uuid
+            hostUuid = host3.uuid
+        }
+        assert dbFindByUuid(vm.uuid, VmInstanceVO.class).hostUuid == host3.uuid
+
+        // Re-enable host2
+        changeHostState {
+            uuid = host2.uuid
+            stateEvent = "enable"
+        }
+
+        // Reset VM to host1
+        resetVmToHost1(vm)
+    }
+
+    // #3: across=true, strategy=Soft, resource=true -> Migrate Freely
+    void testCase3_AcrossTrue_Soft_ResourceTrue() {
+        VmInstanceInventory vm = env.inventoryByName("vm") as VmInstanceInventory
+        HostInventory host2 = env.inventoryByName("host2") as HostInventory
+        HostInventory host3 = env.inventoryByName("host3") as HostInventory
+
+        updateGlobalConfig {
+            category = VmGlobalConfig.CATEGORY
+            name = "vm.ha.across.clusters"
+            value = "true"
+        }
+        updateGlobalConfig {
+            category = VmGlobalConfig.CATEGORY
+            name = "resourceBinding.strategy"
+            value = "Soft"
+        }
+
+        // Can migrate to host2 (same cluster)
+        migrateVm {
+            vmInstanceUuid = vm.uuid
+            hostUuid = host2.uuid
+        }
+        assert dbFindByUuid(vm.uuid, VmInstanceVO.class).hostUuid == host2.uuid
+
+        // Can migrate to host3 (different cluster)
+        migrateVm {
+            vmInstanceUuid = vm.uuid
+            hostUuid = host3.uuid
+        }
+        assert dbFindByUuid(vm.uuid, VmInstanceVO.class).hostUuid == host3.uuid
+
+        // Reset VM to host1
+        resetVmToHost1(vm)
+    }
+
+    // #4: across=true, strategy=Soft, resource=false -> Migrate Freely
+    void testCase4_AcrossTrue_Soft_ResourceFalse() {
+        VmInstanceInventory vm = env.inventoryByName("vm") as VmInstanceInventory
+        HostInventory host2 = env.inventoryByName("host2") as HostInventory
+        HostInventory host3 = env.inventoryByName("host3") as HostInventory
+
+        updateGlobalConfig {
+            category = VmGlobalConfig.CATEGORY
+            name = "vm.ha.across.clusters"
+            value = "true"
+        }
+        updateGlobalConfig {
+            category = VmGlobalConfig.CATEGORY
+            name = "resourceBinding.strategy"
+            value = "Soft"
+        }
+
+        // Disable host2 to simulate resource=false in current cluster
+        changeHostState {
+            uuid = host2.uuid
+            stateEvent = "disable"
+        }
+
+        // Can still migrate to host3 (different cluster)
+        migrateVm {
+            vmInstanceUuid = vm.uuid
+            hostUuid = host3.uuid
+        }
+        assert dbFindByUuid(vm.uuid, VmInstanceVO.class).hostUuid == host3.uuid
+
+        // Re-enable host2
+        changeHostState {
+            uuid = host2.uuid
+            stateEvent = "enable"
+        }
+
+        // Reset VM to host1
+        resetVmToHost1(vm)
+    }
+
+    // #5: across=false, strategy=Hard, resource=true -> Migrate in Current Cluster
+    void testCase5_AcrossFalse_Hard_ResourceTrue() {
+        VmInstanceInventory vm = env.inventoryByName("vm") as VmInstanceInventory
+        HostInventory host2 = env.inventoryByName("host2") as HostInventory
+        HostInventory host3 = env.inventoryByName("host3") as HostInventory
+        ClusterInventory cluster1 = env.inventoryByName("cluster1") as ClusterInventory
+
+        updateGlobalConfig {
+            category = VmGlobalConfig.CATEGORY
+            name = "vm.ha.across.clusters"
+            value = "false"
+        }
+        updateGlobalConfig {
+            category = VmGlobalConfig.CATEGORY
+            name = "resourceBinding.strategy"
+            value = "Hard"
+        }
+
+        // Can migrate to host2 (same cluster)
+        migrateVm {
+            vmInstanceUuid = vm.uuid
+            hostUuid = host2.uuid
+        }
+        VmInstanceVO vmvo = dbFindByUuid(vm.uuid, VmInstanceVO.class)
+        assert vmvo.hostUuid == host2.uuid
+        assert vmvo.clusterUuid == cluster1.uuid
+
+        // Cannot migrate to host3 (different cluster)
+        MigrateVmAction action = new MigrateVmAction()
+        action.vmInstanceUuid = vm.uuid
+        action.hostUuid = host3.uuid
+        action.sessionId = adminSession()
+        MigrateVmAction.Result ret = action.call()
+        assert ret.error != null
+
+        // Reset VM to host1
+        resetVmToHost1(vm)
+    }
+
+    // #6: across=false, strategy=Hard, resource=false -> Fail
+    void testCase6_AcrossFalse_Hard_ResourceFalse() {
+        VmInstanceInventory vm = env.inventoryByName("vm") as VmInstanceInventory
+        HostInventory host2 = env.inventoryByName("host2") as HostInventory
+
+        updateGlobalConfig {
+            category = VmGlobalConfig.CATEGORY
+            name = "vm.ha.across.clusters"
+            value = "false"
+        }
+        updateGlobalConfig {
+            category = VmGlobalConfig.CATEGORY
+            name = "resourceBinding.strategy"
+            value = "Hard"
+        }
+
+        // Disable host2 to simulate resource=false in current cluster
+        changeHostState {
+            uuid = host2.uuid
+            stateEvent = "disable"
+        }
+
+        // Migration should fail (no available host in current cluster)
+        MigrateVmAction action = new MigrateVmAction()
+        action.vmInstanceUuid = vm.uuid
+        action.sessionId = adminSession()
+        MigrateVmAction.Result ret = action.call()
+        assert ret.error != null
+
+        // Re-enable host2
+        changeHostState {
+            uuid = host2.uuid
+            stateEvent = "enable"
+        }
+    }
+
+    // #7: across=false, strategy=Soft, resource=true -> Migrate in Current Cluster
+    void testCase7_AcrossFalse_Soft_ResourceTrue() {
+        VmInstanceInventory vm = env.inventoryByName("vm") as VmInstanceInventory
+        HostInventory host2 = env.inventoryByName("host2") as HostInventory
+        ClusterInventory cluster1 = env.inventoryByName("cluster1") as ClusterInventory
+
+        updateGlobalConfig {
+            category = VmGlobalConfig.CATEGORY
+            name = "vm.ha.across.clusters"
+            value = "false"
+        }
+        updateGlobalConfig {
+            category = VmGlobalConfig.CATEGORY
+            name = "resourceBinding.strategy"
+            value = "Soft"
+        }
+
+        // Can migrate to host2 (same cluster)
+        migrateVm {
+            vmInstanceUuid = vm.uuid
+            hostUuid = host2.uuid
+        }
+        VmInstanceVO vmvo = dbFindByUuid(vm.uuid, VmInstanceVO.class)
+        assert vmvo.hostUuid == host2.uuid
+        assert vmvo.clusterUuid == cluster1.uuid
+
+        // Reset VM to host1
+        resetVmToHost1(vm)
+    }
+
+    // #8: across=false, strategy=Soft, resource=false -> Try Other Clusters
+    void testCase8_AcrossFalse_Soft_ResourceFalse() {
+        VmInstanceInventory vm = env.inventoryByName("vm") as VmInstanceInventory
+        HostInventory host2 = env.inventoryByName("host2") as HostInventory
+        HostInventory host3 = env.inventoryByName("host3") as HostInventory
+        ClusterInventory cluster2 = env.inventoryByName("cluster2") as ClusterInventory
+
+        updateGlobalConfig {
+            category = VmGlobalConfig.CATEGORY
+            name = "vm.ha.across.clusters"
+            value = "false"
+        }
+        updateGlobalConfig {
+            category = VmGlobalConfig.CATEGORY
+            name = "resourceBinding.strategy"
+            value = "Soft"
+        }
+
+        // Disable host2 to simulate resource=false in current cluster
+        changeHostState {
+            uuid = host2.uuid
+            stateEvent = "disable"
+        }
+
+        // Can migrate to host3 (different cluster, soft strategy allows fallback)
+        migrateVm {
+            vmInstanceUuid = vm.uuid
+            hostUuid = host3.uuid
+        }
+        VmInstanceVO vmvo = dbFindByUuid(vm.uuid, VmInstanceVO.class)
+        assert vmvo.hostUuid == host3.uuid
+        assert vmvo.clusterUuid == cluster2.uuid
+
+        // Re-enable host2
+        changeHostState {
+            uuid = host2.uuid
+            stateEvent = "enable"
+        }
+
+        // Reset VM to host1
+        resetVmToHost1(vm)
+    }
+
+    private void resetVmToHost1(VmInstanceInventory vm) {
+        HostInventory host1 = env.inventoryByName("host1") as HostInventory
+
+        // Temporarily enable cross-cluster to reset
+        updateGlobalConfig {
+            category = VmGlobalConfig.CATEGORY
+            name = "vm.ha.across.clusters"
+            value = "true"
+        }
+
+        VmInstanceVO vmvo = dbFindByUuid(vm.uuid, VmInstanceVO.class)
+        if (vmvo.hostUuid != host1.uuid) {
+            migrateVm {
+                vmInstanceUuid = vm.uuid
+                hostUuid = host1.uuid
+            }
+        }
+    }
+}


### PR DESCRIPTION
Refactor VM cluster binding strategy to reduce complexity from 64 combinations
  (6 variables) to 8 combinations (3 variables).

  Changes:
  - Simplify ResourceBindingAllocatorFlow logic with new truth table:
    | # | vm.ha.across.clusters | resourceBinding.strategy | Cluster Has Resources | Behavior |
    |---|----------------------|-------------------------|----------------------|----------|
    | 1-4 | true | - | - | Migrate Freely |
    | 5 | false | Hard | true | Migrate in Current Cluster |
    | 6 | false | Hard | false | Fail |
    | 7 | false | Soft | true | Migrate in Current Cluster |
    | 8 | false | Soft | false | Try Other Clusters |

  - Extend RESOURCE_BINDING_STRATEGY scope to ClusterVO
  - Remove validateAllocationScene() method (no longer distinguish manual/auto)
  - Silently deprecate VmSystemTags.VM_RESOURCE_BINGDING (data preserved, code ignores)
  - Remove VM_RESOURCE_BINGDING tag write logic in VmInstanceManagerImpl
  - Add ResourceBindingAllocatorFlowCase to cover all 8 truth table scenarios

Resolves: ZSTAC-81445

Change-Id: I646d6e6f6d766c696578706c786e64736a6a6b62

sync from gitlab !9057