### PR TITLE
<fix>[utils]: correct CPU model and MAC retrieval in license check

### DIFF
--- a/utils/src/main/java/org/zstack/utils/network/NetworkUtils.java
+++ b/utils/src/main/java/org/zstack/utils/network/NetworkUtils.java
@@ -532,7 +532,7 @@ public class NetworkUtils {
     }
 
     public static List<String> getAllMac() {
-        ShellResult res = ShellUtils.runAndReturn("ip a | awk '/ether/ {print $2}' | sort -u");
+        ShellResult res = ShellUtils.runAndReturn("ip a | awk '/link\\// && !/loopback/ {print $2}' | sort -u");
 
         if (!res.isReturnCode(0)) {
             throw new RuntimeException("Fail to get mac address");


### PR DESCRIPTION
This patch is for zsv_4.10.28, and cherry-pick to zsv_4.10.25;
This patch is cherry-picked from ZSTAC-79487, see commit
bd5f6d644a7dc92f2d9576d62113608478efeeff.

Resolves: ZSV-11252

Change-Id: I646379678a7923767067706e7a6e667a796f686d
(cherry picked from commit 6c48623106f18d6df61e4b8b92310953c1935db2)

sync from gitlab !9071