### PR TITLE
<chore>[testlib]: support diskUsePrimaryStorage in disk block

### DIFF
--- a/test/src/test/groovy/org/zstack/test/integration/image/DeleteIsoCase.groovy
+++ b/test/src/test/groovy/org/zstack/test/integration/image/DeleteIsoCase.groovy
@@ -114,8 +114,10 @@ class DeleteIsoCase extends SubCase {
                 useL3Networks("l3")
                 useImage("iso_1")
                 disk {
+                    name = "disk1"
                     boot = true
                     sizeGB(20)
+                    diskUsePrimaryStorage("local")
                 }
             }
         }
@@ -125,8 +127,19 @@ class DeleteIsoCase extends SubCase {
     @Override
     void test() {
         env.create {
+            prepare()
             testDeleteIso()
         }
+    }
+
+    void prepare() {
+        def vm = queryVmInstance {conditions = ["name=vm"]}[0] as VmInstanceInventory
+        def localPs  = env.inventoryByName("local") as PrimaryStorageInventory
+        def volumes = vm.allVolumes.findAll {
+            volume -> volume.name == "disk1"
+        }
+        assert volumes.size() == 1
+        assert volumes[0].primaryStorageUuid == localPs.uuid
     }
 
     void testDeleteIso() {

--- a/testlib/src/main/java/org/zstack/testlib/VmDiskSpec.groovy
+++ b/testlib/src/main/java/org/zstack/testlib/VmDiskSpec.groovy
@@ -4,6 +4,8 @@ import org.zstack.header.vm.DiskAO
 import org.zstack.utils.data.SizeUnit
 
 class VmDiskSpec extends Spec {
+    private Closure primaryStorage = {}
+
     @SpecParam(required = false)
     boolean boot
     @SpecParam(required = false)
@@ -12,8 +14,6 @@ class VmDiskSpec extends Spec {
     String guestOsType
     @SpecParam(required = false)
     String architecture
-    @SpecParam(required = false)
-    String primaryStorageUuid
     @SpecParam(required = false)
     long size
     /**
@@ -59,7 +59,7 @@ class VmDiskSpec extends Spec {
         ao.platform = platform
         ao.guestOsType = guestOsType
         ao.architecture = architecture
-        ao.primaryStorageUuid = primaryStorageUuid
+        ao.primaryStorageUuid = primaryStorage();
         ao.size = size
         ao.templateUuid = templateUuid
         ao.diskOfferingUuid = diskOfferingUuid
@@ -72,5 +72,17 @@ class VmDiskSpec extends Spec {
 
     void sizeGB(long sizeGB) {
         this.size = SizeUnit.GIGABYTE.toByte(sizeGB)
+    }
+
+    @SpecMethod
+    void diskUsePrimaryStorage(String name) {
+        preCreate {
+            addDependency(name, PrimaryStorageSpec.class)
+        }
+        primaryStorage = {
+            PrimaryStorageSpec spec = findSpec(name, PrimaryStorageSpec.class)
+            assert spec != null: "cannot find primaryStorage[$name], check the vm block of environment"
+            return spec.inventory.uuid
+        }
     }
 }

--- a/testlib/src/main/java/org/zstack/testlib/VmSpec.groovy
+++ b/testlib/src/main/java/org/zstack/testlib/VmSpec.groovy
@@ -33,7 +33,7 @@ class VmSpec extends Spec implements HasSession {
     @SpecParam
     List<String> dataVolumeSystemTags = []
     private List<String> volumeToAttach = []
-    private List<DiskAO> disks = []
+    private List<VmDiskSpec> disks = []
 
     VmInstanceInventory inventory
 
@@ -172,7 +172,7 @@ class VmSpec extends Spec implements HasSession {
         c.resolveStrategy = Closure.DELEGATE_FIRST
         c()
         addChild(diskSpec)
-        disks << diskSpec.toDiskAO()
+        disks << diskSpec
         return diskSpec
     }
 
@@ -199,10 +199,14 @@ class VmSpec extends Spec implements HasSession {
             delegate.virtio = virtio
 
             if (!disks.isEmpty()) {
-                if (disks.every { (!it.boot) }) {
-                    disks.first().boot = true
+                List<DiskAO> diskAOs = []
+                for (VmDiskSpec disk : disks) {
+                    diskAOs << disk.toDiskAO()
                 }
-                delegate.diskAOs = disks
+                if (diskAOs.every { (!it.boot) }) {
+                    diskAOs.first().boot = true
+                }
+                delegate.diskAOs = diskAOs
             }
         }
 


### PR DESCRIPTION
allow users to initizalize the primary storage in the disk block directly.
vm {
    disk {
        sizeGB(10)
        diskUsePrimaryStorage("nfs")
    }
}

Resolves: ZSV-11263

Change-Id: I6a7567646e6c64636279717576727a6878756476

sync from gitlab !9078