### PR TITLE
<fix>[db]: quote `system` column to fix GreatSQL reserved keyword syntax error

### DIFF
--- a/conf/db/upgrade/V5.4.2__schema.sql
+++ b/conf/db/upgrade/V5.4.2__schema.sql
@@ -132,9 +132,9 @@ BEGIN
         END IF;
 
         -- Find the model service uuid, only for system services
-        SELECT COUNT(*) INTO @cnt FROM `zstack`.`ModelServiceVO` WHERE name = model_name AND system = 1;
+        SELECT COUNT(*) INTO @cnt FROM `zstack`.`ModelServiceVO` WHERE name = model_name AND `system` = 1;
         IF @cnt > 0 THEN
-            SELECT uuid INTO service_uuid FROM `zstack`.`ModelServiceVO` WHERE name = model_name AND system = 1 LIMIT 1;
+            SELECT uuid INTO service_uuid FROM `zstack`.`ModelServiceVO` WHERE name = model_name AND `system` = 1 LIMIT 1;
         ELSE
             SET service_uuid = NULL;
         END IF;
@@ -227,9 +227,9 @@ BEGIN
             LEAVE update_template_loop;
         END IF;
 
-        SELECT COUNT(*) INTO @cnt FROM `zstack`.`ModelServiceVO` WHERE name = model_name AND system = 1;
+        SELECT COUNT(*) INTO @cnt FROM `zstack`.`ModelServiceVO` WHERE name = model_name AND `system` = 1;
         IF @cnt > 0 THEN
-        SELECT uuid INTO service_uuid FROM `zstack`.`ModelServiceVO` WHERE name = model_name AND system = 1 LIMIT 1;
+        SELECT uuid INTO service_uuid FROM `zstack`.`ModelServiceVO` WHERE name = model_name AND `system` = 1 LIMIT 1;
         ELSE
             SET service_uuid = NULL;
         END IF;

--- a/conf/db/upgrade/V5.4.6__schema.sql
+++ b/conf/db/upgrade/V5.4.6__schema.sql
@@ -272,9 +272,9 @@ BEGIN
             LEAVE update_template_loop;
         END IF;
 
-        SELECT COUNT(*) INTO @cnt FROM `zstack`.`ModelServiceVO` WHERE name = model_name AND system = 1;
+        SELECT COUNT(*) INTO @cnt FROM `zstack`.`ModelServiceVO` WHERE name = model_name AND `system` = 1;
         IF @cnt > 0 THEN
-            SELECT uuid INTO service_uuid FROM `zstack`.`ModelServiceVO` WHERE name = model_name AND system = 1 LIMIT 1;
+            SELECT uuid INTO service_uuid FROM `zstack`.`ModelServiceVO` WHERE name = model_name AND `system` = 1 LIMIT 1;
         ELSE
             SET service_uuid = NULL;
         END IF;

--- a/conf/db/upgrade/beforeValidate.sql
+++ b/conf/db/upgrade/beforeValidate.sql
@@ -39,9 +39,10 @@ BEGIN
         update `zstack`.`schema_version` set `checksum`=613548663   where `script`='V5.3.6__schema.sql' and `checksum` <> 613548663;
         update `zstack`.`schema_version` set `checksum`=1489363540   where `script`='V5.3.22__schema.sql' and `checksum` <> 1489363540;
         update `zstack`.`schema_version` set `checksum`=1648524318   where `script`='V4.4.0__schema.sql' and `checksum` <> 1648524318;
-        update `zstack`.`schema_version` set `checksum`=-3265430   where `script`='V5.4.6__schema.sql' and `checksum` <> -3265430;
+        update `zstack`.`schema_version` set `checksum`=268584834   where `script`='V5.4.6__schema.sql' and `checksum` <> 268584834;
         update `zstack`.`schema_version` set `checksum`=-1455020895   where `script`='V5.1.4__schema.sql' and `checksum` <> -1455020895;
         update `zstack`.`schema_version` set `checksum`=569762641   where `script`='V5.4.0__schema.sql' and `checksum` <> 569762641;
+        update `zstack`.`schema_version` set `checksum`=1175380657   where `script`='V5.4.2__schema.sql' and `checksum` <> 1175380657;
     END IF;
 END $$
 


### PR DESCRIPTION
`system` is a reserved keyword in MySQL 8.0 / GreatSQL, causing SQL
  syntax errors during database migration. This change wraps the `system`
  column name with backticks in V5.4.2 and V5.4.6 schema files.

  Also updates beforeValidate.sql with new checksums:
  - V5.4.2__schema.sql: 1175380657
  - V5.4.6__schema.sql: 268584834

Resolves: ZSTAC-81449

Change-Id: I686f676775647067616d6966677161646b637071

sync from gitlab !9090