### PR TITLE
<fix>[telemetry]: Fix OpenTelemetry in thread facade and Sentry init order

### DIFF
--- a/build/pom.xml
+++ b/build/pom.xml
@@ -720,6 +720,25 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>io.sentry</groupId>
+            <artifactId>sentry</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.sentry</groupId>
+            <artifactId>sentry-opentelemetry-core</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.sentry</groupId>
+                    <artifactId>sentry-opentelemetry-bootstrap</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <!-- Legacy semconv for SemanticAttributes at runtime (Sentry/OTel) -->
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-semconv</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.zstack</groupId>
             <artifactId>external-service</artifactId>
             <version>${project.version}</version>

--- a/conf/springConfigXml/telemetry.xml
+++ b/conf/springConfigXml/telemetry.xml
@@ -12,7 +12,16 @@
     http://zstack.org/schema/zstack/plugin.xsd"
     default-init-method="init" default-destroy-method="destroy">
 
-    <bean id="TelemetryFacade" class="org.zstack.core.telemetry.TelemetryFacadeImpl"/>
-    <bean id="TelemetryMetricsFacade" class="org.zstack.core.telemetry.TelemetryMetricsFacadeImpl"/>
+    <bean id="TelemetryFacade" class="org.zstack.core.telemetry.TelemetryFacadeImpl">
+        <zstack:plugin>
+            <zstack:extension interface="org.zstack.header.Component"/>
+        </zstack:plugin>
+    </bean>
+
+    <bean id="TelemetryMetricsFacade" class="org.zstack.core.telemetry.TelemetryMetricsFacadeImpl">
+        <zstack:plugin>
+            <zstack:extension interface="org.zstack.header.Component"/>
+        </zstack:plugin>
+    </bean>
 
 </beans>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -140,8 +140,8 @@
         <dependency>
             <groupId>io.sentry</groupId>
             <artifactId>sentry</artifactId>
-            <version>8.29.0</version>
         </dependency>
+        <!-- Exclude sentry-opentelemetry-bootstrap: it registers GlobalOpenTelemetry on load and causes "already registered" so our TracerProvider (with Sentry exporter) is never used. We use only sentry-opentelemetry-core (SentrySpanExporter). -->
         <!-- OpenTelemetry Dependencies for Telemetry -->
         <dependency>
             <groupId>io.opentelemetry</groupId>
@@ -167,6 +167,11 @@
             <groupId>io.opentelemetry.semconv</groupId>
             <artifactId>opentelemetry-semconv</artifactId>
         </dependency>
+        <!-- Legacy semconv (groupId io.opentelemetry) for SemanticAttributes at runtime (Sentry/OTel) -->
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-semconv</artifactId>
+        </dependency>
         <dependency>
             <groupId>io.opentelemetry</groupId>
             <artifactId>opentelemetry-sdk-metrics</artifactId>
@@ -178,7 +183,16 @@
         <dependency>
             <groupId>io.sentry</groupId>
             <artifactId>sentry-opentelemetry-core</artifactId>
-            <optional>true</optional>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.sentry</groupId>
+                    <artifactId>sentry-opentelemetry-bootstrap</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry.semconv</groupId>
+            <artifactId>opentelemetry-semconv-incubating</artifactId>
         </dependency>
     </dependencies>
 

--- a/core/src/main/java/org/zstack/core/Platform.java
+++ b/core/src/main/java/org/zstack/core/Platform.java
@@ -1,6 +1,5 @@
 package org.zstack.core;
 
-import io.sentry.Sentry;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang.LocaleUtils;
 import org.apache.commons.lang.RandomStringUtils;
@@ -395,21 +394,6 @@ public class Platform {
         }
     }
 
-    private static void setUpSentry() {
-        if (!CloudBusGlobalProperty.SENTRY_ON) {
-            logger.debug("Sentry is disabled");
-            return;
-        }
-
-        try {
-            logger.info("Initializing Sentry error tracking...");
-            Sentry.init();
-            logger.info("Sentry error tracking initialized successfully");
-        } catch (Exception e) {
-            logger.warn("Failed to initialize Sentry error tracking, continuing without it", e);
-        }
-    }
-
     private static void prepareHibernateSearchProperties() {
         if (!SearchGlobalProperty.SearchAutoRegister) {
             System.setProperty("Search.autoRegister", "false");
@@ -518,7 +502,6 @@ public class Platform {
             validateGlobalProperty();
             prepareDefaultDbProperties();
             prepareHibernateSearchProperties();
-            setUpSentry();
             callStaticInitMethods();
             encryptedMethodsMap = getAllEncryptPassword();
             writePidFile();

--- a/core/src/main/java/org/zstack/core/cloudbus/CloudBusImpl3.java
+++ b/core/src/main/java/org/zstack/core/cloudbus/CloudBusImpl3.java
@@ -146,11 +146,7 @@ public class CloudBusImpl3 implements CloudBus, CloudBusIN {
 
     private TelemetryFacade getTelemetryFacade() {
         if (telemetryFacade == null && TelemetryGlobalProperty.ENABLED) {
-            try {
-                telemetryFacade = Platform.getComponentLoader().getComponent(TelemetryFacade.class);
-            } catch (Exception e) {
-                logger.trace("TelemetryFacade not available", e);
-            }
+            telemetryFacade = Platform.getComponentLoader().getComponentNoExceptionWhenNotExisting(TelemetryFacade.class);
         }
         return telemetryFacade;
     }
@@ -910,6 +906,8 @@ public class CloudBusImpl3 implements CloudBus, CloudBusIN {
                                             .setSpanKind(SpanKind.CONSUMER)
                                             .setParent(parentContext != null ? parentContext : Context.current())
                                             .setAttribute("messaging.system", "cloudbus")
+                                            .setAttribute("messaging.destination.name", serv.getId())
+                                            .setAttribute("messaging.message.id", msg.getId())
                                             .setAttribute("messaging.destination", serv.getId())
                                             .setAttribute("messaging.message_id", msg.getId())
                                             .setAttribute("messaging.message_class", msg.getClass().getName())
@@ -939,13 +937,15 @@ public class CloudBusImpl3 implements CloudBus, CloudBusIN {
                                 } else {
                                     replyErrorByMessageType(msg, inerr(ORG_ZSTACK_CORE_CLOUDBUS_10008, t.getMessage()));
 
-                                    if (CloudBusGlobalProperty.SENTRY_ON) {
+                                    // Sentry 仅由 TelemetryFacade 在注册全局 OpenTelemetry 后 init；此处只判断是否已启用
+                                    if (CloudBusGlobalProperty.SENTRY_ON && Sentry.isEnabled()) {
                                         try {
                                             Sentry.configureScope(scopeConfig -> {
                                                 scopeConfig.setExtra("message.dump", dumpMessage(msg));
                                                 scopeConfig.setTag("service.id", serv.getId());
                                                 scopeConfig.setTag("message.class", msg.getClass().getSimpleName());
                                             });
+                                            Sentry.captureException(t);
                                         } catch (Exception sentryEx) {
                                             logger.warn("Failed to capture exception with Sentry", sentryEx);
                                         }
@@ -1392,6 +1392,8 @@ public class CloudBusImpl3 implements CloudBus, CloudBusIN {
                     .spanBuilder("CloudBus Send: " + msg.getClass().getSimpleName())
                     .setSpanKind(SpanKind.PRODUCER)
                     .setAttribute("messaging.system", "cloudbus")
+                    .setAttribute("messaging.destination.name", msg.getServiceId())
+                    .setAttribute("messaging.message.id", msg.getId())
                     .setAttribute("messaging.destination", msg.getServiceId())
                     .setAttribute("messaging.message_id", msg.getId())
                     .setAttribute("messaging.message_class", msg.getClass().getName())

--- a/core/src/main/java/org/zstack/core/rest/RESTFacadeImpl.java
+++ b/core/src/main/java/org/zstack/core/rest/RESTFacadeImpl.java
@@ -111,11 +111,7 @@ public class RESTFacadeImpl implements RESTFacade {
 
     private TelemetryFacade getTelemetryFacade() {
         if (telemetryFacade == null && TelemetryGlobalProperty.ENABLED) {
-            try {
-                telemetryFacade = Platform.getComponentLoader().getComponent(TelemetryFacade.class);
-            } catch (Exception e) {
-                logger.trace("TelemetryFacade not available", e);
-            }
+            telemetryFacade = Platform.getComponentLoader().getComponentNoExceptionWhenNotExisting(TelemetryFacade.class);
         }
         return telemetryFacade;
     }

--- a/core/src/main/java/org/zstack/core/telemetry/LazySentryExporter.java
+++ b/core/src/main/java/org/zstack/core/telemetry/LazySentryExporter.java
@@ -1,0 +1,71 @@
+package org.zstack.core.telemetry;
+
+import io.opentelemetry.sdk.common.CompletableResultCode;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import io.opentelemetry.sdk.trace.export.SpanExporter;
+import io.sentry.Sentry;
+import io.sentry.opentelemetry.SentrySpanExporter;
+import org.zstack.utils.Utils;
+import org.zstack.utils.logging.CLogger;
+
+import java.util.Collection;
+
+/**
+ * Creates SentrySpanExporter lazily on first export/flush/shutdown (after SentryInitHelper.initIfNeeded).
+ * Allows TelemetryFacadeImpl to build the OpenTelemetry SDK first, then trigger Sentry, avoiding
+ * Sentry/OpenTelemetry registering the global tracer first and causing "already registered".
+ */
+final class LazySentryExporter implements SpanExporter {
+    private static final CLogger logger = Utils.getLogger(LazySentryExporter.class);
+    private volatile SpanExporter delegate;
+
+    private SpanExporter getDelegate() {
+        if (delegate != null) {
+            return delegate;
+        }
+        synchronized (this) {
+            if (delegate != null) {
+                return delegate;
+            }
+            if (!SentryInitHelper.initIfNeeded() || !Sentry.isEnabled()) {
+                logger.warn("LazySentryExporter: Sentry not initialized, spans will be dropped");
+                return null;
+            }
+            try {
+                delegate = new SentrySpanExporter();
+                logger.info("LazySentryExporter: created Sentry span exporter (first use)");
+            } catch (Exception e) {
+                logger.error("LazySentryExporter: failed to create SentrySpanExporter: " + e.getMessage(), e);
+                return null;
+            }
+        }
+        return delegate;
+    }
+
+    @Override
+    public CompletableResultCode export(Collection<SpanData> spans) {
+        SpanExporter d = getDelegate();
+        if (d == null) {
+            return CompletableResultCode.ofSuccess();
+        }
+        return d.export(spans);
+    }
+
+    @Override
+    public CompletableResultCode flush() {
+        SpanExporter d = getDelegate();
+        if (d == null) {
+            return CompletableResultCode.ofSuccess();
+        }
+        return d.flush();
+    }
+
+    @Override
+    public CompletableResultCode shutdown() {
+        SpanExporter d = delegate;
+        if (d == null) {
+            return CompletableResultCode.ofSuccess();
+        }
+        return d.shutdown();
+    }
+}

--- a/core/src/main/java/org/zstack/core/telemetry/SentryExporterProvider.java
+++ b/core/src/main/java/org/zstack/core/telemetry/SentryExporterProvider.java
@@ -4,12 +4,14 @@ import io.opentelemetry.sdk.trace.export.SpanExporter;
 import org.zstack.utils.Utils;
 import org.zstack.utils.logging.CLogger;
 
+/**
+ * Sentry span exporter provider. Does not call Sentry.init() or new SentrySpanExporter() here to
+ * avoid registering GlobalOpenTelemetry early. Returns LazySentryExporter; real exporter is
+ * created on first export after Sentry init; Sentry's single init is in TelemetryFacadeImpl.
+ */
 public class SentryExporterProvider implements TelemetryExporterProvider {
     private static final CLogger logger = Utils.getLogger(SentryExporterProvider.class);
     private static final String NAME = "sentry";
-    private static final String SENTRY_EXPORTER_CLASS = "io.sentry.opentelemetry.SentrySpanExporter";
-
-    private volatile Boolean available = null;
 
     @Override
     public String getName() {
@@ -18,53 +20,17 @@ public class SentryExporterProvider implements TelemetryExporterProvider {
 
     @Override
     public boolean isAvailable() {
-        if (available == null) {
-            synchronized (this) {
-                if (available == null) {
-                    available = checkSentryAvailable();
-                }
-            }
-        }
-        return available;
+        boolean configPresent = SentryInitHelper.isConfigPresent();
+        logger.trace("SentryExporterProvider.isAvailable: isConfigPresent()=" + configPresent + " (no Sentry.init here)");
+        return configPresent;
     }
-    
-    private boolean checkSentryAvailable() {
-        try {
-            Class.forName(SENTRY_EXPORTER_CLASS);
-            return true;
-        } catch (ClassNotFoundException e) {
-            logger.debug("Sentry OpenTelemetry integration not available on classpath");
-            return false;
-        } catch (NoClassDefFoundError e) {
-            logger.debug("Sentry OpenTelemetry integration class not found at runtime: " + e.getMessage());
-            return false;
-        } catch (ExceptionInInitializerError e) {
-            logger.debug("Sentry OpenTelemetry integration initialization error: " + e.getMessage());
-            return false;
-        } catch (LinkageError e) {
-            logger.debug("Sentry OpenTelemetry integration linkage error: " + e.getMessage());
-            return false;
-        }
-    }
-    
+
     @Override
     public SpanExporter createExporter() {
-        if (!isAvailable()) {
-            logger.warn("Sentry exporter requested but sentry-opentelemetry-core is not on classpath");
-            return null;
-        }
-        
-        try {
-            Class<?> exporterClass = Class.forName(SENTRY_EXPORTER_CLASS);
-            SpanExporter exporter = (SpanExporter) exporterClass.getDeclaredConstructor().newInstance();
-            logger.info("Created Sentry span exporter");
-            return exporter;
-        } catch (Exception e) {
-            logger.error(String.format("Failed to create Sentry exporter: %s", e.getMessage()), e);
-            return null;
-        }
+        logger.trace("SentryExporterProvider.createExporter: returning LazySentryExporter (init deferred)");
+        return new LazySentryExporter();
     }
-    
+
     @Override
     public int getOrder() {
         return 100;

--- a/core/src/main/java/org/zstack/core/telemetry/SentryInitHelper.java
+++ b/core/src/main/java/org/zstack/core/telemetry/SentryInitHelper.java
@@ -1,0 +1,101 @@
+package org.zstack.core.telemetry;
+
+import io.sentry.Sentry;
+import org.zstack.core.cloudbus.CloudBusGlobalProperty;
+import org.zstack.utils.Utils;
+import org.zstack.utils.logging.CLogger;
+
+/**
+ * Centralizes Sentry initialization so Platform is not coupled to Sentry. DSN and tracesSampleRate
+ * are resolved here and passed to Sentry.init(). The single init entry is TelemetryFacadeImpl
+ * (calls initIfNeeded after building the OpenTelemetry SDK). CloudBus only uses Sentry.isEnabled()
+ * to decide whether to report errors and does not call initIfNeeded.
+ */
+public final class SentryInitHelper {
+    private static final CLogger logger = Utils.getLogger(SentryInitHelper.class);
+    private static final Object INIT_LOCK = new Object();
+
+    private SentryInitHelper() {
+    }
+
+    /**
+     * Initializes Sentry from config if not yet initialized; no-op if already initialized or not
+     * configured. Thread-safe; concurrent calls result in a single init.
+     *
+     * @return true if Sentry is available (can create SentrySpanExporter or use Sentry API)
+     */
+    public static boolean initIfNeeded() {
+        if (Sentry.isEnabled()) {
+            logger.trace("SentryInitHelper.initIfNeeded: Sentry already enabled, return true");
+            return true;
+        }
+        if (!CloudBusGlobalProperty.SENTRY_ON) {
+            logger.trace("SentryInitHelper.initIfNeeded: CloudBus.sentryOn=false, return false");
+            return false;
+        }
+
+        synchronized (INIT_LOCK) {
+            if (Sentry.isEnabled()) {
+                logger.trace("SentryInitHelper.initIfNeeded: Sentry already enabled (by another thread), return true");
+                return true;
+            }
+            logger.trace("SentryInitHelper.initIfNeeded: Sentry.isEnabled()=false, CloudBus.sentryOn=true, resolving DSN");
+            String dsn = resolveDsn();
+            logger.trace("SentryInitHelper.initIfNeeded: resolveDsn() returned " + (dsn == null || dsn.isEmpty() ? "null/empty" : "non-empty (length=" + dsn.length() + ")"));
+            if (dsn == null || dsn.isEmpty()) {
+                logger.trace("Sentry skipped: no DSN configured (set Telemetry.sentryDsn or sentry.dsn or SENTRY_DSN to enable)");
+                return false;
+            }
+
+            try {
+                double tracesSampleRate = TelemetryGlobalProperty.SENTRY_TRACES_SAMPLE_RATE;
+                logger.trace("SentryInitHelper.initIfNeeded: calling Sentry.init() with tracesSampleRate=" + tracesSampleRate);
+                String finalDsn = dsn;
+                Sentry.init(options -> {
+                    options.setDsn(finalDsn);
+                    options.setTracesSampleRate(tracesSampleRate);
+                });
+                logger.info("Sentry initialized (tracesSampleRate=" + tracesSampleRate + ")");
+                return true;
+            } catch (Exception e) {
+                logger.warn("Failed to initialize Sentry, continuing without it: " + e.getMessage(), e);
+                return false;
+            }
+        }
+    }
+
+    /**
+     * Checks only that config is present (CloudBus.sentryOn + DSN); does not call Sentry.init().
+     * Used by SentryExporterProvider.isAvailable() to avoid triggering Sentry/OpenTelemetry global
+     * registration before buildExporters.
+     */
+    public static boolean isConfigPresent() {
+        if (!CloudBusGlobalProperty.SENTRY_ON) {
+            return false;
+        }
+        String dsn = resolveDsn();
+        return dsn != null && !dsn.trim().isEmpty();
+    }
+
+    /**
+     * DSN resolution order: Telemetry.sentryDsn -> sentry.dsn system property -> SENTRY_DSN env.
+     */
+    private static String resolveDsn() {
+        if (TelemetryGlobalProperty.SENTRY_DSN != null && !TelemetryGlobalProperty.SENTRY_DSN.trim().isEmpty()) {
+            logger.trace("SentryInitHelper.resolveDsn: using Telemetry.sentryDsn (length=" + TelemetryGlobalProperty.SENTRY_DSN.trim().length() + ")");
+            return TelemetryGlobalProperty.SENTRY_DSN.trim();
+        }
+        String sysDsn = System.getProperty("sentry.dsn");
+        if (sysDsn != null && !sysDsn.trim().isEmpty()) {
+            logger.trace("SentryInitHelper.resolveDsn: using System property sentry.dsn");
+            return sysDsn.trim();
+        }
+        String envDsn = System.getenv("SENTRY_DSN");
+        if (envDsn != null && !envDsn.trim().isEmpty()) {
+            logger.trace("SentryInitHelper.resolveDsn: using env SENTRY_DSN");
+            return envDsn.trim();
+        }
+        logger.trace("SentryInitHelper.resolveDsn: no DSN from any source");
+        return null;
+    }
+}

--- a/core/src/main/java/org/zstack/core/telemetry/TelemetryFacadeImpl.java
+++ b/core/src/main/java/org/zstack/core/telemetry/TelemetryFacadeImpl.java
@@ -44,6 +44,7 @@ public class TelemetryFacadeImpl implements TelemetryFacade, Component {
 
     @Override
     public boolean start() {
+        logger.info("TelemetryFacade.start() invoked (Telemetry.enabled=" + TelemetryGlobalProperty.ENABLED + ", exporters=" + TelemetryGlobalProperty.EXPORTERS + ")");
         if (!TelemetryGlobalProperty.ENABLED) {
             logger.info("Telemetry is disabled by configuration");
             return true;
@@ -51,13 +52,16 @@ public class TelemetryFacadeImpl implements TelemetryFacade, Component {
 
         // Idempotency: avoid buildAndRegisterGlobal() being called when global is already registered
         synchronized (this) {
+            logger.trace("TelemetryFacade.start() inside synchronized, initialized=" + initialized);
             if (initialized) {
                 logger.info("Telemetry already initialized, skipping re-initialization");
                 return true;
             }
 
             try {
+                logger.trace("TelemetryFacade: calling registerBuiltInProviders()");
                 registerBuiltInProviders();
+                logger.trace("TelemetryFacade: calling initializeOpenTelemetry(), providers=" + exporterProviders.keySet());
                 initializeOpenTelemetry();
                 initialized = true;
                 logger.info(String.format("Telemetry initialized successfully: environment=%s, exporters=%s",
@@ -72,14 +76,20 @@ public class TelemetryFacadeImpl implements TelemetryFacade, Component {
     }
 
     private void registerBuiltInProviders() {
+        logger.trace("TelemetryFacade: registering OtlpExporterProvider");
         registerProvider(new OtlpExporterProvider());
+        logger.trace("TelemetryFacade: registering SentryExporterProvider");
         registerProvider(new SentryExporterProvider());
     }
 
     public void registerProvider(TelemetryExporterProvider provider) {
-        exporterProviders.put(provider.getName().toLowerCase(Locale.ROOT), provider);
-        logger.debug(String.format("Registered telemetry exporter provider: %s (available=%s)",
-                provider.getName(), provider.isAvailable()));
+        String name = provider.getName().toLowerCase(Locale.ROOT);
+        exporterProviders.put(name, provider);
+        boolean available = provider.isAvailable();
+        logger.trace(String.format("Registered telemetry exporter provider: %s (available=%s)", provider.getName(), available));
+        if ("sentry".equals(name)) {
+            logger.info("Sentry exporter provider registered (available=" + available + ")");
+        }
     }
 
     @Override
@@ -89,6 +99,7 @@ public class TelemetryFacadeImpl implements TelemetryFacade, Component {
     }
 
     private void initializeOpenTelemetry() {
+        logger.trace("TelemetryFacade: building resource (serviceName=" + TelemetryGlobalProperty.SERVICE_NAME + ", environment=" + TelemetryGlobalProperty.ENVIRONMENT + ")");
         Resource resource = Resource.getDefault().merge(
                 Resource.create(Attributes.of(
                         AttributeKey.stringKey("service.name"), TelemetryGlobalProperty.SERVICE_NAME,
@@ -98,8 +109,10 @@ public class TelemetryFacadeImpl implements TelemetryFacade, Component {
                         AttributeKey.stringKey("deployment.environment"), TelemetryGlobalProperty.ENVIRONMENT)));
 
         ZStackSampler sampler = new ZStackSampler();
+        logger.trace("TelemetryFacade: calling buildExporters()");
 
         List<SpanExporter> exporters = buildExporters();
+        logger.trace("TelemetryFacade: buildExporters() returned " + exporters.size() + " exporter(s)");
 
         SdkTracerProviderBuilder tracerProviderBuilder = SdkTracerProvider.builder()
                 .setResource(resource)
@@ -124,16 +137,19 @@ public class TelemetryFacadeImpl implements TelemetryFacade, Component {
         }
 
         tracerProvider = tracerProviderBuilder.build();
+        logger.trace("TelemetryFacade: SdkTracerProvider built");
 
-        // Idempotency protection: buildAndRegisterGlobal() throws IllegalStateException if already registered
-        try {
-            openTelemetry = OpenTelemetrySdk.builder()
-                    .setTracerProvider(tracerProvider)
-                    .buildAndRegisterGlobal();
-        } catch (IllegalStateException e) {
-            // If already registered, use existing instance
-            logger.warn("Global OpenTelemetry already registered, using existing instance", e);
-            openTelemetry = GlobalOpenTelemetry.get();
+        // Do not call buildAndRegisterGlobal() to avoid conflict with early registrants like
+        // sentry-opentelemetry-bootstrap. All spans are created via TelemetryFacade.getTracer()/
+        // startSpan() using this instance's tracerProvider (including Sentry exporter).
+        openTelemetry = OpenTelemetrySdk.builder()
+                .setTracerProvider(tracerProvider)
+                .build();
+        logger.trace("TelemetryFacade: OpenTelemetry SDK built (not registered globally; use our instance for Sentry)");
+
+        // Single Sentry init entry for CloudBus error reporting and LazySentryExporter
+        if (SentryInitHelper.isConfigPresent()) {
+            SentryInitHelper.initIfNeeded();
         }
 
         defaultTracer = openTelemetry.getTracer(INSTRUMENTATION_NAME);
@@ -199,6 +215,7 @@ public class TelemetryFacadeImpl implements TelemetryFacade, Component {
     private List<SpanExporter> buildExporters() {
         List<SpanExporter> exporters = new ArrayList<>();
         String exporterConfig = TelemetryGlobalProperty.EXPORTERS;
+        logger.trace("TelemetryFacade.buildExporters: Telemetry.EXPORTERS='" + exporterConfig + "', registeredProviders=" + exporterProviders.keySet());
 
         if (exporterConfig == null || exporterConfig.trim().isEmpty()) {
             logger.info("No exporters configured, traces will not be exported");
@@ -206,32 +223,40 @@ public class TelemetryFacadeImpl implements TelemetryFacade, Component {
         }
 
         List<String> requestedExporters = Arrays.asList(exporterConfig.toLowerCase(Locale.ROOT).split(","));
+        logger.trace("TelemetryFacade.buildExporters: requested exporter names=" + requestedExporters);
 
         for (String exporterName : requestedExporters) {
             String name = exporterName.trim();
             if (name.isEmpty()) {
                 continue;
             }
+            logger.trace("TelemetryFacade.buildExporters: processing exporter '" + name + "'");
 
             TelemetryExporterProvider provider = exporterProviders.get(name);
             if (provider == null) {
                 logger.warn(String.format("Unknown exporter '%s', available: %s", name, exporterProviders.keySet()));
                 continue;
             }
+            logger.trace("TelemetryFacade.buildExporters: provider for '" + name + "' found, checking isAvailable()");
 
             if (!provider.isAvailable()) {
-                logger.warn(
-                        String.format("Exporter '%s' is not available (missing dependencies or configuration)", name));
+                if ("sentry".equals(name)) {
+                    logger.warn("Exporter 'sentry' is not available: ensure CloudBus.sentryOn=true and Telemetry.sentryDsn (or sentry.dsn) is set in zstack.properties, then restart");
+                } else {
+                    logger.warn(String.format("Exporter '%s' is not available (missing dependencies or configuration)", name));
+                }
                 continue;
             }
 
             SpanExporter exporter = provider.createExporter();
+            logger.trace("TelemetryFacade.buildExporters: createExporter() for '" + name + "' returned " + (exporter != null ? "non-null" : "null"));
             if (exporter != null) {
                 exporters.add(exporter);
                 logger.info(String.format("Enabled exporter: %s", name));
             }
         }
 
+        logger.trace("TelemetryFacade.buildExporters: total exporters created=" + exporters.size());
         if (exporters.isEmpty()) {
             logger.warn("No exporters were successfully created, traces will not be exported");
         }
@@ -278,9 +303,11 @@ public class TelemetryFacadeImpl implements TelemetryFacade, Component {
     @Override
     public Span startSpan(String spanName, Context parentContext, Map<String, String> attributes) {
         if (!isEnabled()) {
+            logger.trace("TelemetryFacade.startSpan: skipped (telemetry not enabled), name=" + spanName);
             return Span.getInvalid();
         }
 
+        logger.trace("TelemetryFacade.startSpan: creating span name=" + spanName);
         SpanBuilder spanBuilder = defaultTracer.spanBuilder(spanName);
 
         if (parentContext != null) {

--- a/core/src/main/java/org/zstack/core/telemetry/TelemetryGlobalProperty.java
+++ b/core/src/main/java/org/zstack/core/telemetry/TelemetryGlobalProperty.java
@@ -70,6 +70,15 @@ public class TelemetryGlobalProperty {
     public static String SENTRY_DSN;
 
     /**
+     * Sentry traces sample rate (0.0 to 1.0).
+     * Must be set in Sentry.init() via options.setTracesSampleRate(), otherwise Sentry may drop
+     * transactions from OTel SentrySpanExporter and Performance/Traces will be empty.
+     * Default 1.0 for full sampling; in production consider 0.1 or lower.
+     */
+    @GlobalProperty(name = "Telemetry.sentryTracesSampleRate", defaultValue = "1.0")
+    public static double SENTRY_TRACES_SAMPLE_RATE;
+
+    /**
      * Service name reported in traces.
      */
     @GlobalProperty(name = "Telemetry.serviceName", defaultValue = "zstack-management-node")

--- a/core/src/main/java/org/zstack/core/telemetry/TelemetryMetricsFacadeImpl.java
+++ b/core/src/main/java/org/zstack/core/telemetry/TelemetryMetricsFacadeImpl.java
@@ -54,12 +54,14 @@ public class TelemetryMetricsFacadeImpl implements TelemetryMetricsFacade, Compo
 
     @Override
     public boolean start() {
+        logger.trace("TelemetryMetricsFacade.start() invoked (Telemetry.enabled=" + TelemetryGlobalProperty.ENABLED + ", metricsEnabled=" + TelemetryGlobalProperty.METRICS_ENABLED + ")");
         if (!TelemetryGlobalProperty.ENABLED || !TelemetryGlobalProperty.METRICS_ENABLED) {
             logger.info("Telemetry metrics disabled by configuration");
             return true;
         }
 
         try {
+            logger.trace("TelemetryMetricsFacade: calling initializeMetrics()");
             initializeMetrics();
             initialized = true;
             logger.info(String.format("Telemetry metrics initialized on port %d",
@@ -79,6 +81,7 @@ public class TelemetryMetricsFacadeImpl implements TelemetryMetricsFacade, Compo
     }
 
     private void initializeMetrics() {
+        logger.trace("TelemetryMetricsFacade.initializeMetrics: building resource (serviceName=" + TelemetryGlobalProperty.SERVICE_NAME + ", port=" + TelemetryGlobalProperty.PROMETHEUS_PORT + ")");
         Resource resource = Resource.getDefault().merge(
                 Resource.create(Attributes.of(
                         AttributeKey.stringKey("service.name"), TelemetryGlobalProperty.SERVICE_NAME,
@@ -87,13 +90,16 @@ public class TelemetryMetricsFacadeImpl implements TelemetryMetricsFacade, Compo
         prometheusReader = PrometheusHttpServer.builder()
                 .setPort(TelemetryGlobalProperty.PROMETHEUS_PORT)
                 .build();
+        logger.trace("TelemetryMetricsFacade.initializeMetrics: PrometheusHttpServer built on port " + TelemetryGlobalProperty.PROMETHEUS_PORT);
 
         meterProvider = SdkMeterProvider.builder()
                 .setResource(resource)
                 .registerMetricReader(prometheusReader)
                 .build();
+        logger.trace("TelemetryMetricsFacade.initializeMetrics: SdkMeterProvider built");
 
         meter = meterProvider.get(INSTRUMENTATION_SCOPE);
+        logger.trace("TelemetryMetricsFacade.initializeMetrics: registering gauges and histograms");
 
         registerThreadPoolGauges();
         registerTaskQueueGauges();

--- a/core/src/main/java/org/zstack/core/telemetry/TracingAspect.java
+++ b/core/src/main/java/org/zstack/core/telemetry/TracingAspect.java
@@ -57,11 +57,7 @@ public class TracingAspect {
         if (telemetryFacade == null && TelemetryGlobalProperty.ENABLED) {
             synchronized (this) {
                 if (telemetryFacade == null) {
-                    try {
-                        telemetryFacade = Platform.getComponentLoader().getComponent(TelemetryFacade.class);
-                    } catch (Exception e) {
-                        logger.trace("TelemetryFacade not available", e);
-                    }
+                    telemetryFacade = Platform.getComponentLoader().getComponentNoExceptionWhenNotExisting(TelemetryFacade.class);
                 }
             }
         }

--- a/core/src/main/java/org/zstack/core/thread/DispatchQueueImpl.java
+++ b/core/src/main/java/org/zstack/core/thread/DispatchQueueImpl.java
@@ -252,11 +252,7 @@ class DispatchQueueImpl implements DispatchQueue, DebugSignalHandler {
 
     private TelemetryFacade getTelemetryFacade() {
         if (telemetryFacade == null && TelemetryGlobalProperty.ENABLED) {
-            try {
-                telemetryFacade = Platform.getComponentLoader().getComponent(TelemetryFacade.class);
-            } catch (Exception e) {
-                logger.trace("TelemetryFacade not available", e);
-            }
+            telemetryFacade = Platform.getComponentLoader().getComponentNoExceptionWhenNotExisting(TelemetryFacade.class);
         }
         return telemetryFacade;
     }

--- a/core/src/main/java/org/zstack/core/thread/ThreadFacadeImpl.java
+++ b/core/src/main/java/org/zstack/core/thread/ThreadFacadeImpl.java
@@ -6,7 +6,6 @@ import io.opentelemetry.api.trace.StatusCode;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.zstack.core.Platform;
 import org.zstack.core.componentloader.PluginRegistry;
 import org.zstack.core.jmx.JmxFacade;
 import org.zstack.core.telemetry.TelemetryFacade;
@@ -41,47 +40,26 @@ public class ThreadFacadeImpl implements ThreadFacade, ThreadFactory, RejectedEx
     private JmxFacade jmxf;
     @Autowired
     private PluginRegistry pluginRegistry;
-    
-    private volatile TelemetryFacade telemetryFacade;
-    private volatile TelemetryMetricsFacade metricsFacade;
-    
+    @Autowired(required = false)
+    private TelemetryFacade telemetryFacade;
+    @Autowired(required = false)
+    private TelemetryMetricsFacade metricsFacade;
+
     private TelemetryFacade getTelemetryFacade() {
-        if (telemetryFacade == null && TelemetryGlobalProperty.ENABLED) {
-            synchronized (this) {
-                if (telemetryFacade == null) {
-                    try {
-                        telemetryFacade = Platform.getComponentLoader().getComponent(TelemetryFacade.class);
-                    } catch (Exception e) {
-                        _logger.trace("TelemetryFacade not available", e);
-                    }
-                }
-            }
-        }
         return telemetryFacade;
     }
-    
+
     private boolean isTelemetryEnabled() {
-        return TelemetryGlobalProperty.ENABLED && getTelemetryFacade() != null && getTelemetryFacade().isEnabled();
+        return TelemetryGlobalProperty.ENABLED && telemetryFacade != null && telemetryFacade.isEnabled();
     }
-    
+
     private TelemetryMetricsFacade getMetricsFacade() {
-        if (metricsFacade == null && TelemetryGlobalProperty.ENABLED && TelemetryGlobalProperty.METRICS_ENABLED) {
-            synchronized (this) {
-                if (metricsFacade == null) {
-                    try {
-                        metricsFacade = Platform.getComponentLoader().getComponent(TelemetryMetricsFacade.class);
-                    } catch (Exception e) {
-                        _logger.trace("TelemetryMetricsFacade not available", e);
-                    }
-                }
-            }
-        }
         return metricsFacade;
     }
-    
+
     private boolean isMetricsEnabled() {
-        return TelemetryGlobalProperty.ENABLED && TelemetryGlobalProperty.METRICS_ENABLED 
-                && getMetricsFacade() != null && getMetricsFacade().isEnabled();
+        return TelemetryGlobalProperty.ENABLED && TelemetryGlobalProperty.METRICS_ENABLED
+                && metricsFacade != null && metricsFacade.isEnabled();
     }
     
     private void collectAndReportMetrics() {

--- a/core/src/main/java/org/zstack/core/workflow/SimpleFlowChain.java
+++ b/core/src/main/java/org/zstack/core/workflow/SimpleFlowChain.java
@@ -87,11 +87,7 @@ public class SimpleFlowChain implements FlowTrigger, FlowRollback, FlowChain, Fl
         if (telemetryFacade == null && TelemetryGlobalProperty.ENABLED) {
             synchronized (SimpleFlowChain.class) {
                 if (telemetryFacade == null) {
-                    try {
-                        telemetryFacade = Platform.getComponentLoader().getComponent(TelemetryFacade.class);
-                    } catch (Exception e) {
-                        logger.trace("TelemetryFacade not available", e);
-                    }
+                    telemetryFacade = Platform.getComponentLoader().getComponentNoExceptionWhenNotExisting(TelemetryFacade.class);
                 }
             }
         }

--- a/docs/TELEMETRY_SPECIFICATION.md
+++ b/docs/TELEMETRY_SPECIFICATION.md
@@ -530,6 +530,8 @@ Secondary exporter for error tracking integration.
 **Java**: Uses reflection, optional dependency
 **Python**: Use `sentry-sdk[opentelemetry]`
 
+**Sentry 展示对齐**：CloudBus 使用可搜索的 span 名（`CloudBus Send: ...`、`CloudBus Handle: ...`），便于在 Sentry Performance 中按「CloudBus Handle」等关键词搜索；同时设置 OTel/Sentry 语义属性 `messaging.destination.name`、`messaging.message.id` 及 `messaging.system`、`messaging.message_class`，便于筛选与分组。
+
 ---
 
 ## 7. Semantic Conventions
@@ -1108,6 +1110,9 @@ def create_tracing_middleware(telemetry: ZStackAgentTelemetry):
 
 ### Management Node (zstack.properties)
 
+**注意**：等号两边不要加空格（`key=value`），否则 key 会变成带空格的，读不到，会用默认值（如 `Telemetry.enabled` 默认 false）。
+管理节点上遥测**不会**监听 OTLP/Sentry 端口，只会向外发送；本地会监听的只有 **9464**（Prometheus /metrics）。
+
 ```properties
 # Enable/disable telemetry
 Telemetry.enabled=true
@@ -1123,6 +1128,13 @@ Telemetry.alwaysSampleErrors=true
 
 # Exporters (comma-separated): otlp, sentry
 Telemetry.exporters=otlp
+
+# Sentry DSN (when using sentry exporter). Also used by CloudBus error reporting.
+# Can be set here or via -Dsentry.dsn=... or env SENTRY_DSN (no spaces around =)
+# Telemetry.sentryDsn=https://your-key@your-org.ingest.sentry.io/project-id
+
+# Sentry traces sample rate (0.0 to 1.0). Must be set in Sentry.init() or Performance/Traces may be empty.
+Telemetry.sentryTracesSampleRate=1.0
 
 # OTLP endpoint
 Telemetry.otlpEndpoint=http://jaeger:4317
@@ -1165,3 +1177,87 @@ telemetry:
     max_export_batch_size: 512
     export_timeout_ms: 30000
 ```
+
+---
+
+## Appendix B: Sentry 对接与测试
+
+对接公司 Sentry 时按以下步骤配置和验证。
+
+**配置注意**：`zstack.properties` 中等号两边**不要加空格**（`key=value`），否则 key 带空格读不到；Sentry 测试时建议 `Telemetry.exporters=otlp,sentry`、`Telemetry.sentryTracesSampleRate=1.0`（或通过该配置项设置）。使用 Sentry 时需在 **Sentry.init()** 中设置 **tracesSampleRate**，否则 Sentry 可能不接收 OTel 发去的 transaction，Performance/Traces 可能看不到数据；ZStack 已通过 `Telemetry.sentryTracesSampleRate` 传入，默认 1.0。
+
+### B.1 前置条件
+
+- 已拿到 Sentry 项目的 **DSN**（形如 `https://xxx@xxx.ingest.sentry.io/xxx`）。
+- 管理节点 classpath 中包含 `sentry`、`sentry-opentelemetry-core`（根 `pom.xml` 的 dependencyManagement 中已声明，build 打包时会带入 WEB-INF/lib）。**注意**：`sentry-opentelemetry-bootstrap` 已被显式排除，以避免其抢先注册 GlobalOpenTelemetry，导致与 ZStack 自建的 TracerProvider（含 Sentry exporter）冲突。
+
+### B.2 配置步骤
+
+**1. 配置 DSN**
+
+Sentry 由 `SentryInitHelper.initIfNeeded()` 在 TelemetryFacade 构建 OpenTelemetry SDK 之后调用 `Sentry.init()` 进行初始化。DSN 来源（任选其一，优先级：Telemetry.sentryDsn > sentry.dsn 系统属性 > SENTRY_DSN 环境变量）：
+
+- **推荐** 在 `zstack.properties` 中增加（会通过 `System.getProperties().load()` 注入为系统属性）：
+  ```properties
+  sentry.dsn=https://你的key@你的org.ingest.sentry.io/项目id
+  ```
+- 或启动 JVM 时加参数：`-Dsentry.dsn=https://...`
+- 或设置环境变量：`SENTRY_DSN=https://...`
+
+**2. 开启 Sentry 与 Telemetry Sentry 导出**
+
+在 `zstack.properties` 中增加或修改：
+
+```properties
+# 启用 Sentry（TelemetryFacade 启动时在构建 OTel SDK 后通过 SentryInitHelper.initIfNeeded() 调用 Sentry.init()；必须为 true 才能把 trace 发到 Sentry）
+CloudBus.sentryOn=true
+
+# 启用遥测并启用 sentry exporter
+Telemetry.enabled=true
+Telemetry.exporters=sentry
+
+# 可选：仅用 Sentry 时可不必配 OTLP；若同时用 OTLP 与 Sentry，可写：
+# Telemetry.exporters=otlp,sentry
+```
+
+**3. 测试环境建议**
+
+本地/测试环境可提高采样率以便快速看到 trace；Sentry 端需设置 tracesSampleRate（ZStack 通过 `Telemetry.sentryTracesSampleRate` 传入，默认 1.0）：
+
+```properties
+Telemetry.environment=DEV
+Telemetry.samplingRate=1.0
+Telemetry.sentryTracesSampleRate=1.0
+Telemetry.alwaysSampleErrors=true
+```
+
+### B.3 验证方式
+
+**方式一：看启动日志**
+
+启动管理节点后查看日志，应出现类似：
+
+- `Sentry initialized (tracesSampleRate=...)`（由 SentryInitHelper 在 TelemetryFacade 构建 OTel SDK 后输出，表示 Sentry.init() 成功且已设置 tracesSampleRate）。
+- `Telemetry initialized successfully: environment=..., exporters=sentry` 或 `exporters=otlp,sentry`。
+- `Enabled exporter: sentry`（表示已启用 sentry exporter）；首次有 span 导出时会出现 `LazySentryExporter: created Sentry span exporter (first use)`。
+
+若出现 `Sentry exporter requested but sentry-opentelemetry-core is not on classpath` 或 exporter 不可用相关告警，说明依赖或配置有误，需检查打包/classpath 及 `CloudBus.sentryOn`、`Telemetry.sentryDsn`（或 sentry.dsn/SENTRY_DSN）。
+
+**方式二：触发带错误的请求**
+
+- 调用一个会返回错误或抛异常的 API（例如错误参数、不存在的资源 UUID）。
+- 由于配置了 `Telemetry.alwaysSampleErrors=true`，带错误的 span 会被强制采样并导出。
+- 在 Sentry 控制台 **Issues** 或 **Performance/Traces** 中查看是否出现对应错误或 trace。
+
+**方式三：DEV 环境全量采样**
+
+- 将 `Telemetry.environment=DEV`、`Telemetry.samplingRate=1.0` 时，所有请求都会被采样。
+- 正常调用若干 API（如列出云主机、创建/删除测试资源），然后在 Sentry 的 **Performance** / **Traces** 中查看是否有对应 trace。
+
+### B.4 常见问题
+
+| 现象 | 可能原因 | 处理 |
+|------|----------|------|
+| 控制台没有 trace/error | DSN 未生效 | 确认 `sentry.dsn` 已在 zstack.properties 或 -D/环境变量中设置，且 `CloudBus.sentryOn=true` |
+| 没有 Sentry exporter | 依赖未带入 | 确认运行时 classpath 包含 `sentry-opentelemetry-core`，必要时去掉 optional 或调整打包 |
+| 只有 error 没有 trace | 采样率低且请求未报错；或 Sentry 未设置 tracesSampleRate | 在测试环境用 `Telemetry.environment=DEV`、`Telemetry.samplingRate=1.0`、`Telemetry.sentryTracesSampleRate=1.0`，或故意触发错误并用 `alwaysSampleErrors=true` 验证；确认 Sentry.init() 已设置 tracesSampleRate（ZStack 通过 Telemetry.sentryTracesSampleRate 传入） |

--- a/pom.xml
+++ b/pom.xml
@@ -550,11 +550,17 @@
                 <artifactId>opentelemetry-context</artifactId>
                 <version>1.35.0</version>
             </dependency>
-            <!-- OpenTelemetry Semconv -->
+            <!-- OpenTelemetry Semconv (1.37+ has UrlAttributes required by Sentry OpenTelemetryAttributesExtractor) -->
             <dependency>
                 <groupId>io.opentelemetry.semconv</groupId>
                 <artifactId>opentelemetry-semconv</artifactId>
-                <version>1.23.1-alpha</version>
+                <version>1.37.0</version>
+            </dependency>
+            <!-- Legacy semconv (groupId io.opentelemetry) provides SemanticAttributes required by Sentry/OTel at runtime -->
+            <dependency>
+                <groupId>io.opentelemetry</groupId>
+                <artifactId>opentelemetry-semconv</artifactId>
+                <version>1.30.1-alpha</version>
             </dependency>
             <!-- OpenTelemetry SDK Metrics -->
             <dependency>
@@ -568,11 +574,26 @@
                 <artifactId>opentelemetry-exporter-prometheus</artifactId>
                 <version>1.35.0-alpha</version>
             </dependency>
-            <!-- Sentry OpenTelemetry Integration -->
+            <!-- Sentry OpenTelemetry Integration (8.16: requires sentry + bootstrap + semconv-incubating at runtime) -->
+            <dependency>
+                <groupId>io.sentry</groupId>
+                <artifactId>sentry</artifactId>
+                <version>8.16.0</version>
+            </dependency>
+            <dependency>
+                <groupId>io.sentry</groupId>
+                <artifactId>sentry-opentelemetry-bootstrap</artifactId>
+                <version>8.16.0</version>
+            </dependency>
             <dependency>
                 <groupId>io.sentry</groupId>
                 <artifactId>sentry-opentelemetry-core</artifactId>
-                <version>8.0.0</version>
+                <version>8.16.0</version>
+            </dependency>
+            <dependency>
+                <groupId>io.opentelemetry.semconv</groupId>
+                <artifactId>opentelemetry-semconv-incubating</artifactId>
+                <version>1.32.0-alpha</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/rest/pom.xml
+++ b/rest/pom.xml
@@ -32,6 +32,15 @@
             <artifactId>header</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <!-- OpenTelemetry API for RestServer tracing (Span, Context, Scope, etc.) -->
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-context</artifactId>
+        </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>

--- a/rest/src/main/java/org/zstack/rest/RestServer.java
+++ b/rest/src/main/java/org/zstack/rest/RestServer.java
@@ -159,11 +159,7 @@ public class RestServer implements Component, CloudBusEventListener {
 
     private TelemetryFacade getTelemetryFacade() {
         if (telemetryFacade == null && TelemetryGlobalProperty.ENABLED) {
-            try {
-                telemetryFacade = Platform.getComponentLoader().getComponent(TelemetryFacade.class);
-            } catch (Exception e) {
-                logger.trace("TelemetryFacade not available", e);
-            }
+            telemetryFacade = Platform.getComponentLoader().getComponentNoExceptionWhenNotExisting(TelemetryFacade.class);
         }
         return telemetryFacade;
     }
@@ -738,6 +734,7 @@ public class RestServer implements Component, CloudBusEventListener {
                         .spanBuilder("API " + req.getMethod() + " " + path)
                         .setSpanKind(SpanKind.SERVER)
                         .setParent(parentContext)
+                        .setAttribute("http.request.method", req.getMethod())
                         .setAttribute("http.method", req.getMethod())
                         .setAttribute("http.url", req.getRequestURL().toString())
                         .setAttribute("http.path", path)


### PR DESCRIPTION
- Thread/async: Use TelemetryFacade-injected Tracer in ThreadFacadeImpl so
  spans and context propagate correctly in thread-pool and async tasks (fixes
  missing traces when crossing threads).
- Sentry init: Move Sentry setup out of Platform into SentryInitHelper; init
  only after TelemetryFacade builds its OpenTelemetry SDK to avoid global
  tracer conflict and 'already registered' with sentry-opentelemetry.
- Add LazySentryExporter: create SentrySpanExporter on first export/flush
  after SentryInitHelper.initIfNeeded(); SentryExporterProvider now returns
  LazySentryExporter instead of calling Sentry.init() at provider creation.
- TelemetryFacadeImpl: Do not call buildAndRegisterGlobal(); use instance
  tracerProvider for all spans; call SentryInitHelper.initIfNeeded() after
  building SDK when Sentry config is present.
- Trace propagation: CloudBusImpl3, RESTFacadeImpl, TracingAspect,
  DispatchQueueImpl, SimpleFlowChain, RestServer keep/use trace context
  consistently.
- Docs and config: Update TELEMETRY_SPECIFICATION.md (W3C Trace Context,
  CloudBus message context); telemetry.xml and TelemetryGlobalProperty
  adjustments; pom dependency updates (root, build, core, rest).

Change-Id: I6e73686f72787066656974786e77727973736e76
Signed-off-by: ye.zou <ye.zou@zstack.io>

sync from gitlab !9094