### PR TITLE
<fix>[gpu]: fix virtualized GPU incorrectly showing as allocatable

### DIFF
--- a/conf/db/upgrade/V5.5.6__schema.sql
+++ b/conf/db/upgrade/V5.5.6__schema.sql
@@ -219,3 +219,13 @@ UPDATE ModelServiceInstanceVO msi
 INNER JOIN PodVO p ON msi.vmInstanceUuid = p.uuid
 SET msi.clusterId = p.clusterId
 WHERE msi.clusterId IS NULL AND p.clusterId IS NOT NULL;
+
+-- Fix GPU allocateStatus for virtualized devices
+-- Issue: Virtualized physical GPUs (with vGPUs generated) should show as Unallocatable, not Unallocated
+-- This UPDATE is idempotent: WHERE clause ensures only incorrect statuses are updated
+UPDATE `zstack`.`GpuDeviceVO` g
+INNER JOIN `zstack`.`PciDeviceVO` p ON g.`uuid` = p.`uuid`
+SET g.`allocateStatus` = 'Unallocatable'
+WHERE p.`virtStatus` IN ('VFIO_MDEV_VIRTUALIZED', 'SRIOV_VIRTUALIZED')
+  AND p.`vmInstanceUuid` IS NULL
+  AND g.`allocateStatus` != 'Unallocatable';

--- a/sdk/src/main/java/org/zstack/sdk/GpuAllocateStatus.java
+++ b/sdk/src/main/java/org/zstack/sdk/GpuAllocateStatus.java
@@ -3,4 +3,5 @@ package org.zstack.sdk;
 public enum GpuAllocateStatus {
 	Unallocated,
 	Allocated,
+	Unallocatable,
 }


### PR DESCRIPTION
When GPU is virtualized (VFIO MDEV or SR-IOV), its allocateStatus should be
Unallocatable instead of Unallocated to prevent incorrect allocation.

Changes:
1. Add Unallocatable status to GpuAllocateStatus enum (SDK sync)
2. Add database migration SQL to fix existing data

DBImpact

Resolves: ZSTAC-81457
Change-Id: I66851c798d9a4cf2f401d24a6fdb9179972a15418

sync from gitlab !9146