### PR TITLE
fix(core): fix otel/sentry classpath NoClassDefFoundError

### DIFF
--- a/build/pom.xml
+++ b/build/pom.xml
@@ -731,11 +731,6 @@
             <groupId>io.sentry</groupId>
             <artifactId>sentry-opentelemetry-bootstrap</artifactId>
         </dependency>
-        <!-- New semconv (io.opentelemetry.semconv) for UrlAttributes required by Sentry 8.x -->
-        <dependency>
-            <groupId>io.opentelemetry.semconv</groupId>
-            <artifactId>opentelemetry-semconv</artifactId>
-        </dependency>
         <!-- Legacy semconv 1.23.1-alpha for top-level SemanticAttributes (sentry-opentelemetry-bootstrap) -->
         <dependency>
             <groupId>io.opentelemetry</groupId>

--- a/build/pom.xml
+++ b/build/pom.xml
@@ -727,6 +727,15 @@
             <groupId>io.sentry</groupId>
             <artifactId>sentry-opentelemetry-core</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.sentry</groupId>
+            <artifactId>sentry-opentelemetry-bootstrap</artifactId>
+        </dependency>
+        <!-- New semconv (io.opentelemetry.semconv) for UrlAttributes required by Sentry 8.x -->
+        <dependency>
+            <groupId>io.opentelemetry.semconv</groupId>
+            <artifactId>opentelemetry-semconv</artifactId>
+        </dependency>
         <!-- Legacy semconv 1.23.1-alpha for top-level SemanticAttributes (sentry-opentelemetry-bootstrap) -->
         <dependency>
             <groupId>io.opentelemetry</groupId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -185,6 +185,10 @@
             <artifactId>sentry-opentelemetry-core</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.sentry</groupId>
+            <artifactId>sentry-opentelemetry-bootstrap</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.opentelemetry.semconv</groupId>
             <artifactId>opentelemetry-semconv-incubating</artifactId>
         </dependency>


### PR DESCRIPTION
## Summary
- Add missing `sentry-opentelemetry-bootstrap` dependency to `core/pom.xml` and `build/pom.xml` — fixes `NoClassDefFoundError: io/sentry/opentelemetry/SentryWeakSpanStorage`
- Add `io.opentelemetry.semconv:opentelemetry-semconv` (1.37.0) to `build/pom.xml` — fixes `NoClassDefFoundError: io/opentelemetry/semconv/UrlAttributes`

## Root Cause
1. `sentry-opentelemetry-bootstrap` was declared in root `pom.xml` `dependencyManagement` but never added as an actual dependency in any module
2. `build/pom.xml` only included legacy semconv (`io.opentelemetry:opentelemetry-semconv` 1.23.1-alpha) but Sentry 8.x requires the new `io.opentelemetry.semconv:opentelemetry-semconv` (1.37.0) which provides `UrlAttributes`

## Test Plan
- Deploy and verify no more Fatal-level `NoClassDefFoundError` for `SentryWeakSpanStorage` and `UrlAttributes` in Sentry

sync from gitlab !9163