### PR TITLE
<fix>[vm]: add Destroying->Stopped state transition

### DIFF
--- a/header/src/main/java/org/zstack/header/vm/VmInstanceState.java
+++ b/header/src/main/java/org/zstack/header/vm/VmInstanceState.java
@@ -168,6 +168,7 @@ public enum VmInstanceState {
                 new Transaction(VmInstanceStateEvent.destroyed, VmInstanceState.Destroyed),
                 new Transaction(VmInstanceStateEvent.destroying, VmInstanceState.Destroying),
                 new Transaction(VmInstanceStateEvent.running, VmInstanceState.Running),
+                new Transaction(VmInstanceStateEvent.stopped, VmInstanceState.Stopped),
                 new Transaction(VmInstanceStateEvent.expunging, VmInstanceState.Expunging)
         );
         Destroyed.transactions(


### PR DESCRIPTION
## Summary
When MN restarts during a VM destroy operation, the hypervisor may report the VM as Stopped. Without the Destroying→Stopped transition in the state machine, it throws a CloudRuntimeException and the VM stays stuck in Destroying state forever.

Added `stopped → Stopped` transition to `Destroying` state, consistent with how `Stopping`, `Rebooting`, and other intermediate states handle the `stopped` event.

Resolves: ZSTAC-80620

sync from gitlab !9156