### PR TITLE
<fix>[volumebackup]: add backup cancel timeout error code

### DIFF
--- a/utils/src/main/java/org/zstack/utils/clouderrorcode/CloudOperationsErrorCode.java
+++ b/utils/src/main/java/org/zstack/utils/clouderrorcode/CloudOperationsErrorCode.java
@@ -6274,6 +6274,8 @@ public class CloudOperationsErrorCode {
 
     public static final String ORG_ZSTACK_STORAGE_BACKUP_10133 = "ORG_ZSTACK_STORAGE_BACKUP_10133";
 
+    public static final String ORG_ZSTACK_STORAGE_BACKUP_CANCEL_TIMEOUT = "ORG_ZSTACK_STORAGE_BACKUP_CANCEL_TIMEOUT";
+
     public static final String ORG_ZSTACK_COMPUTE_10000 = "ORG_ZSTACK_COMPUTE_10000";
 
     public static final String ORG_ZSTACK_COMPUTE_10001 = "ORG_ZSTACK_COMPUTE_10001";


### PR DESCRIPTION
## Summary

Add `ORG_ZSTACK_STORAGE_BACKUP_CANCEL_TIMEOUT` constant to `CloudOperationsErrorCode` for use by premium volumebackup module.

This is the `@@2` companion MR for premium MR !12975 which adds a backup chain task exit wait mechanism after cancel.

Resolves: ZSTAC-82195
Target: 5.5.12

sync from gitlab !9200