### PR TITLE
<fix>[ai,db]: add error code 10134 + V5.5.12 DB migrations

### DIFF
--- a/conf/db/upgrade/V5.5.12__schema.sql
+++ b/conf/db/upgrade/V5.5.12__schema.sql
@@ -1,0 +1,5 @@
+-- ZSTAC-68709: Add targetQueueKey column for evaluation task queue concurrency control
+CALL ADD_COLUMN('ModelEvaluationTaskVO', 'targetQueueKey', 'VARCHAR(512)', 1, NULL);
+
+-- ZSTAC-70478: Add deleted (soft-delete) column for ModelServiceVO
+CALL ADD_COLUMN('ModelServiceVO', 'deleted', 'tinyint(1)', 0, '0');

--- a/utils/src/main/java/org/zstack/utils/clouderrorcode/CloudOperationsErrorCode.java
+++ b/utils/src/main/java/org/zstack/utils/clouderrorcode/CloudOperationsErrorCode.java
@@ -14804,6 +14804,8 @@ public class CloudOperationsErrorCode {
 
     public static final String ORG_ZSTACK_AI_10133 = "ORG_ZSTACK_AI_10133";
 
+    public static final String ORG_ZSTACK_AI_10134 = "ORG_ZSTACK_AI_10134";
+
     public static final String ORG_ZSTACK_CORE_CLOUDBUS_10000 = "ORG_ZSTACK_CORE_CLOUDBUS_10000";
 
     public static final String ORG_ZSTACK_CORE_CLOUDBUS_10001 = "ORG_ZSTACK_CORE_CLOUDBUS_10001";


### PR DESCRIPTION
## Summary
- Add missing `ORG_ZSTACK_AI_10134` constant (unblocks ZSTAC-80991 GPU validation in premium)
- Create `V5.5.12__schema.sql` with:
  - `ModelEvaluationTaskVO.targetQueueKey` VARCHAR(512) (ZSTAC-68709 eval queue concurrency)
  - `ModelServiceVO.deleted` tinyint(1) soft-delete flag (ZSTAC-70478)

## Test Plan
- Verify `mvn compile -pl utils` passes
- Verify upgrade from 5.5.6 → 5.5.12 applies new columns correctly

Resolves: ZSTAC-80991, ZSTAC-68709, ZSTAC-70478

sync from gitlab !9208