### PR TITLE
<feature>[errorcode]: global error code i18n

### DIFF
--- a/conf/springConfigXml/Error.xml
+++ b/conf/springConfigXml/Error.xml
@@ -13,4 +13,9 @@
     default-init-method="init" default-destroy-method="destroy">
 
     <bean id="ErrorFacade" class="org.zstack.core.errorcode.ErrorFacadeImpl" />
+    <bean id="GlobalErrorCodeI18nService" class="org.zstack.core.errorcode.GlobalErrorCodeI18nServiceImpl">
+        <zstack:plugin>
+            <zstack:extension interface="org.zstack.header.Component"/>
+        </zstack:plugin>
+    </bean>
 </beans>

--- a/core/src/main/java/org/zstack/core/Platform.java
+++ b/core/src/main/java/org/zstack/core/Platform.java
@@ -979,6 +979,11 @@ public class Platform {
         handleErrorElaboration(errCode, fmt, result, cause, args);
         addErrorCounter(result);
         result.setGlobalErrorCode(globalErrorCode);
+        if (args != null && args.length > 0) {
+            result.setFormatArgs(java.util.Arrays.stream(args)
+                    .map(a -> a == null ? "null" : a.toString())
+                    .toArray(String[]::new));
+        }
 
         return result;
     }

--- a/core/src/main/java/org/zstack/core/errorcode/GlobalErrorCodeI18nService.java
+++ b/core/src/main/java/org/zstack/core/errorcode/GlobalErrorCodeI18nService.java
@@ -1,0 +1,29 @@
+package org.zstack.core.errorcode;
+
+import org.zstack.header.errorcode.ErrorCode;
+
+public interface GlobalErrorCodeI18nService {
+    /**
+     * Get localized message for a globalErrorCode.
+     *
+     * @param globalErrorCode the global error code key
+     * @param locale the locale key (e.g. "zh_CN", "ja-JP")
+     * @param formatArgs optional format arguments for %s placeholders
+     * @return the localized message, or null if not found
+     */
+    String getLocalizedMessage(String globalErrorCode, String locale, String[] formatArgs);
+
+    /**
+     * Recursively localize an ErrorCode and its cause chain,
+     * setting the message field on each ErrorCode.
+     *
+     * @param error the ErrorCode to localize
+     * @param locale the locale key
+     */
+    void localizeErrorCode(ErrorCode error, String locale);
+
+    /**
+     * Get the set of available locale keys loaded from JSON files.
+     */
+    java.util.Set<String> getAvailableLocales();
+}

--- a/core/src/main/java/org/zstack/core/errorcode/GlobalErrorCodeI18nServiceImpl.java
+++ b/core/src/main/java/org/zstack/core/errorcode/GlobalErrorCodeI18nServiceImpl.java
@@ -1,0 +1,152 @@
+package org.zstack.core.errorcode;
+
+import org.zstack.header.Component;
+import org.zstack.header.errorcode.ErrorCode;
+import org.zstack.header.errorcode.ErrorCodeList;
+import org.zstack.utils.Utils;
+import org.zstack.utils.gson.JSONObjectUtil;
+import org.zstack.utils.logging.CLogger;
+import org.zstack.utils.path.PathUtil;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class GlobalErrorCodeI18nServiceImpl implements GlobalErrorCodeI18nService, Component {
+    private static final CLogger logger = Utils.getLogger(GlobalErrorCodeI18nServiceImpl.class);
+
+    private static final String I18N_FOLDER = "i18n" + File.separator + "globalErrorCodeMapping";
+    private static final String FILE_PREFIX = "global-error-";
+    private static final String FILE_SUFFIX = ".json";
+
+    // locale -> (globalErrorCode -> template)
+    private final Map<String, Map<String, String>> localeMessages = new ConcurrentHashMap<>();
+
+    @Override
+    public boolean start() {
+        loadAllJsonFiles();
+        return true;
+    }
+
+    @Override
+    public boolean stop() {
+        return true;
+    }
+
+    private void loadAllJsonFiles() {
+        try {
+            List<String> paths = PathUtil.scanFolderOnClassPath(I18N_FOLDER);
+            for (String path : paths) {
+                if (!path.endsWith(FILE_SUFFIX)) {
+                    continue;
+                }
+
+                File file = new File(path);
+                String fileName = file.getName();
+                if (!fileName.startsWith(FILE_PREFIX)) {
+                    continue;
+                }
+
+                String locale = fileName.substring(FILE_PREFIX.length(),
+                        fileName.length() - FILE_SUFFIX.length());
+
+                try {
+                    String content = new String(Files.readAllBytes(file.toPath()), StandardCharsets.UTF_8);
+                    @SuppressWarnings("unchecked")
+                    Map<String, String> messages = JSONObjectUtil.toObject(content, LinkedHashMap.class);
+                    localeMessages.put(locale, messages);
+                    logger.info(String.format("loaded %d i18n error messages for locale [%s]",
+                            messages.size(), locale));
+                } catch (Exception e) {
+                    logger.warn(String.format("failed to load i18n file [%s]: %s", path, e.getMessage()), e);
+                }
+            }
+        } catch (Exception e) {
+            logger.warn(String.format("failed to scan i18n folder: %s", e.getMessage()));
+        }
+
+        logger.info(String.format("GlobalErrorCodeI18nService loaded %d locales: %s",
+                localeMessages.size(), localeMessages.keySet()));
+    }
+
+    @Override
+    public Set<String> getAvailableLocales() {
+        return Collections.unmodifiableSet(localeMessages.keySet());
+    }
+
+    @Override
+    public String getLocalizedMessage(String globalErrorCode, String locale, String[] formatArgs) {
+        if (globalErrorCode == null || locale == null) {
+            return null;
+        }
+
+        String template = getTemplate(globalErrorCode, locale);
+        if (template == null) {
+            return null;
+        }
+
+        return formatTemplate(template, formatArgs);
+    }
+
+    private String getTemplate(String globalErrorCode, String locale) {
+        Map<String, String> messages = localeMessages.get(locale);
+        if (messages != null) {
+            String template = messages.get(globalErrorCode);
+            if (template != null) {
+                return template;
+            }
+        }
+
+        // fallback to en_US
+        if (!"en_US".equals(locale)) {
+            Map<String, String> enMessages = localeMessages.get("en_US");
+            if (enMessages != null) {
+                return enMessages.get(globalErrorCode);
+            }
+        }
+
+        return null;
+    }
+
+    private String formatTemplate(String template, String[] formatArgs) {
+        if (formatArgs == null || formatArgs.length == 0) {
+            return template;
+        }
+
+        try {
+            return String.format(template, (Object[]) formatArgs);
+        } catch (Exception e) {
+            logger.debug(String.format("failed to format i18n template [%s]: %s", template, e.getMessage()));
+            return template;
+        }
+    }
+
+    @Override
+    public void localizeErrorCode(ErrorCode error, String locale) {
+        if (error == null || locale == null) {
+            return;
+        }
+
+        if (error.getGlobalErrorCode() != null) {
+            String message = getLocalizedMessage(error.getGlobalErrorCode(), locale, error.getFormatArgs());
+            if (message != null) {
+                error.setMessage(message);
+            }
+        }
+
+        if (error.getCause() != null) {
+            localizeErrorCode(error.getCause(), locale);
+        }
+
+        if (error instanceof ErrorCodeList) {
+            List<ErrorCode> causes = ((ErrorCodeList) error).getCauses();
+            if (causes != null) {
+                for (ErrorCode cause : causes) {
+                    localizeErrorCode(cause, locale);
+                }
+            }
+        }
+    }
+}

--- a/core/src/main/java/org/zstack/core/errorcode/LocaleUtils.java
+++ b/core/src/main/java/org/zstack/core/errorcode/LocaleUtils.java
@@ -1,0 +1,119 @@
+package org.zstack.core.errorcode;
+
+import org.zstack.utils.Utils;
+import org.zstack.utils.logging.CLogger;
+
+import java.util.*;
+
+public class LocaleUtils {
+    private static final CLogger logger = Utils.getLogger(LocaleUtils.class);
+    public static final String DEFAULT_LOCALE = "en_US";
+
+    private static final Map<String, String> LANGUAGE_TO_LOCALE = new HashMap<>();
+
+    // Languages that use underscore format in locale file names (e.g. zh_CN, en_US)
+    private static final Set<String> UNDERSCORE_LANGS = new HashSet<>(Arrays.asList("zh", "en"));
+
+    static {
+        LANGUAGE_TO_LOCALE.put("zh", "zh_CN");
+        LANGUAGE_TO_LOCALE.put("en", "en_US");
+        LANGUAGE_TO_LOCALE.put("ja", "ja-JP");
+        LANGUAGE_TO_LOCALE.put("ko", "ko-KR");
+        LANGUAGE_TO_LOCALE.put("de", "de-DE");
+        LANGUAGE_TO_LOCALE.put("fr", "fr-FR");
+        LANGUAGE_TO_LOCALE.put("ru", "ru-RU");
+        LANGUAGE_TO_LOCALE.put("th", "th-TH");
+        LANGUAGE_TO_LOCALE.put("id", "id-ID");
+    }
+
+    /**
+     * Parse Accept-Language header and return the best matching locale key
+     * from the set of available locales.
+     *
+     * @param acceptLanguage the Accept-Language header value
+     * @param availableLocales the set of locale keys loaded from JSON files
+     * @return the best matching locale key, or en_US as fallback
+     */
+    public static String resolveLocale(String acceptLanguage, Set<String> availableLocales) {
+        if (acceptLanguage == null || acceptLanguage.trim().isEmpty()) {
+            return DEFAULT_LOCALE;
+        }
+
+        List<LocaleEntry> entries = parseAcceptLanguage(acceptLanguage);
+        for (LocaleEntry entry : entries) {
+            if (entry.quality <= 0) {
+                continue;
+            }
+
+            String normalized = normalizeTag(entry.tag);
+            if (availableLocales.contains(normalized)) {
+                return normalized;
+            }
+
+            String lang = entry.tag.split("[-_]")[0].toLowerCase();
+            String mapped = LANGUAGE_TO_LOCALE.get(lang);
+            if (mapped != null && availableLocales.contains(mapped)) {
+                return mapped;
+            }
+        }
+
+        return DEFAULT_LOCALE;
+    }
+
+    /**
+     * Normalize an HTTP language tag to match file locale keys.
+     * e.g. "zh-CN" -> "zh_CN", "en-US" -> "en_US", "ja-JP" -> "ja-JP"
+     * See UNDERSCORE_LANGS for languages that use underscore format.
+     */
+    static String normalizeTag(String tag) {
+        tag = tag.trim();
+        String[] parts = tag.split("[-_]");
+        if (parts.length == 2) {
+            String lang = parts[0].toLowerCase();
+            String region = parts[1].toUpperCase();
+            if (UNDERSCORE_LANGS.contains(lang)) {
+                return lang + "_" + region;
+            }
+            return lang + "-" + region;
+        }
+        return tag;
+    }
+
+    private static List<LocaleEntry> parseAcceptLanguage(String header) {
+        List<LocaleEntry> entries = new ArrayList<>();
+        String[] parts = header.split(",");
+        for (String part : parts) {
+            part = part.trim();
+            if (part.isEmpty()) {
+                continue;
+            }
+            String[] tagAndParams = part.split(";");
+            String tag = tagAndParams[0].trim();
+            double quality = 1.0;
+            for (int i = 1; i < tagAndParams.length; i++) {
+                String param = tagAndParams[i].trim();
+                if (param.startsWith("q=")) {
+                    try {
+                        quality = Double.parseDouble(param.substring(2).trim());
+                    } catch (NumberFormatException e) {
+                        logger.debug(String.format("failed to parse quality value [%s]: %s", param, e.getMessage()));
+                        quality = 0;
+                    }
+                }
+            }
+            entries.add(new LocaleEntry(tag, quality));
+        }
+        entries.sort((a, b) -> Double.compare(b.quality, a.quality));
+        return entries;
+    }
+
+    private static class LocaleEntry {
+        final String tag;
+        final double quality;
+
+        LocaleEntry(String tag, double quality) {
+            this.tag = tag;
+            this.quality = quality;
+        }
+    }
+}

--- a/core/src/main/java/org/zstack/core/rest/RESTApiController.java
+++ b/core/src/main/java/org/zstack/core/rest/RESTApiController.java
@@ -7,8 +7,13 @@ import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
+import org.zstack.core.errorcode.GlobalErrorCodeI18nService;
+import org.zstack.core.errorcode.LocaleUtils;
 import org.zstack.header.message.APIMessage;
 import org.zstack.header.message.APISyncCallMessage;
+import org.zstack.header.message.APIEvent;
+import org.zstack.header.message.Message;
+import org.zstack.header.message.MessageReply;
 import org.zstack.header.rest.RESTApiFacade;
 import org.zstack.header.rest.RESTConstant;
 import org.zstack.header.rest.RESTFacade;
@@ -30,15 +35,19 @@ public class RESTApiController {
     private RESTApiFacade restApi;
     @Autowired
     private RESTFacade restf;
+    @Autowired
+    private GlobalErrorCodeI18nService i18nService;
 
     @RequestMapping(value = RESTConstant.REST_API_RESULT + "{uuid}", method = {RequestMethod.GET, RequestMethod.PUT})
-    public void queryResult(@PathVariable String uuid, HttpServletResponse rsp) throws IOException {
+    public void queryResult(@PathVariable String uuid, HttpServletRequest req, HttpServletResponse rsp) throws IOException {
         try {
             RestAPIResponse apiRsp = restApi.getResult(uuid);
             if (apiRsp == null) {
                 rsp.sendError(HttpStatus.SC_NOT_FOUND, String.format("No api result[uuid:%s] found", uuid));
                 return;
             }
+            String locale = resolveLocale(req);
+            localizeRestAPIResponse(apiRsp, locale);
             rsp.setCharacterEncoding("UTF-8");
             PrintWriter writer = rsp.getWriter();
             String res = JSONObjectUtil.toJsonString(apiRsp);
@@ -50,7 +59,7 @@ public class RESTApiController {
         }
     }
 
-    private String handleByMessageType(String body, String clientIp, String clientBrowser) {
+    private String handleByMessageType(String body, String clientIp, String clientBrowser, String locale) {
         APIMessage amsg = null;
         try {
             amsg = (APIMessage) RESTApiDecoder.loads(body);
@@ -66,6 +75,7 @@ public class RESTApiController {
         } else {
             rsp = restApi.send(amsg);
         }
+        localizeRestAPIResponse(rsp, locale);
         return JSONObjectUtil.toJsonString(rsp);
     }
 
@@ -74,8 +84,9 @@ public class RESTApiController {
         HttpEntity<String> entity = restf.httpServletRequestToHttpEntity(request);
         String clientIp = HttpServletRequestUtils.getClientIP(request);
         String clientBrowser = HttpServletRequestUtils.getClientBrowser(request);
+        String locale = resolveLocale(request);
         try {
-            String ret = handleByMessageType(entity.getBody(), clientIp, clientBrowser);
+            String ret = handleByMessageType(entity.getBody(), clientIp, clientBrowser, locale);
             response.setStatus(HttpStatus.SC_OK);
             response.setCharacterEncoding("UTF-8");
             PrintWriter writer = response.getWriter();
@@ -87,6 +98,36 @@ public class RESTApiController {
             sb.append(String.format("\nexception message: %s", t.getMessage()));
             logger.debug(sb.toString(), t);
             response.sendError(HttpStatus.SC_INTERNAL_SERVER_ERROR, sb.toString());
+        }
+    }
+
+    private String resolveLocale(HttpServletRequest req) {
+        String acceptLanguage = req.getHeader("Accept-Language");
+        return LocaleUtils.resolveLocale(acceptLanguage, i18nService.getAvailableLocales());
+    }
+
+    private void localizeRestAPIResponse(RestAPIResponse rsp, String locale) {
+        if (rsp == null || rsp.getResult() == null || locale == null) {
+            return;
+        }
+
+        try {
+            Message msg = RESTApiDecoder.loads(rsp.getResult());
+            if (msg instanceof MessageReply) {
+                MessageReply reply = (MessageReply) msg;
+                if (!reply.isSuccess() && reply.getError() != null) {
+                    i18nService.localizeErrorCode(reply.getError(), locale);
+                    rsp.setResult(RESTApiDecoder.dump(reply));
+                }
+            } else if (msg instanceof APIEvent) {
+                APIEvent evt = (APIEvent) msg;
+                if (!evt.isSuccess() && evt.getError() != null) {
+                    i18nService.localizeErrorCode(evt.getError(), locale);
+                    rsp.setResult(RESTApiDecoder.dump(evt));
+                }
+            }
+        } catch (Exception e) {
+            logger.debug(String.format("failed to localize RestAPIResponse: %s", e.getMessage()), e);
         }
     }
 

--- a/header/src/main/java/org/zstack/header/errorcode/ErrorCode.java
+++ b/header/src/main/java/org/zstack/header/errorcode/ErrorCode.java
@@ -24,6 +24,26 @@ public class ErrorCode implements Serializable, Cloneable {
     @NoJsonSchema
     private LinkedHashMap opaque;
     private String globalErrorCode;
+    private String message;
+    @APINoSee
+    @NoJsonSchema
+    private String[] formatArgs;
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+    public String[] getFormatArgs() {
+        return formatArgs == null ? null : formatArgs.clone();
+    }
+
+    public void setFormatArgs(String[] formatArgs) {
+        this.formatArgs = formatArgs == null ? null : formatArgs.clone();
+    }
 
     public String getGlobalErrorCode() {
         return globalErrorCode;
@@ -81,6 +101,9 @@ public class ErrorCode implements Serializable, Cloneable {
         this.messages = other.messages;
         this.cause = other.cause;
         this.location = other.location;
+        this.message = other.message;
+        this.formatArgs = other.formatArgs == null ? null : other.formatArgs.clone();
+        this.globalErrorCode = other.globalErrorCode;
     }
 
     public void setCode(String code) {

--- a/rest/src/main/java/org/zstack/rest/RestServer.java
+++ b/rest/src/main/java/org/zstack/rest/RestServer.java
@@ -31,6 +31,8 @@ import org.zstack.core.cloudbus.CloudBus;
 import org.zstack.core.cloudbus.CloudBusEventListener;
 import org.zstack.core.cloudbus.CloudBusGson;
 import org.zstack.core.componentloader.PluginRegistry;
+import org.zstack.core.errorcode.GlobalErrorCodeI18nService;
+import org.zstack.core.errorcode.LocaleUtils;
 import org.zstack.core.db.Q;
 import org.zstack.core.log.LogSafeGson;
 import org.zstack.core.log.LogUtils;
@@ -148,6 +150,8 @@ public class RestServer implements Component, CloudBusEventListener {
     private RESTFacade restf;
     @Autowired
     private PluginRegistry pluginRgty;
+    @Autowired
+    private GlobalErrorCodeI18nService i18nService;
 
     RateLimiter rateLimiter = new RateLimiter(RestGlobalProperty.REST_RATE_LIMITS);
 
@@ -404,6 +408,8 @@ public class RestServer implements Component, CloudBusEventListener {
 
             writeResponse(response, w, ret.getResult());
         } else {
+            String locale = resolveLocale();
+            i18nService.localizeErrorCode(evt.getError(), locale);
             response.setError(evt.getError());
         }
 
@@ -911,6 +917,8 @@ public class RestServer implements Component, CloudBusEventListener {
             writeResponse(response, w, ret.getResult());
             sendResponse(HttpStatus.OK.value(), response, rsp);
         } else {
+            String locale = resolveLocaleFromRequest(req);
+            i18nService.localizeErrorCode(evt.getError(), locale);
             response.setError(evt.getError());
             sendResponse(HttpStatus.SERVICE_UNAVAILABLE.value(), response, rsp);
         }
@@ -1411,10 +1419,26 @@ public class RestServer implements Component, CloudBusEventListener {
         }
     }
 
+    private String resolveLocale() {
+        RequestInfo info = requestInfo.get();
+        if (info == null) {
+            return LocaleUtils.DEFAULT_LOCALE;
+        }
+        String acceptLanguage = info.headers.getFirst("Accept-Language");
+        return LocaleUtils.resolveLocale(acceptLanguage, i18nService.getAvailableLocales());
+    }
+
+    private String resolveLocaleFromRequest(HttpServletRequest req) {
+        String acceptLanguage = req.getHeader("Accept-Language");
+        return LocaleUtils.resolveLocale(acceptLanguage, i18nService.getAvailableLocales());
+    }
+
     private void sendReplyResponse(MessageReply reply, Api api, HttpServletResponse rsp) throws IOException, IllegalAccessException, NoSuchMethodException, InvocationTargetException {
         ApiResponse response = new ApiResponse();
 
         if (!reply.isSuccess()) {
+            String locale = resolveLocale();
+            i18nService.localizeErrorCode(reply.getError(), locale);
             response.setError(reply.getError());
             sendResponse(HttpStatus.SERVICE_UNAVAILABLE.value(), JSONObjectUtil.toJsonString(response), rsp);
             return;

--- a/sdk/src/main/java/org/zstack/sdk/ErrorCode.java
+++ b/sdk/src/main/java/org/zstack/sdk/ErrorCode.java
@@ -76,4 +76,12 @@ public class ErrorCode  {
         return this.globalErrorCode;
     }
 
+    public java.lang.String message;
+    public void setMessage(java.lang.String message) {
+        this.message = message;
+    }
+    public java.lang.String getMessage() {
+        return this.message;
+    }
+
 }

--- a/test/src/test/groovy/org/zstack/test/integration/rest/ErrorCodeI18nCase.groovy
+++ b/test/src/test/groovy/org/zstack/test/integration/rest/ErrorCodeI18nCase.groovy
@@ -1,0 +1,316 @@
+package org.zstack.test.integration.rest
+
+import org.zstack.core.errorcode.GlobalErrorCodeI18nService
+import org.zstack.header.errorcode.ErrorCode
+import org.zstack.header.errorcode.ErrorCodeList
+import org.zstack.header.errorcode.SysErrors
+import org.zstack.header.zone.APIQueryZoneMsg
+import org.zstack.test.integration.ZStackTest
+import org.zstack.testlib.EnvSpec
+import org.zstack.testlib.SubCase
+import org.zstack.testlib.WebBeanConstructor
+import org.zstack.utils.gson.JSONObjectUtil
+
+class ErrorCodeI18nCase extends SubCase {
+    EnvSpec env
+
+    @Override
+    void clean() {
+        env.delete()
+    }
+
+    @Override
+    void setup() {
+        useSpring(ZStackTest.springSpec)
+    }
+
+    @Override
+    void environment() {
+        env = env {}
+    }
+
+    @Override
+    void test() {
+        env.create {
+            testServiceLocalizesZhCN()
+            testServiceLocalizesEnUS()
+            testServiceFallbackToEnUS()
+            testServiceFormatsArgs()
+            testServiceRecursiveCauseChain()
+            testServiceErrorCodeList()
+            testRestServerSyncApiWithAcceptLanguage()
+            testRestServerAsyncApiWithAcceptLanguage()
+            testNoAcceptLanguageHeaderFallsBackToEnUS()
+        }
+    }
+
+    void testServiceLocalizesZhCN() {
+        GlobalErrorCodeI18nService i18nService = bean(GlobalErrorCodeI18nService.class)
+        // ORG_ZSTACK_STORAGE_PRIMARY_10039: zh_CN = "未找到主存储[uuid:%s]"
+        String msg = i18nService.getLocalizedMessage(
+                "ORG_ZSTACK_STORAGE_PRIMARY_10039", "zh_CN", ["test-uuid-123"] as String[])
+        assert msg != null
+        assert msg.contains("未找到主存储")
+        assert msg.contains("test-uuid-123")
+    }
+
+    void testServiceLocalizesEnUS() {
+        GlobalErrorCodeI18nService i18nService = bean(GlobalErrorCodeI18nService.class)
+        // ORG_ZSTACK_STORAGE_PRIMARY_10039: en_US = "no primary storage[uuid:%s] exists"
+        String msg = i18nService.getLocalizedMessage(
+                "ORG_ZSTACK_STORAGE_PRIMARY_10039", "en_US", ["test-uuid-456"] as String[])
+        assert msg != null
+        assert msg.contains("no primary storage")
+        assert msg.contains("test-uuid-456")
+    }
+
+    void testServiceFallbackToEnUS() {
+        GlobalErrorCodeI18nService i18nService = bean(GlobalErrorCodeI18nService.class)
+        // Request a locale that doesn't exist, should fallback to en_US
+        String msg = i18nService.getLocalizedMessage(
+                "ORG_ZSTACK_STORAGE_PRIMARY_10039", "nonexistent_locale", ["uuid-789"] as String[])
+        assert msg != null
+        assert msg.contains("no primary storage")
+    }
+
+    void testServiceFormatsArgs() {
+        GlobalErrorCodeI18nService i18nService = bean(GlobalErrorCodeI18nService.class)
+        // Test with null formatArgs - should return template as-is
+        String msg = i18nService.getLocalizedMessage(
+                "ORG_ZSTACK_STORAGE_PRIMARY_10039", "zh_CN", null)
+        assert msg != null
+        assert msg.contains("%s")  // template not formatted
+    }
+
+    void testServiceRecursiveCauseChain() {
+        GlobalErrorCodeI18nService i18nService = bean(GlobalErrorCodeI18nService.class)
+
+        ErrorCode cause = new ErrorCode()
+        cause.setCode(SysErrors.INTERNAL.toString())
+        cause.setGlobalErrorCode("ORG_ZSTACK_STORAGE_PRIMARY_10039")
+        cause.setFormatArgs(["inner-uuid"] as String[])
+
+        ErrorCode outer = new ErrorCode()
+        outer.setCode(SysErrors.INTERNAL.toString())
+        outer.setGlobalErrorCode("ORG_ZSTACK_STORAGE_PRIMARY_10039")
+        outer.setFormatArgs(["outer-uuid"] as String[])
+        outer.setCause(cause)
+
+        i18nService.localizeErrorCode(outer, "zh_CN")
+
+        assert outer.getMessage() != null
+        assert outer.getMessage().contains("outer-uuid")
+        assert outer.getCause().getMessage() != null
+        assert outer.getCause().getMessage().contains("inner-uuid")
+    }
+
+    void testServiceErrorCodeList() {
+        GlobalErrorCodeI18nService i18nService = bean(GlobalErrorCodeI18nService.class)
+
+        ErrorCodeList errorList = new ErrorCodeList()
+        errorList.setCode(SysErrors.INTERNAL.toString())
+        errorList.setGlobalErrorCode("ORG_ZSTACK_STORAGE_PRIMARY_10039")
+        errorList.setFormatArgs(["list-uuid"] as String[])
+
+        ErrorCode child1 = new ErrorCode()
+        child1.setCode(SysErrors.INTERNAL.toString())
+        child1.setGlobalErrorCode("ORG_ZSTACK_STORAGE_PRIMARY_10039")
+        child1.setFormatArgs(["child1-uuid"] as String[])
+
+        ErrorCode child2 = new ErrorCode()
+        child2.setCode(SysErrors.INTERNAL.toString())
+        child2.setGlobalErrorCode("ORG_ZSTACK_STORAGE_PRIMARY_10039")
+        child2.setFormatArgs(["child2-uuid"] as String[])
+
+        errorList.setCauses([child1, child2])
+
+        i18nService.localizeErrorCode(errorList, "zh_CN")
+
+        assert errorList.getMessage().contains("list-uuid")
+        assert errorList.getCauses()[0].getMessage().contains("child1-uuid")
+        assert errorList.getCauses()[1].getMessage().contains("child2-uuid")
+    }
+
+    void testRestServerSyncApiWithAcceptLanguage() {
+        // Intercept APIQueryZoneMsg and return error with known globalErrorCode
+        ErrorCode mockError = new ErrorCode()
+        mockError.setCode(SysErrors.INTERNAL.toString())
+        mockError.setDetails("no primary storage[uuid:test-sync-uuid] exists")
+        mockError.setGlobalErrorCode("ORG_ZSTACK_STORAGE_PRIMARY_10039")
+        mockError.setFormatArgs(["test-sync-uuid"] as String[])
+
+        env.message(APIQueryZoneMsg.class) { APIQueryZoneMsg msg, bus ->
+            bus.replyErrorByMessageType(msg, mockError)
+        }
+
+        try {
+            // Make raw HTTP GET to /v1/zones with Accept-Language: zh-CN
+            String sessionId = adminSession()
+            String url = "http://127.0.0.1:${WebBeanConstructor.port}/v1/zones"
+            HttpURLConnection conn = (HttpURLConnection) new URL(url).openConnection()
+            try {
+                conn.setRequestMethod("GET")
+                conn.setRequestProperty("Authorization", "OAuth ${sessionId}")
+                conn.setRequestProperty("Accept-Language", "zh-CN")
+
+                int responseCode = conn.getResponseCode()
+                String responseBody
+                if (responseCode >= 400) {
+                    responseBody = conn.getErrorStream()?.text ?: ""
+                } else {
+                    responseBody = conn.getInputStream()?.text ?: ""
+                }
+
+                assert responseCode == 503  // SERVICE_UNAVAILABLE for error responses
+                Map response = JSONObjectUtil.toObject(responseBody, LinkedHashMap.class)
+                Map error = response.get("error") as Map
+                assert error != null
+                assert error.get("message") != null
+                String message = error.get("message") as String
+                assert message.contains("未找到主存储")
+                assert message.contains("test-sync-uuid")
+            } finally {
+                conn.disconnect()
+            }
+        } finally {
+            env.cleanMessageHandlers()
+        }
+    }
+
+    void testRestServerAsyncApiWithAcceptLanguage() {
+        // Use an async API (create zone) and intercept to return error
+        ErrorCode asyncError = new ErrorCode()
+        asyncError.setCode(SysErrors.INTERNAL.toString())
+        asyncError.setDetails("no primary storage[uuid:test-async-uuid] exists")
+        asyncError.setGlobalErrorCode("ORG_ZSTACK_STORAGE_PRIMARY_10039")
+        asyncError.setFormatArgs(["test-async-uuid"] as String[])
+
+        env.message(org.zstack.header.zone.APICreateZoneMsg.class) { msg, bus ->
+            bus.replyErrorByMessageType(msg, asyncError)
+        }
+
+        try {
+            // POST to create zone
+            String sessionId = adminSession()
+            String postUrl = "http://127.0.0.1:${WebBeanConstructor.port}/v1/zones"
+            String body = '{"params":{"name":"test-i18n-zone","description":"test"}}'
+
+            HttpURLConnection postConn = (HttpURLConnection) new URL(postUrl).openConnection()
+            try {
+                postConn.setRequestMethod("POST")
+                postConn.setRequestProperty("Authorization", "OAuth ${sessionId}")
+                postConn.setRequestProperty("Accept-Language", "zh-CN")
+                postConn.setRequestProperty("Content-Type", "application/json")
+                postConn.setDoOutput(true)
+                postConn.getOutputStream().write(body.getBytes("UTF-8"))
+
+                int postCode = postConn.getResponseCode()
+                String postBody
+                if (postCode >= 400) {
+                    postBody = postConn.getErrorStream()?.text ?: ""
+                } else {
+                    postBody = postConn.getInputStream()?.text ?: ""
+                }
+
+                // Async API returns 202 with location header for job polling
+                if (postCode == 202) {
+                    Map postResponse = JSONObjectUtil.toObject(postBody, LinkedHashMap.class)
+                    String location = postResponse.get("location") as String
+                    assert location != null
+
+                    // Poll the job with Accept-Language header
+                    retryInSecs(5) {
+                        String jobUrl = location.startsWith("http") ? location : "http://127.0.0.1:${WebBeanConstructor.port}${location}"
+                        HttpURLConnection jobConn = (HttpURLConnection) new URL(jobUrl).openConnection()
+                        try {
+                            jobConn.setRequestMethod("GET")
+                            jobConn.setRequestProperty("Authorization", "OAuth ${sessionId}")
+                            jobConn.setRequestProperty("Accept-Language", "zh-CN")
+
+                            int jobCode = jobConn.getResponseCode()
+                            String jobBody
+                            if (jobCode >= 400) {
+                                jobBody = jobConn.getErrorStream()?.text ?: ""
+                            } else {
+                                jobBody = jobConn.getInputStream()?.text ?: ""
+                            }
+
+                            // Job should be done (503 for error)
+                            assert jobCode == 503
+                            Map jobResponse = JSONObjectUtil.toObject(jobBody, LinkedHashMap.class)
+                            Map jobError = jobResponse.get("error") as Map
+                            assert jobError != null
+                            String jobMessage = jobError.get("message") as String
+                            assert jobMessage != null
+                            assert jobMessage.contains("未找到主存储")
+                            assert jobMessage.contains("test-async-uuid")
+                        } finally {
+                            jobConn.disconnect()
+                        }
+                    }
+                } else {
+                    // If returned directly (e.g. 503), check the error
+                    assert postCode == 503
+                    Map directResponse = JSONObjectUtil.toObject(postBody, LinkedHashMap.class)
+                    Map directError = directResponse.get("error") as Map
+                    assert directError != null
+                    String directMessage = directError.get("message") as String
+                    assert directMessage != null
+                    assert directMessage.contains("未找到主存储")
+                }
+            } finally {
+                postConn.disconnect()
+            }
+        } finally {
+            env.cleanMessageHandlers()
+        }
+    }
+
+    void testNoAcceptLanguageHeaderFallsBackToEnUS() {
+        // Intercept APIQueryZoneMsg and return error with known globalErrorCode
+        ErrorCode mockError = new ErrorCode()
+        mockError.setCode(SysErrors.INTERNAL.toString())
+        mockError.setDetails("no primary storage[uuid:test-no-lang] exists")
+        mockError.setGlobalErrorCode("ORG_ZSTACK_STORAGE_PRIMARY_10039")
+        mockError.setFormatArgs(["test-no-lang"] as String[])
+
+        env.message(APIQueryZoneMsg.class) { APIQueryZoneMsg msg, bus ->
+            bus.replyErrorByMessageType(msg, mockError)
+        }
+
+        try {
+            // Make raw HTTP GET without Accept-Language header
+            String sessionId = adminSession()
+            String url = "http://127.0.0.1:${WebBeanConstructor.port}/v1/zones"
+            HttpURLConnection conn = (HttpURLConnection) new URL(url).openConnection()
+            try {
+                conn.setRequestMethod("GET")
+                conn.setRequestProperty("Authorization", "OAuth ${sessionId}")
+                // No Accept-Language header
+
+                int responseCode = conn.getResponseCode()
+                String responseBody
+                if (responseCode >= 400) {
+                    responseBody = conn.getErrorStream()?.text ?: ""
+                } else {
+                    responseBody = conn.getInputStream()?.text ?: ""
+                }
+
+                assert responseCode == 503
+                Map response = JSONObjectUtil.toObject(responseBody, LinkedHashMap.class)
+                Map error = response.get("error") as Map
+                assert error != null
+                // Without Accept-Language, resolveLocale defaults to en_US
+                // So message should be the en_US version
+                String message = error.get("message") as String
+                assert message != null
+                assert message.contains("no primary storage")
+                assert message.contains("test-no-lang")
+            } finally {
+                conn.disconnect()
+            }
+        } finally {
+            env.cleanMessageHandlers()
+        }
+    }
+}

--- a/test/src/test/java/org/zstack/test/core/errorcode/TestGlobalErrorCodeI18n.java
+++ b/test/src/test/java/org/zstack/test/core/errorcode/TestGlobalErrorCodeI18n.java
@@ -1,0 +1,135 @@
+package org.zstack.test.core.errorcode;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.zstack.core.componentloader.ComponentLoader;
+import org.zstack.core.errorcode.GlobalErrorCodeI18nService;
+import org.zstack.header.errorcode.ErrorCode;
+import org.zstack.header.errorcode.ErrorCodeList;
+import org.zstack.test.BeanConstructor;
+import org.zstack.utils.Utils;
+import org.zstack.utils.logging.CLogger;
+
+import java.util.Arrays;
+
+public class TestGlobalErrorCodeI18n {
+    CLogger logger = Utils.getLogger(TestGlobalErrorCodeI18n.class);
+    ComponentLoader loader;
+    GlobalErrorCodeI18nService i18nService;
+
+    @Before
+    public void setUp() throws Exception {
+        BeanConstructor con = new BeanConstructor();
+        loader = con.build();
+        i18nService = loader.getComponent(GlobalErrorCodeI18nService.class);
+    }
+
+    @Test
+    public void testLoadJsonFiles() {
+        Assert.assertTrue("should load at least 2 locales",
+                i18nService.getAvailableLocales().size() >= 2);
+        logger.debug(String.format("loaded locales: %s", i18nService.getAvailableLocales()));
+    }
+
+    @Test
+    public void testZhCNMatch() {
+        String msg = i18nService.getLocalizedMessage(
+                "ORG_ZSTACK_STORAGE_PRIMARY_10039", "zh_CN", new String[]{"abc123"});
+        Assert.assertNotNull(msg);
+        Assert.assertTrue("should contain Chinese text", msg.contains("abc123"));
+        logger.debug(String.format("zh_CN message: %s", msg));
+    }
+
+    @Test
+    public void testEnUSMatch() {
+        String msg = i18nService.getLocalizedMessage(
+                "ORG_ZSTACK_STORAGE_PRIMARY_10039", "en_US", new String[]{"abc123"});
+        Assert.assertNotNull(msg);
+        Assert.assertTrue("should contain English text", msg.contains("abc123"));
+        logger.debug(String.format("en_US message: %s", msg));
+    }
+
+    @Test
+    public void testFallbackToEnUS() {
+        String msg = i18nService.getLocalizedMessage(
+                "ORG_ZSTACK_STORAGE_PRIMARY_10039", "pt_BR", new String[]{"abc123"});
+        Assert.assertNotNull("should fallback to en_US", msg);
+        logger.debug(String.format("fallback message: %s", msg));
+    }
+
+    @Test
+    public void testNonExistentGlobalErrorCode() {
+        String msg = i18nService.getLocalizedMessage(
+                "NOT_EXIST_CODE", "zh_CN", null);
+        Assert.assertNull("should return null for non-existent code", msg);
+    }
+
+    @Test
+    public void testFormatArgsNull() {
+        String msg = i18nService.getLocalizedMessage(
+                "ORG_ZSTACK_STORAGE_PRIMARY_10039", "zh_CN", null);
+        Assert.assertNotNull(msg);
+        // template contains %s but args is null, should return raw template
+        Assert.assertTrue("should contain %s placeholder", msg.contains("%s"));
+    }
+
+    @Test
+    public void testFormatArgsMismatch() {
+        // template has 1 %s but we pass 3 args - should not crash
+        String msg = i18nService.getLocalizedMessage(
+                "ORG_ZSTACK_STORAGE_PRIMARY_10039", "zh_CN",
+                new String[]{"arg1", "arg2", "arg3"});
+        Assert.assertNotNull(msg);
+    }
+
+    @Test
+    public void testLocalizeErrorCodeWithCause() {
+        ErrorCode cause = new ErrorCode();
+        cause.setGlobalErrorCode("ORG_ZSTACK_STORAGE_PRIMARY_10039");
+        cause.setFormatArgs(new String[]{"inner-uuid"});
+
+        ErrorCode error = new ErrorCode();
+        error.setGlobalErrorCode("ORG_ZSTACK_STORAGE_PRIMARY_10039");
+        error.setFormatArgs(new String[]{"outer-uuid"});
+        error.setCause(cause);
+
+        i18nService.localizeErrorCode(error, "zh_CN");
+
+        Assert.assertNotNull("error.message should be set", error.getMessage());
+        Assert.assertNotNull("cause.message should be set", cause.getMessage());
+        Assert.assertTrue(error.getMessage().contains("outer-uuid"));
+        Assert.assertTrue(cause.getMessage().contains("inner-uuid"));
+    }
+
+    @Test
+    public void testLocalizeErrorCodeList() {
+        ErrorCodeList errorList = new ErrorCodeList();
+        errorList.setCode("SYS.1000");
+
+        ErrorCode cause1 = new ErrorCode();
+        cause1.setGlobalErrorCode("ORG_ZSTACK_STORAGE_PRIMARY_10039");
+        cause1.setFormatArgs(new String[]{"uuid1"});
+
+        ErrorCode cause2 = new ErrorCode();
+        cause2.setGlobalErrorCode("ORG_ZSTACK_STORAGE_PRIMARY_10039");
+        cause2.setFormatArgs(new String[]{"uuid2"});
+
+        errorList.setCauses(Arrays.asList(cause1, cause2));
+
+        i18nService.localizeErrorCode(errorList, "zh_CN");
+
+        Assert.assertNotNull("cause1.message should be set", cause1.getMessage());
+        Assert.assertNotNull("cause2.message should be set", cause2.getMessage());
+        Assert.assertTrue(cause1.getMessage().contains("uuid1"));
+        Assert.assertTrue(cause2.getMessage().contains("uuid2"));
+    }
+
+    @Test
+    public void testNoGlobalErrorCode() {
+        ErrorCode error = new ErrorCode("SYS.1000", "test error");
+        // no globalErrorCode set
+        i18nService.localizeErrorCode(error, "zh_CN");
+        Assert.assertNull("message should remain null", error.getMessage());
+    }
+}

--- a/test/src/test/java/org/zstack/test/core/errorcode/TestLocaleUtils.java
+++ b/test/src/test/java/org/zstack/test/core/errorcode/TestLocaleUtils.java
@@ -1,0 +1,67 @@
+package org.zstack.test.core.errorcode;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.zstack.core.errorcode.LocaleUtils;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public class TestLocaleUtils {
+    private static final Set<String> AVAILABLE_LOCALES = new HashSet<>();
+
+    static {
+        AVAILABLE_LOCALES.add("zh_CN");
+        AVAILABLE_LOCALES.add("en_US");
+        AVAILABLE_LOCALES.add("ja-JP");
+        AVAILABLE_LOCALES.add("ko-KR");
+        AVAILABLE_LOCALES.add("de-DE");
+        AVAILABLE_LOCALES.add("fr-FR");
+        AVAILABLE_LOCALES.add("ru-RU");
+        AVAILABLE_LOCALES.add("th-TH");
+        AVAILABLE_LOCALES.add("id-ID");
+        AVAILABLE_LOCALES.add("zh_TW");
+    }
+
+    @Test
+    public void testSimpleLocale() {
+        String result = LocaleUtils.resolveLocale("zh-CN", AVAILABLE_LOCALES);
+        Assert.assertEquals("zh_CN", result);
+    }
+
+    @Test
+    public void testMultiLocaleWithQuality() {
+        String result = LocaleUtils.resolveLocale("ja-JP,zh-CN;q=0.9,en;q=0.8", AVAILABLE_LOCALES);
+        Assert.assertEquals("ja-JP", result);
+    }
+
+    @Test
+    public void testLanguageCodeOnly() {
+        String result = LocaleUtils.resolveLocale("zh", AVAILABLE_LOCALES);
+        Assert.assertEquals("zh_CN", result);
+    }
+
+    @Test
+    public void testUnsupportedLocale() {
+        String result = LocaleUtils.resolveLocale("pt-BR", AVAILABLE_LOCALES);
+        Assert.assertEquals("en_US", result);
+    }
+
+    @Test
+    public void testNullAndEmpty() {
+        Assert.assertEquals("en_US", LocaleUtils.resolveLocale(null, AVAILABLE_LOCALES));
+        Assert.assertEquals("en_US", LocaleUtils.resolveLocale("", AVAILABLE_LOCALES));
+    }
+
+    @Test
+    public void testEnUS() {
+        String result = LocaleUtils.resolveLocale("en-US", AVAILABLE_LOCALES);
+        Assert.assertEquals("en_US", result);
+    }
+
+    @Test
+    public void testUnderscoreFormat() {
+        String result = LocaleUtils.resolveLocale("zh_CN", AVAILABLE_LOCALES);
+        Assert.assertEquals("zh_CN", result);
+    }
+}


### PR DESCRIPTION
Add global error code internationalization support that translates
  ErrorCode messages based on the client's Accept-Language header.

  Core changes:
  - Add GlobalErrorCodeI18nService interface and implementation that
    loads locale-specific JSON templates from classpath at startup
  - Add LocaleUtils to parse Accept-Language headers and resolve the
    best matching locale with quality-based priority
  - Extend ErrorCode with message and formatArgs fields to carry
    localized text and format parameters
  - Wire Platform.err to populate formatArgs when args are present

  REST integration:
  - RESTApiController: localize ErrorCode for both MessageReply and
    APIEvent responses, resolve locale from Accept-Language header
  - RestServer: localize error responses using LocaleUtils, use
    LocaleUtils.DEFAULT_LOCALE constant instead of hardcoded string

  Robustness:
  - Filter Accept-Language entries with quality <= 0
  - Defensive copy of formatArgs in ErrorCode getter/setter/copy-ctor
  - try-finally for HttpURLConnection in integration tests
  - Log exception stacktrace in localization failure catch block

  Tests:
  - Unit tests for LocaleUtils, GlobalErrorCodeI18nService
  - Integration test ErrorCodeI18nCase covering sync/async API and
    Accept-Language fallback behavior

 Resolves: ZSTAC-81675

Change-Id: I706d6d6b6f687662656e6576736d73676c7a6e6a

sync from gitlab !9251