### PR TITLE
<fix>[conf]: translate the error message when reconnecting hosts after modifying host password

### DIFF
--- a/conf/i18n/messages_zh_CN.properties
+++ b/conf/i18n/messages_zh_CN.properties
@@ -1914,7 +1914,7 @@ unable\ to\ connect\ to\ kvm\ host[uuid\:%s,\ ip\:%s,\ url\:%s],\ because\ %s = 
 host\ can\ not\ access\ any\ primary\ storage = 主机无法访问任何数据存储
 connection\ error\ for\ KVM\ host[uuid\:%s,\ ip\:%s] = 连接主机 {0} [ip:{1}] 失败
 the\ host[%s]\ ssh\ port[%s]\ not\ open\ after\ %s\ seconds,\ connect\ timeout = 主机[{0}]SSH端口[{1}]在{2}秒后未打开，连接超时
-host\ password\ has\ been\ changed.\ Please\ update\ host\ password\ in\ management\ node\ by\ UpdateKVMHostAction\ with\ host\ UUID[%s] = 
+host\ password\ has\ been\ changed.\ Please\ update\ host\ password\ in\ management\ node\ by\ UpdateKVMHostAction\ with\ host\ UUID[%s] = 主机[UUID:{0}]的密码已被修改，请通过 UpdateKVMHostAction 在管理节点更新主机密码
 failed\ to\ connect\ host[UUID\=%s]\ with\ SSH\ password = 
 failed\ to\ connect\ host[UUID\=%s]\ with\ private\ key = 
 unable\ to\ connect\ to\ KVM[ip\:%s,\ username\:%s,\ sshPort\:\ %d,\ ]\ to\ do\ DNS\ check,\ please\ check\ if\ username/password\ is\ wrong;\ %s = 无法连接主机[ip:{0}, 用户名:{1}, ssh端口:{2} ]做DNS检查，请检查用户名密码是否正确；{3}


### PR DESCRIPTION
Problem:
when the locale is set as zh_CN, if the password of the host has been
changed, the zsv reconnects the host and complain the error in English.
Actually, it should report the error using chinese.

Solution:
Add the chinese version of the error to the messages_zh_CN.properties file.

Resolves: ZSV-8182

Change-Id: I756965616171666272646d6465666e6e71706467

sync from gitlab !9260