### PR TITLE
<test>[vm]: add test globalconfig for pre-push checker validation

### DIFF
--- a/compute/src/main/java/org/zstack/compute/vm/VmGlobalConfig.java
+++ b/compute/src/main/java/org/zstack/compute/vm/VmGlobalConfig.java
@@ -137,4 +137,8 @@ public class VmGlobalConfig {
     @GlobalConfigValidation(validValues = {"true", "false", "auto"})
     @GlobalConfigDef(defaultValue = "false", type = String.class, description = "generate config required for vhost primary storage")
     public static GlobalConfig GENERATE_CONFIG_VHOST_REQUIRED = new GlobalConfig(CATEGORY, "generate.config.vhost.required");
+
+    @GlobalConfigValidation(validValues = {"true", "false"})
+    @GlobalConfigDef(defaultValue = "false", type = Boolean.class, description = "enable pre-push obligation checker for vm operations")
+    public static GlobalConfig PRE_PUSH_CHECKER_TEST = new GlobalConfig(CATEGORY, "prePushChecker.test");
 }


### PR DESCRIPTION
## 目的

验证 pre-push obligation checker 工具的跨仓库 fix 能力。

## 改动

### zstack
- `VmGlobalConfig.java`: 新增一个测试用 GlobalConfig 字段 `prePushChecker.test`

### premium
- `doc/globalconfig/vm/prePushChecker.test.md`: 由 pre-push-checker fixer 自动生成的 markdown 文档

## 验证方式

1. checker 检测到 VmGlobalConfig 新字段缺少 markdown → ERROR
2. fixer 自动生成符合 CI 格式的 markdown stub
3. checker 再次运行 → PASS
4. 提交跨仓库 @@2 分支，CI 编译验证

Resolves: ZSTAC-82099

sync from gitlab !9271