### PR TITLE
fix(vm): handle NoState in abnormal lifecycle + Expunging safety net [ZSTAC-80898]

### DIFF
--- a/compute/src/main/java/org/zstack/compute/vm/VmInstanceBase.java
+++ b/compute/src/main/java/org/zstack/compute/vm/VmInstanceBase.java
@@ -1603,6 +1603,11 @@ public class VmInstanceBase extends AbstractVmInstance {
                     changeVmStateInDb(VmInstanceStateEvent.paused, () -> self.setHostUuid(currentHostUuid));
                 } else if (currentState == VmInstanceState.Stopped) {
                     changeVmStateInDb(VmInstanceStateEvent.stopped);
+                } else if (currentState == VmInstanceState.NoState) {
+                    // ZSTAC-80898: When host reports NoState (e.g. QEMU crashed, libvirtd restarted),
+                    // update DB to reflect actual state. Without this, VMs in intermediate states
+                    // (Migrating, Starting, etc.) remain stuck in DB forever.
+                    changeVmStateInDb(VmInstanceStateEvent.noState, () -> self.setHostUuid(currentHostUuid));
                 }
 
                 fireEvent.run();

--- a/header/src/main/java/org/zstack/header/vm/VmInstanceState.java
+++ b/header/src/main/java/org/zstack/header/vm/VmInstanceState.java
@@ -171,6 +171,13 @@ public enum VmInstanceState {
                 new Transaction(VmInstanceStateEvent.stopped, VmInstanceState.Stopped),
                 new Transaction(VmInstanceStateEvent.expunging, VmInstanceState.Expunging)
         );
+        // ZSTAC-80898: Expunging safety net — if expunge fails, allow recovery
+        // instead of leaving VM permanently stuck.
+        Expunging.transactions(
+                new Transaction(VmInstanceStateEvent.destroyed, VmInstanceState.Destroyed),
+                new Transaction(VmInstanceStateEvent.stopped, VmInstanceState.Stopped),
+                new Transaction(VmInstanceStateEvent.unknown, VmInstanceState.Unknown)
+        );
         Destroyed.transactions(
                 new Transaction(VmInstanceStateEvent.stopped, VmInstanceState.Stopped)
         );


### PR DESCRIPTION
## Problem

Two state machine gaps cause VMs to get permanently stuck:

### Gap 1: NoState not handled in abnormal lifecycle done handler
When host reports NoState for a VM in an intermediate state (Migrating, Starting, Stopping, etc.), `VmInstanceBase.java:1600-1606` only updates DB for Running/Paused/Stopped. NoState is silently skipped, leaving the VM permanently stuck in the intermediate state in DB.

Root cause of ZSTAC-80898 (VM enters NoState) and contributes to many "VM stuck in intermediate state" reports.

### Gap 2: Expunging has no outgoing transitions
`VmInstanceState.Expunging` has zero transactions defined. If the expunge operation fails, the VM is trapped in Expunging state with no recovery path.

## Solution

**Fix 1** (`VmInstanceBase.java`): Add `NoState` branch to the abnormal lifecycle done handler:
```java
} else if (currentState == VmInstanceState.NoState) {
    changeVmStateInDb(VmInstanceStateEvent.noState, () -> self.setHostUuid(currentHostUuid));
}
```

**Fix 2** (`VmInstanceState.java`): Add safety-net transitions for Expunging:
```java
Expunging.transactions(
    new Transaction(VmInstanceStateEvent.destroyed, VmInstanceState.Destroyed),
    new Transaction(VmInstanceStateEvent.stopped, VmInstanceState.Stopped),
    new Transaction(VmInstanceStateEvent.unknown, VmInstanceState.Unknown)
);
```

## Testing
- VM in Migrating state + host reports NoState -> DB should update to NoState (not stuck in Migrating)
- VM in Starting state + QEMU crash -> DB should update to NoState
- Failed expunge -> VM should be recoverable (not permanently stuck)
- Normal lifecycle operations should not be affected

sync from gitlab !9275