### PR TITLE
<fix>[compute]: validate hostname uniqueness on L3 network to prevent duplicate hostnames (ZSTAC-54307)

### DIFF
--- a/compute/src/main/java/org/zstack/compute/vm/VmInstanceManagerImpl.java
+++ b/compute/src/main/java/org/zstack/compute/vm/VmInstanceManagerImpl.java
@@ -1750,22 +1750,31 @@ public class VmInstanceManagerImpl extends AbstractService implements
                         String hostname = VmSystemTags.HOSTNAME.getTokenByTag(sysTag, VmSystemTags.HOSTNAME_TOKEN);
 
                         validateHostname(sysTag, hostname);
+
+                        String l3Uuid = msg.getDefaultL3NetworkUuid();
+                        if (l3Uuid != null) {
+                            validateHostNameOnDefaultL3Network(sysTag, hostname, l3Uuid);
+                        }
                     }
                 }
             }
 
-            @Transactional(readOnly = true)
             private List<SystemTagVO> querySystemTagsByL3(String tag, String l3Uuid) {
-                String sql = "select t" +
-                        " from SystemTagVO t, VmInstanceVO vm, VmNicVO nic" +
-                        " where t.resourceUuid = vm.uuid" +
-                        " and vm.uuid = nic.vmInstanceUuid" +
-                        " and nic.l3NetworkUuid = :l3Uuid" +
-                        " and t.tag = :sysTag";
-                TypedQuery<SystemTagVO> q = dbf.getEntityManager().createQuery(sql, SystemTagVO.class);
-                q.setParameter("l3Uuid", l3Uuid);
-                q.setParameter("sysTag", tag);
-                return q.getResultList();
+                return new SQLBatchWithReturn<List<SystemTagVO>>() {
+                    @Override
+                    protected List<SystemTagVO> scripts() {
+                        String sql = "select t" +
+                                " from SystemTagVO t, VmInstanceVO vm, VmNicVO nic" +
+                                " where t.resourceUuid = vm.uuid" +
+                                " and vm.uuid = nic.vmInstanceUuid" +
+                                " and nic.l3NetworkUuid = :l3Uuid" +
+                                " and t.tag = :sysTag";
+                        TypedQuery<SystemTagVO> q = dbf.getEntityManager().createQuery(sql, SystemTagVO.class);
+                        q.setParameter("l3Uuid", l3Uuid);
+                        q.setParameter("sysTag", tag);
+                        return q.getResultList();
+                    }
+                }.execute();
             }
 
             private void validateHostNameOnDefaultL3Network(String tag, String hostname, String l3Uuid) {
@@ -1789,6 +1798,9 @@ public class VmInstanceManagerImpl extends AbstractService implements
                     q.select(VmInstanceVO_.defaultL3NetworkUuid);
                     q.add(VmInstanceVO_.uuid, Op.EQ, resourceUuid);
                     String defaultL3Uuid = q.findValue();
+                    if (defaultL3Uuid != null) {
+                        validateHostNameOnDefaultL3Network(systemTag, hostname, defaultL3Uuid);
+                    }
                 } else if (VmSystemTags.BOOT_ORDER.isMatch(systemTag)) {
                     validateBootOrder(systemTag);
                 }


### PR DESCRIPTION
## Problem\n\nConcurrent VM creation with the same hostname on the same L3 network could result in duplicate hostnames. The `validateSystemTag` method fetched `defaultL3Uuid` but never called `validateHostNameOnDefaultL3Network`, making the uniqueness check a no-op. Additionally, `validateSystemTagInCreateMessage` only validated hostname format without checking L3 uniqueness.\n\n## Fix\n\n1. In `validateSystemTag`: call `validateHostNameOnDefaultL3Network(systemTag, hostname, defaultL3Uuid)` with the already-fetched L3 UUID.\n2. In `validateSystemTagInCreateMessage`: add L3 hostname uniqueness check using `msg.getDefaultL3NetworkUuid()`.\n\nFixes ZSTAC-54307

sync from gitlab !9285