### PR TITLE
<fix>[db]: change VARCHAR(4096) to MEDIUMTEXT in beforeMigrate.sql to fix 5.5.12 upgrade failure

### DIFF
--- a/conf/db/upgrade/beforeMigrate.sql
+++ b/conf/db/upgrade/beforeMigrate.sql
@@ -5,12 +5,12 @@ DELIMITER $$
 DROP FUNCTION IF EXISTS `Json_getKeyValue` $$
 
 CREATE FUNCTION `Json_getKeyValue`(
-    in_JsonArray VARCHAR(4096),
+    in_JsonArray MEDIUMTEXT,
     in_KeyName VARCHAR(64)
-) RETURNS VARCHAR(4096) CHARSET utf8
+) RETURNS MEDIUMTEXT CHARSET utf8
 
 BEGIN
-    DECLARE vs_return, vs_JsonArray, vs_JsonString, vs_Json, vs_KeyName VARCHAR(4096);
+    DECLARE vs_return, vs_JsonArray, vs_JsonString, vs_Json, vs_KeyName MEDIUMTEXT;
     DECLARE vi_pos1, vi_pos2 SMALLINT UNSIGNED;
 
     SET vs_JsonArray = TRIM(in_JsonArray);


### PR DESCRIPTION
## Root Cause
beforeMigrate.sql 中 `Json_getKeyValue` 函数使用 `VARCHAR(4096)` 作为参数/返回值/局部变量类型。在 MySQL utf8mb4 编码 + ROW_FORMAT=COMPACT 下，`4096 * 4 = 16384` 字节，多变量叠加触发行大小限制，导致 flyway migration 失败，5.5.12 升级中断。

## Solution
将 3 处 `VARCHAR(4096)` 改为 `MEDIUMTEXT`：
- 第8行：函数输入参数 `in_JsonArray`
- 第10行：函数返回值
- 第13行：DECLARE 局部变量（5个）

MEDIUMTEXT 完全兼容 VARCHAR(4096) 的所有字符串操作，且 V4.7.0 中类似函数 `Json_simpleGetKeyValue` 已使用 `text` 类型作为先例。

## Testing
- 验证 3 处替换无残留
- VARCHAR(64) 的 in_KeyName 未改动（正确保留）
- 已执行过的 V2.1.0/V4.7.0 migration 文件不需要改动

## Jira
Resolves: ZSTAC-82980

sync from gitlab !9299