### PR TITLE
[ZSTAC-80103] AI inference resource request/limit separation - add error codes

### DIFF
--- a/sdk/src/main/java/org/zstack/sdk/DeployAppDevelopmentServiceAction.java
+++ b/sdk/src/main/java/org/zstack/sdk/DeployAppDevelopmentServiceAction.java
@@ -55,6 +55,9 @@ public class DeployAppDevelopmentServiceAction extends AbstractAction {
     @Param(required = false, nonempty = false, nullElements = false, emptyString = true, noTrim = false)
     public java.lang.Integer cpuNum;
 
+    @Param(required = false, nonempty = false, nullElements = false, emptyString = true, noTrim = false)
+    public java.lang.Integer requestCpuNum;
+
     @Param(required = true, nonempty = false, nullElements = false, emptyString = true, noTrim = false)
     public java.lang.String name;
 
@@ -72,6 +75,9 @@ public class DeployAppDevelopmentServiceAction extends AbstractAction {
 
     @Param(required = false, nonempty = false, nullElements = false, emptyString = true, noTrim = false)
     public java.lang.Long memorySize;
+
+    @Param(required = false, nonempty = false, nullElements = false, emptyString = true, noTrim = false)
+    public java.lang.Long requestMemorySize;
 
     @Param(required = false, nonempty = false, nullElements = false, emptyString = true, noTrim = false)
     public java.util.List l3NetworkUuids;

--- a/sdk/src/main/java/org/zstack/sdk/DeployModelEvalServiceAction.java
+++ b/sdk/src/main/java/org/zstack/sdk/DeployModelEvalServiceAction.java
@@ -106,6 +106,9 @@ public class DeployModelEvalServiceAction extends AbstractAction {
     @Param(required = false, nonempty = false, nullElements = false, emptyString = true, noTrim = false)
     public java.lang.Integer cpuNum;
 
+    @Param(required = false, nonempty = false, nullElements = false, emptyString = true, noTrim = false)
+    public java.lang.Integer requestCpuNum;
+
     @Param(required = true, nonempty = false, nullElements = false, emptyString = true, noTrim = false)
     public java.lang.String name;
 
@@ -123,6 +126,9 @@ public class DeployModelEvalServiceAction extends AbstractAction {
 
     @Param(required = false, nonempty = false, nullElements = false, emptyString = true, noTrim = false)
     public java.lang.Long memorySize;
+
+    @Param(required = false, nonempty = false, nullElements = false, emptyString = true, noTrim = false)
+    public java.lang.Long requestMemorySize;
 
     @Param(required = false, nonempty = false, nullElements = false, emptyString = true, noTrim = false)
     public java.util.List l3NetworkUuids;

--- a/sdk/src/main/java/org/zstack/sdk/DeployModelServiceAction.java
+++ b/sdk/src/main/java/org/zstack/sdk/DeployModelServiceAction.java
@@ -55,6 +55,9 @@ public class DeployModelServiceAction extends AbstractAction {
     @Param(required = false, nonempty = false, nullElements = false, emptyString = true, noTrim = false)
     public java.lang.Integer cpuNum;
 
+    @Param(required = false, nonempty = false, nullElements = false, emptyString = true, noTrim = false)
+    public java.lang.Integer requestCpuNum;
+
     @Param(required = true, nonempty = false, nullElements = false, emptyString = true, noTrim = false)
     public java.lang.String name;
 
@@ -72,6 +75,9 @@ public class DeployModelServiceAction extends AbstractAction {
 
     @Param(required = false, nonempty = false, nullElements = false, emptyString = true, noTrim = false)
     public java.lang.Long memorySize;
+
+    @Param(required = false, nonempty = false, nullElements = false, emptyString = true, noTrim = false)
+    public java.lang.Long requestMemorySize;
 
     @Param(required = false, nonempty = false, nullElements = false, emptyString = true, noTrim = false)
     public java.util.List l3NetworkUuids;

--- a/sdk/src/main/java/org/zstack/sdk/MatchModelServiceTemplateWithModelAction.java
+++ b/sdk/src/main/java/org/zstack/sdk/MatchModelServiceTemplateWithModelAction.java
@@ -64,6 +64,9 @@ public class MatchModelServiceTemplateWithModelAction extends AbstractAction {
     @Param(required = false, nonempty = false, nullElements = false, emptyString = true, noTrim = false)
     public java.lang.Integer cpuNum;
 
+    @Param(required = false, nonempty = false, nullElements = false, emptyString = true, noTrim = false)
+    public java.lang.Integer requestCpuNum;
+
     @Param(required = true, nonempty = false, nullElements = false, emptyString = true, noTrim = false)
     public java.lang.String name;
 
@@ -81,6 +84,9 @@ public class MatchModelServiceTemplateWithModelAction extends AbstractAction {
 
     @Param(required = false, nonempty = false, nullElements = false, emptyString = true, noTrim = false)
     public java.lang.Long memorySize;
+
+    @Param(required = false, nonempty = false, nullElements = false, emptyString = true, noTrim = false)
+    public java.lang.Long requestMemorySize;
 
     @Param(required = false, nonempty = false, nullElements = false, emptyString = true, noTrim = false)
     public java.util.List l3NetworkUuids;

--- a/sdk/src/main/java/org/zstack/sdk/ModelService.java
+++ b/sdk/src/main/java/org/zstack/sdk/ModelService.java
@@ -108,6 +108,14 @@ public class ModelService  {
         return this.cpuNum;
     }
 
+    public java.lang.Integer requestCpuNum;
+    public void setRequestCpuNum(java.lang.Integer requestCpuNum) {
+        this.requestCpuNum = requestCpuNum;
+    }
+    public java.lang.Integer getRequestCpuNum() {
+        return this.requestCpuNum;
+    }
+
     public java.lang.String name;
     public void setName(java.lang.String name) {
         this.name = name;
@@ -154,6 +162,14 @@ public class ModelService  {
     }
     public java.lang.Long getMemorySize() {
         return this.memorySize;
+    }
+
+    public java.lang.Long requestMemorySize;
+    public void setRequestMemorySize(java.lang.Long requestMemorySize) {
+        this.requestMemorySize = requestMemorySize;
+    }
+    public java.lang.Long getRequestMemorySize() {
+        return this.requestMemorySize;
     }
 
     public java.util.List l3NetworkUuids;

--- a/utils/src/main/java/org/zstack/utils/clouderrorcode/CloudOperationsErrorCode.java
+++ b/utils/src/main/java/org/zstack/utils/clouderrorcode/CloudOperationsErrorCode.java
@@ -14816,6 +14816,16 @@ public class CloudOperationsErrorCode {
 
     public static final String ORG_ZSTACK_AI_10134 = "ORG_ZSTACK_AI_10134";
 
+    public static final String ORG_ZSTACK_AI_10135 = "ORG_ZSTACK_AI_10135";
+
+    public static final String ORG_ZSTACK_AI_10136 = "ORG_ZSTACK_AI_10136";
+
+    public static final String ORG_ZSTACK_AI_10137 = "ORG_ZSTACK_AI_10137";
+
+    public static final String ORG_ZSTACK_AI_10138 = "ORG_ZSTACK_AI_10138";
+
+    public static final String ORG_ZSTACK_AI_10139 = "ORG_ZSTACK_AI_10139";
+
     public static final String ORG_ZSTACK_CORE_CLOUDBUS_10000 = "ORG_ZSTACK_CORE_CLOUDBUS_10000";
 
     public static final String ORG_ZSTACK_CORE_CLOUDBUS_10001 = "ORG_ZSTACK_CORE_CLOUDBUS_10001";


### PR DESCRIPTION
## 📋 概述

为AI推理服务资源验证添加错误码（ORG_ZSTACK_AI_10135-10139），支持CPU/内存request和limit参数的分离验证。

## 🔧 主要变更

### 新增错误码
- `ORG_ZSTACK_AI_10135`: memorySize验证（必须为正数）
- `ORG_ZSTACK_AI_10136`: requestCpuNum验证（必须为正数）
- `ORG_ZSTACK_AI_10137`: requestMemorySize验证（必须为正数）
- `ORG_ZSTACK_AI_10138`: requestCpuNum不能超过cpuNum
- `ORG_ZSTACK_AI_10139`: requestMemorySize不能超过memorySize

### 修改的文件
- `zstack/utils/clouderrorcode/CloudOperationsErrorCode.java`: 新增5个错误码定义

## 📚 相关文档

完整分析和测试策略请参考：
- [详细分析报告](http://dev.zstack.io:9080/zstackio/zstack-workspace/blob/master/docs/ZSTAC-80103-FINAL-REPORT.md)
- [需求分析](http://dev.zstack.io:9080/zstackio/zstack-workspace/blob/master/docs/zstac-80103-requirements-analysis.md)
- [验证逻辑分析](http://dev.zstack.io:9080/zstackio/zstack-workspace/blob/master/docs/zstac-80103-validation-and-naming-analysis.md)

## ✅ 向后兼容性

✅ 完全兼容：新增错误码不影响现有功能，仅用于新参数验证

## 🧪 测试建议

推荐测试场景：
1. 默认参数测试（向后兼容性）
2. 自定义request参数测试
3. 负数或零值验证测试
4. request超过limit验证测试
5. 错误码消息测试

详细测试代码和测试用例请参考上述文档。

## 📝 相关Issue

ZSTAC-80103: AI 推理服务创建时分离 CPU/内存 request 和 limit

---

**Co-Authored-By**: Claude Opus 4.6 <noreply@anthropic.com>

sync from gitlab !9303