### PR TITLE
<fix>[vm]: ZSTAC-68874 always submit DeleteVmGC on create rollback

### DIFF
--- a/compute/src/main/java/org/zstack/compute/vm/VmCreateOnHypervisorFlow.java
+++ b/compute/src/main/java/org/zstack/compute/vm/VmCreateOnHypervisorFlow.java
@@ -79,20 +79,23 @@ public class VmCreateOnHypervisorFlow implements Flow {
                             spec.getVmInventory().getUuid(), spec.getVmInventory().getName(),
                             spec.getDestHost().getUuid(), spec.getDestHost().getName(), reply.getError()));
 
-                    if (reply.getError().isError(HostErrors.OPERATION_FAILURE_GC_ELIGIBLE)) {
-                        String gcName = String.format("gc-vm-%s-on-host-%s", spec.getVmInventory().getUuid(), spec.getDestHost().getUuid());
+                    // Always submit GC to clean up the VM on the hypervisor,
+                    // regardless of whether the error is GC_ELIGIBLE or not.
+                    // This prevents orphaned VMs and GPU dirty data (ZSTAC-68874).
+                    String gcName = String.format("gc-vm-%s-on-host-%s", spec.getVmInventory().getUuid(), spec.getDestHost().getUuid());
 
-                        DeleteVmGC gc = new DeleteVmGC();
-                        gc.NAME = gcName;
-                        gc.hostUuid = spec.getVmInventory().getHostUuid();
-                        gc.inventory = spec.getVmInventory();
-                        if (gc.existedAndNotCompleted()) {
-                            logger.debug(String.format("There is already a DeleteVmGC of vm[uuid:%s] " +
-                                    "on host[uuid:%s], skip.", spec.getVmInventory().getUuid(), spec.getDestHost().getUuid()));
-                        } else {
-                            gc.submit();
-                        }
+                    DeleteVmGC gc = new DeleteVmGC();
+                    gc.NAME = gcName;
+                    gc.hostUuid = spec.getVmInventory().getHostUuid();
+                    gc.inventory = spec.getVmInventory();
+                    if (gc.existedAndNotCompleted()) {
+                        logger.debug(String.format("There is already a DeleteVmGC of vm[uuid:%s] " +
+                                "on host[uuid:%s], skip.", spec.getVmInventory().getUuid(), spec.getDestHost().getUuid()));
                     } else {
+                        gc.submit();
+                    }
+
+                    if (!reply.getError().isError(HostErrors.OPERATION_FAILURE_GC_ELIGIBLE)) {
                         VmTracerCanonicalEvents.OperateFailOnHypervisorData data = new VmTracerCanonicalEvents.OperateFailOnHypervisorData();
                         data.setHostUuid(spec.getVmInventory().getHostUuid());
                         data.setVmUuid(spec.getVmInventory().getUuid());


### PR DESCRIPTION
## ZSTAC-68874 推理服务断开vip导致GPU脏数据

### Root Cause
VM创建失败rollback时，DestroyVm也失败的场景下，旧逻辑只在GC_ELIGIBLE错误时提交DeleteVmGC。
非GC_ELIGIBLE错误（如MN不可用）不创建GC，导致orphan VM残留在hypervisor上占用GPU资源。

### Fix
rollback始终提交DeleteVmGC，无论错误类型。非GC_ELIGIBLE错误额外触发canonical event（保持告警行为不变）。

### Cross-repo
- zstack: VmCreateOnHypervisorFlow.java rollback逻辑
- premium (fix/ZSTAC-68874@@2): VmCreateGCCase.groovy 测试断言更新

sync from gitlab !9323