### PR TITLE
<feature>[longjob]: standardize progress detail fields to be unit-agnostic

### DIFF
--- a/header/src/main/java/org/zstack/header/core/progress/APIGetTaskProgressReply.java
+++ b/header/src/main/java/org/zstack/header/core/progress/APIGetTaskProgressReply.java
@@ -35,9 +35,10 @@ public class APIGetTaskProgressReply extends APIReply {
         detail.setPercent(42);
         detail.setStage("downloading");
         detail.setState("running");
-        detail.setProcessedBytes(440401920L);
-        detail.setTotalBytes(1073741824L);
-        detail.setSpeedBytesPerSecond(10485760L);
+        detail.setProcessed(440401920L);
+        detail.setTotal(1073741824L);
+        detail.setUnit("bytes");
+        detail.setSpeed(10485760L);
         detail.setEstimatedRemainingSeconds(60L);
         inv.setProgressDetail(detail);
 

--- a/header/src/main/java/org/zstack/header/core/progress/LongJobProgressDetail.java
+++ b/header/src/main/java/org/zstack/header/core/progress/LongJobProgressDetail.java
@@ -21,11 +21,11 @@ public class LongJobProgressDetail {
     /** Human-readable reason for current state. */
     private String stateReason;
 
-    /** Bytes already processed. */
-    private Long processedBytes;
+    /** Amount already processed (unit described by the {@code unit} field). */
+    private Long processed;
 
-    /** Total bytes to process. */
-    private Long totalBytes;
+    /** Total amount to process (unit described by the {@code unit} field). */
+    private Long total;
 
     /** Items already processed (e.g. files, chunks). */
     private Long processedItems;
@@ -33,8 +33,11 @@ public class LongJobProgressDetail {
     /** Total items to process. */
     private Long totalItems;
 
-    /** Transfer speed in bytes/s. */
-    private Long speedBytesPerSecond;
+    /** Processing speed per second (unit described by the {@code unit} field). */
+    private Long speed;
+
+    /** Unit for processed/total/speed, e.g. "bytes", "items", "steps". */
+    private String unit;
 
     /** Estimated remaining time in seconds. */
     private Long estimatedRemainingSeconds;
@@ -77,20 +80,20 @@ public class LongJobProgressDetail {
         this.stateReason = stateReason;
     }
 
-    public Long getProcessedBytes() {
-        return processedBytes;
+    public Long getProcessed() {
+        return processed;
     }
 
-    public void setProcessedBytes(Long processedBytes) {
-        this.processedBytes = processedBytes;
+    public void setProcessed(Long processed) {
+        this.processed = processed;
     }
 
-    public Long getTotalBytes() {
-        return totalBytes;
+    public Long getTotal() {
+        return total;
     }
 
-    public void setTotalBytes(Long totalBytes) {
-        this.totalBytes = totalBytes;
+    public void setTotal(Long total) {
+        this.total = total;
     }
 
     public Long getProcessedItems() {
@@ -109,12 +112,20 @@ public class LongJobProgressDetail {
         this.totalItems = totalItems;
     }
 
-    public Long getSpeedBytesPerSecond() {
-        return speedBytesPerSecond;
+    public Long getSpeed() {
+        return speed;
     }
 
-    public void setSpeedBytesPerSecond(Long speedBytesPerSecond) {
-        this.speedBytesPerSecond = speedBytesPerSecond;
+    public void setSpeed(Long speed) {
+        this.speed = speed;
+    }
+
+    public String getUnit() {
+        return unit;
+    }
+
+    public void setUnit(String unit) {
+        this.unit = unit;
     }
 
     public Long getEstimatedRemainingSeconds() {

--- a/header/src/main/java/org/zstack/header/core/progress/LongJobProgressDetailBuilder.java
+++ b/header/src/main/java/org/zstack/header/core/progress/LongJobProgressDetailBuilder.java
@@ -10,24 +10,31 @@ import java.util.Map;
 /**
  * Parses TaskProgressVO.opaque (free-form JSON) into a typed LongJobProgressDetail.
  *
- * Three known opaque formats are handled:
- *   Format 1 — VM migration:   {"remain":N, "total":N, "speed":N, "remaining_migration_time":N}
- *   Format 2 — AI download:    {"data": "<JSON string>"}  where the inner JSON has
- *                               {state, progress:{percent,downloaded_bytes,total_bytes,
- *                                speed_bytes_per_second,estimated_remaining_seconds,
- *                                downloaded_files,total_files,stage}, state_reason}
- *   Format 3 — unknown:        entire map goes into LongJobProgressDetail.extra
+ * All agents now send a standardized camelCase format:
+ *   {"processed":N, "total":N, "percent":N, "stage":"migrating",
+ *    "speed":N, "estimatedRemainingSeconds":N, "state":"running",
+ *    "stateReason":"...", "processedItems":N, "totalItems":N, "unit":"bytes"}
  *
- * Each format is tried independently. Failures in one format don't affect others.
+ * The "unit" field tells the UI how to format processed/total/speed:
+ *   "bytes" — byte quantities (format as KB/MB/GB)
+ *   "items" — discrete items (format as count)
+ *   "steps" — workflow steps
+ *
+ * Unknown keys are preserved in LongJobProgressDetail.extra so no data is silently dropped.
  */
 public class LongJobProgressDetailBuilder {
     private static final CLogger logger = Utils.getLogger(LongJobProgressDetailBuilder.class);
+
+    private static final String[] KNOWN_KEYS = {
+            "processed", "total", "percent", "stage", "state", "stateReason",
+            "speed", "estimatedRemainingSeconds", "processedItems", "totalItems", "unit"
+    };
 
     private LongJobProgressDetailBuilder() {}
 
     /**
      * Build a LongJobProgressDetail from a TaskProgressVO.
-     * Returns null if opaque is null/empty or all parsers fail.
+     * Returns null if opaque is null/empty or not valid JSON.
      */
     public static LongJobProgressDetail fromTaskProgressVO(TaskProgressVO vo) {
         if (vo == null || vo.getOpaque() == null || vo.getOpaque().isEmpty()) {
@@ -46,207 +53,78 @@ public class LongJobProgressDetailBuilder {
             return null;
         }
 
-        // Try Format 2 first: AI download wraps everything under "data" key
-        if (raw.containsKey("data")) {
-            LongJobProgressDetail detail = tryParseAiDownloadFormat(raw);
-            if (detail != null) {
-                return detail;
-            }
-        }
-
-        // Try Format 1: VM migration with remain/total/speed keys
-        if (raw.containsKey("remain") && raw.containsKey("total")) {
-            LongJobProgressDetail detail = tryParseVmMigrationFormat(raw);
-            if (detail != null) {
-                return detail;
-            }
-        }
-
-        // Format 3: unknown — put everything into extra
-        return parseAsExtra(raw);
-    }
-
-    /**
-     * Format 1: VM migration opaque
-     * {"remain": 1234567, "total": 9999999, "speed": 102400, "remaining_migration_time": 30}
-     * remain = bytes still to transfer; processed = total - remain
-     */
-    private static LongJobProgressDetail tryParseVmMigrationFormat(Map<String, Object> raw) {
         try {
             LongJobProgressDetail detail = new LongJobProgressDetail();
-            detail.setStage("migrating");
+
+            Number processed = toNumber(raw.get("processed"));
+            if (processed != null) {
+                detail.setProcessed(processed.longValue());
+            }
 
             Number total = toNumber(raw.get("total"));
-            Number remain = toNumber(raw.get("remain"));
-            Number speed = toNumber(raw.get("speed"));
-            Number remainingTime = toNumber(raw.get("remaining_migration_time"));
-
             if (total != null) {
-                detail.setTotalBytes(total.longValue());
+                detail.setTotal(total.longValue());
             }
-            if (total != null && remain != null) {
-                long processed = Math.max(0L, total.longValue() - remain.longValue());
-                detail.setProcessedBytes(processed);
-                if (total.longValue() > 0) {
-                    detail.setPercent((int) Math.min(100, Math.round(processed * 100.0 / total.longValue())));
-                }
+
+            Number percent = toNumber(raw.get("percent"));
+            if (percent != null) {
+                detail.setPercent(Math.max(0, Math.min(100, (int) Math.round(percent.doubleValue()))));
             }
+
+            Object stage = raw.get("stage");
+            if (stage instanceof String) {
+                detail.setStage((String) stage);
+            }
+
+            Object state = raw.get("state");
+            if (state instanceof String) {
+                detail.setState((String) state);
+            }
+
+            Object stateReason = raw.get("stateReason");
+            if (stateReason instanceof String) {
+                detail.setStateReason((String) stateReason);
+            }
+
+            Number speed = toNumber(raw.get("speed"));
             if (speed != null) {
-                detail.setSpeedBytesPerSecond(speed.longValue());
+                detail.setSpeed(speed.longValue());
             }
-            if (remainingTime != null) {
-                detail.setEstimatedRemainingSeconds(remainingTime.longValue());
+
+            Number eta = toNumber(raw.get("estimatedRemainingSeconds"));
+            if (eta != null) {
+                detail.setEstimatedRemainingSeconds(eta.longValue());
+            }
+
+            Number processedItems = toNumber(raw.get("processedItems"));
+            if (processedItems != null) {
+                detail.setProcessedItems(processedItems.longValue());
+            }
+
+            Number totalItems = toNumber(raw.get("totalItems"));
+            if (totalItems != null) {
+                detail.setTotalItems(totalItems.longValue());
+            }
+
+            Object unit = raw.get("unit");
+            if (unit instanceof String) {
+                detail.setUnit((String) unit);
             }
 
             // Carry over any unrecognized keys into extra
             Map<String, Object> extra = new HashMap<>(raw);
-            extra.remove("remain");
-            extra.remove("total");
-            extra.remove("speed");
-            extra.remove("remaining_migration_time");
+            for (String key : KNOWN_KEYS) {
+                extra.remove(key);
+            }
             if (!extra.isEmpty()) {
                 detail.setExtra(extra);
             }
 
             return detail;
         } catch (Exception e) {
-            logger.trace("LongJobProgressDetailBuilder: failed to parse VM migration format", e);
+            logger.trace("LongJobProgressDetailBuilder: failed to parse standard format", e);
             return null;
         }
-    }
-
-    /**
-     * Format 2: AI download opaque
-     * {"data": "{\"state\":\"downloading\", \"progress\":{\"percent\":42, \"processedBytes\":N, ...}}"}
-     * The "data" value is a JSON string (double-encoded).
-     */
-    private static LongJobProgressDetail tryParseAiDownloadFormat(Map<String, Object> raw) {
-        try {
-            Object dataVal = raw.get("data");
-            if (dataVal == null) {
-                return null;
-            }
-
-            Map<String, Object> inner;
-            if (dataVal instanceof String) {
-                // double-encoded JSON string
-                inner = JSONObjectUtil.toObject((String) dataVal, HashMap.class);
-            } else if (dataVal instanceof Map) {
-                inner = (Map<String, Object>) dataVal;
-            } else {
-                return null;
-            }
-
-            if (inner == null) {
-                return null;
-            }
-
-            LongJobProgressDetail detail = new LongJobProgressDetail();
-            Map<String, Object> extra = new HashMap<>();
-
-            // state field
-            Object stateVal = inner.get("state");
-            if (stateVal instanceof String) {
-                detail.setState((String) stateVal);
-            }
-
-            // progress sub-object
-            Object progressVal = inner.get("progress");
-            if (progressVal instanceof Map) {
-                Map<String, Object> progress = (Map<String, Object>) progressVal;
-
-                Number percent = toNumber(progress.get("percent"));
-                if (percent != null) {
-                    detail.setPercent(Math.max(0, Math.min(100, (int) Math.round(percent.doubleValue()))));
-                }
-
-                // AI agent uses snake_case field names
-                Number processedBytes = toNumber(progress.get("downloaded_bytes"));
-                if (processedBytes != null) {
-                    detail.setProcessedBytes(processedBytes.longValue());
-                }
-
-                Number totalBytes = toNumber(progress.get("total_bytes"));
-                if (totalBytes != null) {
-                    detail.setTotalBytes(totalBytes.longValue());
-                }
-
-                Number speed = toNumber(progress.get("speed_bytes_per_second"));
-                if (speed != null) {
-                    detail.setSpeedBytesPerSecond(speed.longValue());
-                }
-
-                Number eta = toNumber(progress.get("estimated_remaining_seconds"));
-                if (eta != null) {
-                    detail.setEstimatedRemainingSeconds(eta.longValue());
-                }
-
-                Number processedFiles = toNumber(progress.get("downloaded_files"));
-                if (processedFiles != null) {
-                    detail.setProcessedItems(processedFiles.longValue());
-                }
-
-                Number totalFiles = toNumber(progress.get("total_files"));
-                if (totalFiles != null) {
-                    detail.setTotalItems(totalFiles.longValue());
-                }
-
-                Object stage = progress.get("stage");
-                if (stage instanceof String) {
-                    detail.setStage((String) stage);
-                }
-
-                // remaining progress fields go into extra
-                Map<String, Object> extraProgress = new HashMap<>(progress);
-                extraProgress.remove("percent");
-                extraProgress.remove("downloaded_bytes");
-                extraProgress.remove("total_bytes");
-                extraProgress.remove("speed_bytes_per_second");
-                extraProgress.remove("estimated_remaining_seconds");
-                extraProgress.remove("downloaded_files");
-                extraProgress.remove("total_files");
-                extraProgress.remove("stage");
-                extra.putAll(extraProgress);
-            }
-
-            // stateReason field — can be String or Map (structured reason with code/description)
-            Object stateReason = inner.get("state_reason");
-            if (stateReason instanceof String) {
-                detail.setStateReason((String) stateReason);
-            } else if (stateReason instanceof Map) {
-                detail.setStateReason(JSONObjectUtil.toJsonString(stateReason));
-            }
-
-            // preserve unknown keys from inner top-level
-            Map<String, Object> extraInner = new HashMap<>(inner);
-            extraInner.remove("state");
-            extraInner.remove("progress");
-            extraInner.remove("state_reason");
-            extra.putAll(extraInner);
-
-            // preserve unknown keys from raw outer-level
-            Map<String, Object> extraRaw = new HashMap<>(raw);
-            extraRaw.remove("data");
-            extra.putAll(extraRaw);
-
-            if (!extra.isEmpty()) {
-                detail.setExtra(extra);
-            }
-
-            return detail;
-        } catch (Exception e) {
-            logger.trace("LongJobProgressDetailBuilder: failed to parse AI download format", e);
-            return null;
-        }
-    }
-
-    /**
-     * Format 3: unknown — preserve the entire map as extra for UI passthrough.
-     */
-    private static LongJobProgressDetail parseAsExtra(Map<String, Object> raw) {
-        LongJobProgressDetail detail = new LongJobProgressDetail();
-        detail.setExtra(new HashMap<>(raw));
-        return detail;
     }
 
     private static Number toNumber(Object val) {

--- a/sdk/src/main/java/org/zstack/sdk/LongJobProgressDetail.java
+++ b/sdk/src/main/java/org/zstack/sdk/LongJobProgressDetail.java
@@ -36,20 +36,20 @@ public class LongJobProgressDetail  {
         return this.stateReason;
     }
 
-    public java.lang.Long processedBytes;
-    public void setProcessedBytes(java.lang.Long processedBytes) {
-        this.processedBytes = processedBytes;
+    public java.lang.Long processed;
+    public void setProcessed(java.lang.Long processed) {
+        this.processed = processed;
     }
-    public java.lang.Long getProcessedBytes() {
-        return this.processedBytes;
+    public java.lang.Long getProcessed() {
+        return this.processed;
     }
 
-    public java.lang.Long totalBytes;
-    public void setTotalBytes(java.lang.Long totalBytes) {
-        this.totalBytes = totalBytes;
+    public java.lang.Long total;
+    public void setTotal(java.lang.Long total) {
+        this.total = total;
     }
-    public java.lang.Long getTotalBytes() {
-        return this.totalBytes;
+    public java.lang.Long getTotal() {
+        return this.total;
     }
 
     public java.lang.Long processedItems;
@@ -68,12 +68,20 @@ public class LongJobProgressDetail  {
         return this.totalItems;
     }
 
-    public java.lang.Long speedBytesPerSecond;
-    public void setSpeedBytesPerSecond(java.lang.Long speedBytesPerSecond) {
-        this.speedBytesPerSecond = speedBytesPerSecond;
+    public java.lang.Long speed;
+    public void setSpeed(java.lang.Long speed) {
+        this.speed = speed;
     }
-    public java.lang.Long getSpeedBytesPerSecond() {
-        return this.speedBytesPerSecond;
+    public java.lang.Long getSpeed() {
+        return this.speed;
+    }
+
+    public java.lang.String unit;
+    public void setUnit(java.lang.String unit) {
+        this.unit = unit;
+    }
+    public java.lang.String getUnit() {
+        return this.unit;
     }
 
     public java.lang.Long estimatedRemainingSeconds;


### PR DESCRIPTION
## Summary
Phase 2 of ZSTAC-82318: 将 LongJobProgressDetail 的字段名从字节专用改为通用名称，新增 `unit` 字段让 UI 按类型格式化。

### 字段变更
| 旧字段 | 新字段 | 说明 |
|--------|--------|------|
| `processedBytes` | `processed` | 已处理量（不限类型） |
| `totalBytes` | `total` | 总量 |
| `speedBytesPerSecond` | `speed` | 速率/秒 |
| — | `unit` | `"bytes"` / `"items"` / `"steps"` |

### Builder 简化
删除旧 Format 1（VM 迁移 remain/total）和 Format 2（AI 下载 double-encoded JSON）的适配器，因为 agent 端已统一发送标准 camelCase 格式。264 行 → 136 行。

### 配套 MR
- zstack-utility: kvmagent vm_plugin.py 两处 `_get_detail()` 改为标准格式
- aios: progress_utils.py 去掉双层 JSON 嵌套
- zstack-ui-next: BFF 新增 `ProgressDetail` 类型 + 前端 hook 适配

Resolves: ZSTAC-82318

sync from gitlab !9358