### PR TITLE
<fix>[vmScheduling]: change GET scheduling APIs from POST to GET method (ZSTAC-71075)

### DIFF
--- a/sdk/src/main/java/org/zstack/sdk/GetVmSchedulingRulesExecuteStateAction.java
+++ b/sdk/src/main/java/org/zstack/sdk/GetVmSchedulingRulesExecuteStateAction.java
@@ -84,11 +84,11 @@ public class GetVmSchedulingRulesExecuteStateAction extends AbstractAction {
 
     protected RestInfo getRestInfo() {
         RestInfo info = new RestInfo();
-        info.httpMethod = "POST";
+        info.httpMethod = "GET";
         info.path = "/get/vmSchedulingRules/conflict/state";
         info.needSession = true;
         info.needPoll = false;
-        info.parameterName = "params";
+        info.parameterName = "";
         return info;
     }
 

--- a/sdk/src/main/java/org/zstack/sdk/GetVmsSchedulingStateFromSchedulingRuleAction.java
+++ b/sdk/src/main/java/org/zstack/sdk/GetVmsSchedulingStateFromSchedulingRuleAction.java
@@ -87,11 +87,11 @@ public class GetVmsSchedulingStateFromSchedulingRuleAction extends AbstractActio
 
     protected RestInfo getRestInfo() {
         RestInfo info = new RestInfo();
-        info.httpMethod = "POST";
+        info.httpMethod = "GET";
         info.path = "/get/vms/schedulingState/from/SchedulingRule";
         info.needSession = true;
         info.needPoll = false;
-        info.parameterName = "params";
+        info.parameterName = "";
         return info;
     }
 


### PR DESCRIPTION
## Summary
- Change `GetVmSchedulingRulesExecuteStateAction` from POST to GET
- Change `GetVmsSchedulingStateFromSchedulingRuleAction` from POST to GET
- Remove `parameterName = "params"` for GET requests

SDK changes (this repo) + API message changes (premium @@2)

sync from gitlab !9373