### PR TITLE
<fix>[core,kvm]: fix SSH session leak in CallBackNetworkChecker and KVMHost

### DIFF
--- a/core/src/main/java/org/zstack/core/ansible/CallBackNetworkChecker.java
+++ b/core/src/main/java/org/zstack/core/ansible/CallBackNetworkChecker.java
@@ -72,6 +72,8 @@ public class CallBackNetworkChecker implements AnsibleChecker {
             return useNcatAndNmapToTestConnection(ssh);
         } catch (SshException e) {
             return operr(ORG_ZSTACK_CORE_ANSIBLE_10004, e.getMessage());
+        } finally {
+            ssh.close();
         }
     }
 

--- a/plugin/kvm/src/main/java/org/zstack/kvm/KVMHost.java
+++ b/plugin/kvm/src/main/java/org/zstack/kvm/KVMHost.java
@@ -5573,10 +5573,10 @@ public class KVMHost extends HostBase implements Host {
 
                     @Override
                     public void run(FlowTrigger trigger, Map data) {
+                        Ssh ssh = new Ssh().setUsername(getSelf().getUsername())
+                                .setPassword(getSelf().getPassword()).setPort(getSelf().getPort())
+                                .setHostname(getSelf().getManagementIp());
                         try {
-                            Ssh ssh = new Ssh().setUsername(getSelf().getUsername())
-                                    .setPassword(getSelf().getPassword()).setPort(getSelf().getPort())
-                                    .setHostname(getSelf().getManagementIp());
                             ssh.command(String.format("grep -i ^uuid %s | sed 's/uuid://g'", hostTakeOverFlagPath));
                             SshResult hostRet = ssh.run();
                             if (hostRet.isSshFailure() || hostRet.getReturnCode() != 0) {
@@ -5625,6 +5625,8 @@ public class KVMHost extends HostBase implements Host {
                             logger.warn(e.getMessage(), e);
                             trigger.next();
                             return;
+                        } finally {
+                            ssh.close();
                         }
                     }
                 });


### PR DESCRIPTION
## 问题

CallBackNetworkChecker.stopAnsible() 和 KVMHost "check-host-is-taken-over" flow 中创建 Ssh 对象后未调用 ssh.close()，导致 JSch Session 线程泄漏。

当某台 host 因底层异常（如 sharedblock VG Duplicate sanlock global lock）持续 reconnect 失败时，每次 reconnect 都泄漏 1-2 个 SSH session。按每分钟重连一次计算，约 6-13 天累积 ~19000 个未关闭的 JSch SSH 线程，耗尽 8GB 堆内存导致 MN OOM → Unknown。

## 修复

在两处泄漏点添加 `finally { ssh.close(); }`：

1. **CallBackNetworkChecker.stopAnsible()** — 在 try-catch 后加 finally 关闭 SSH session
2. **KVMHost "check-host-is-taken-over"** — 将 Ssh 对象提到 try 外，添加 finally 关闭

## 影响范围

- `core/src/main/java/org/zstack/core/ansible/CallBackNetworkChecker.java`
- `plugin/kvm/src/main/java/org/zstack/kvm/KVMHost.java`

改动最小化，仅添加 finally block，不改变任何业务逻辑。

## 关联工单

- ZSTAC-83305
- ZSTAC-82731
- TIC-5447

sync from gitlab !9398