### PR TITLE
<fix>[pci]: split virt mode from capability lifecycle

### DIFF
--- a/conf/db/upgrade/V5.5.12__schema.sql
+++ b/conf/db/upgrade/V5.5.12__schema.sql
@@ -32,6 +32,95 @@ WHERE `opaque` IS NOT NULL
   AND Json_getKeyValue(`opaque`, 'end_time') IS NOT NULL
   AND Json_getKeyValue(`opaque`, 'end_time') != '';
 
+-- PCI virtualization capability metadata
+
+CREATE TABLE IF NOT EXISTS `zstack`.`PciDeviceVirtCapabilityVO` (
+    `id`            BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+    `pciDeviceUuid` VARCHAR(32)     NOT NULL,
+    `capability`    VARCHAR(32)     NOT NULL,
+    `createDate`    TIMESTAMP       NOT NULL,
+    `lastOpDate`    TIMESTAMP       NOT NULL,
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `uk_pci_device_virt_capability` (`pciDeviceUuid`, `capability`),
+    KEY `idx_pci_device_virt_capability_pci` (`pciDeviceUuid`),
+    CONSTRAINT `fk_pci_device_virt_capability_pci`
+        FOREIGN KEY (`pciDeviceUuid`) REFERENCES `zstack`.`PciDeviceVO`(`uuid`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+CALL ADD_COLUMN('PciDeviceVO', 'virtState', 'varchar(32)', 1, NULL);
+
+UPDATE `zstack`.`PciDeviceVO`
+SET `virtState` =
+    CASE
+        WHEN `virtStatus` IN ('SRIOV_VIRTUALIZABLE', 'VFIO_MDEV_VIRTUALIZABLE', 'TENSORFUSION_VIRTUALIZABLE') THEN 'VIRTUALIZABLE'
+        WHEN `virtStatus` IN ('SRIOV_VIRTUALIZED', 'VFIO_MDEV_VIRTUALIZED', 'VIRTUALIZED_BYPASS_ZSTACK',
+                              'HAMI_VIRTUALIZED', 'TENSORFUSION_VIRTUALIZED') THEN 'VIRTUALIZED'
+        WHEN `virtStatus` = 'SRIOV_VIRTUAL' THEN 'VIRTUAL'
+        ELSE 'UNVIRTUALIZABLE'
+    END
+WHERE `virtState` IS NULL;
+
+INSERT IGNORE INTO `zstack`.`PciDeviceVirtCapabilityVO`
+    (`pciDeviceUuid`, `capability`, `createDate`, `lastOpDate`)
+SELECT `uuid`, 'SRIOV', NOW(), NOW()
+FROM `zstack`.`PciDeviceVO`
+WHERE `virtStatus` IN ('SRIOV_VIRTUALIZABLE', 'SRIOV_VIRTUALIZED');
+
+INSERT IGNORE INTO `zstack`.`PciDeviceVirtCapabilityVO`
+    (`pciDeviceUuid`, `capability`, `createDate`, `lastOpDate`)
+SELECT `uuid`, 'VFIO_MDEV', NOW(), NOW()
+FROM `zstack`.`PciDeviceVO`
+WHERE `virtStatus` IN ('VFIO_MDEV_VIRTUALIZABLE', 'VFIO_MDEV_VIRTUALIZED', 'VIRTUALIZED_BYPASS_ZSTACK');
+
+INSERT IGNORE INTO `zstack`.`PciDeviceVirtCapabilityVO`
+    (`pciDeviceUuid`, `capability`, `createDate`, `lastOpDate`)
+SELECT `uuid`, 'TENSORFUSION', NOW(), NOW()
+FROM `zstack`.`PciDeviceVO`
+WHERE `virtStatus` IN ('TENSORFUSION_VIRTUALIZABLE', 'TENSORFUSION_VIRTUALIZED');
+
+INSERT IGNORE INTO `zstack`.`PciDeviceVirtCapabilityVO`
+    (`pciDeviceUuid`, `capability`, `createDate`, `lastOpDate`)
+SELECT `uuid`, 'HAMI', NOW(), NOW()
+FROM `zstack`.`PciDeviceVO`
+WHERE `virtStatus` = 'HAMI_VIRTUALIZED';
+
+CALL ADD_COLUMN('PciDeviceVO', 'virtMode', 'varchar(32)', 1, NULL);
+
+UPDATE `zstack`.`PciDeviceVO`
+SET `virtMode` =
+    CASE
+        WHEN `virtStatus` IN ('SRIOV_VIRTUALIZED') THEN 'SRIOV'
+        WHEN `virtStatus` = 'SRIOV_VIRTUAL' THEN 'SRIOV'
+        WHEN `virtStatus` IN ('VFIO_MDEV_VIRTUALIZED', 'VIRTUALIZED_BYPASS_ZSTACK') THEN 'VFIO_MDEV'
+        WHEN `virtStatus` = 'TENSORFUSION_VIRTUALIZED' THEN 'TENSORFUSION'
+        WHEN `virtStatus` = 'HAMI_VIRTUALIZED' THEN 'HAMI'
+        ELSE `virtMode`
+    END
+WHERE `virtStatus` IN (
+    'SRIOV_VIRTUALIZED', 'SRIOV_VIRTUAL',
+    'VFIO_MDEV_VIRTUALIZED', 'VIRTUALIZED_BYPASS_ZSTACK',
+    'TENSORFUSION_VIRTUALIZED', 'HAMI_VIRTUALIZED'
+);
+
+CALL ADD_COLUMN('GpuDeviceVO', 'mode', 'varchar(32)', 1, NULL);
+CALL CREATE_INDEX('GpuDeviceVO', 'idx_gpu_device_mode', 'mode');
+
+UPDATE `zstack`.`GpuDeviceVO` g
+INNER JOIN `zstack`.`PciDeviceVO` p ON g.`uuid` = p.`uuid`
+SET g.`mode` = CASE
+    WHEN p.`virtState` = 'VIRTUALIZED' AND p.`virtMode` = 'TENSORFUSION' THEN 'DGPU'
+    WHEN p.`virtState` = 'VIRTUALIZED' AND p.`virtMode` IN ('VFIO_MDEV', 'SRIOV') THEN 'VGPU'
+    ELSE 'PCI'
+END;
+
+UPDATE `zstack`.`GpuDeviceVO` g
+INNER JOIN `zstack`.`PciDeviceVO` p ON g.`uuid` = p.`uuid`
+SET g.`allocateStatus` = CASE
+    WHEN p.`vmInstanceUuid` IS NOT NULL THEN 'Allocated'
+    WHEN p.`virtState` = 'VIRTUALIZED' AND p.`virtMode` IS NOT NULL THEN 'Unallocatable'
+    ELSE 'Unallocated'
+END;
+
 -- dGPU (TensorFusion) support tables
 
 CREATE TABLE IF NOT EXISTS `zstack`.`DGpuProfileVO` (

--- a/sdk/src/main/java/SourceClassMap.java
+++ b/sdk/src/main/java/SourceClassMap.java
@@ -651,6 +651,8 @@ public class SourceClassMap {
 			put("org.zstack.pciDevice.specification.pci.PciDeviceSpecInventory", "org.zstack.sdk.PciDeviceSpecInventory");
 			put("org.zstack.pciDevice.specification.pci.PciDeviceSpecState", "org.zstack.sdk.PciDeviceSpecState");
 			put("org.zstack.pciDevice.specification.pci.VmInstancePciDeviceSpecRefInventory", "org.zstack.sdk.VmInstancePciDeviceSpecRefInventory");
+			put("org.zstack.pciDevice.virtual.PciDeviceVirtMode", "org.zstack.sdk.PciDeviceVirtMode");
+			put("org.zstack.pciDevice.virtual.PciDeviceVirtState", "org.zstack.sdk.PciDeviceVirtState");
 			put("org.zstack.pciDevice.virtual.PciDeviceVirtStatus", "org.zstack.sdk.PciDeviceVirtStatus");
 			put("org.zstack.pciDevice.virtual.vfio_mdev.MdevDeviceChooser", "org.zstack.sdk.MdevDeviceChooser");
 			put("org.zstack.pciDevice.virtual.vfio_mdev.MdevDeviceInventory", "org.zstack.sdk.MdevDeviceInventory");
@@ -1339,6 +1341,8 @@ public class SourceClassMap {
 			put("org.zstack.sdk.PciDeviceState", "org.zstack.pciDevice.PciDeviceState");
 			put("org.zstack.sdk.PciDeviceStatus", "org.zstack.pciDevice.PciDeviceStatus");
 			put("org.zstack.sdk.PciDeviceType", "org.zstack.pciDevice.PciDeviceType");
+			put("org.zstack.sdk.PciDeviceVirtMode", "org.zstack.pciDevice.virtual.PciDeviceVirtMode");
+			put("org.zstack.sdk.PciDeviceVirtState", "org.zstack.pciDevice.virtual.PciDeviceVirtState");
 			put("org.zstack.sdk.PciDeviceVirtStatus", "org.zstack.pciDevice.virtual.PciDeviceVirtStatus");
 			put("org.zstack.sdk.PendingTaskInfo", "org.zstack.header.core.progress.PendingTaskInfo");
 			put("org.zstack.sdk.PhysicalDriveSmartSelfTestHistoryInventory", "org.zstack.storage.device.localRaid.PhysicalDriveSmartSelfTestHistoryInventory");

--- a/sdk/src/main/java/org/zstack/sdk/GpuDeviceInventory.java
+++ b/sdk/src/main/java/org/zstack/sdk/GpuDeviceInventory.java
@@ -60,4 +60,12 @@ public class GpuDeviceInventory extends org.zstack.sdk.PciDeviceInventory {
         return this.allocateStatus;
     }
 
+    public java.lang.String mode;
+    public void setMode(java.lang.String mode) {
+        this.mode = mode;
+    }
+    public java.lang.String getMode() {
+        return this.mode;
+    }
+
 }

--- a/sdk/src/main/java/org/zstack/sdk/PciDeviceInventory.java
+++ b/sdk/src/main/java/org/zstack/sdk/PciDeviceInventory.java
@@ -4,6 +4,8 @@ import org.zstack.sdk.PciDeviceType;
 import org.zstack.sdk.PciDeviceState;
 import org.zstack.sdk.PciDeviceStatus;
 import org.zstack.sdk.PciDeviceVirtStatus;
+import org.zstack.sdk.PciDeviceVirtState;
+import org.zstack.sdk.PciDeviceVirtMode;
 import org.zstack.sdk.PciDeviceChooser;
 import org.zstack.sdk.PciDeviceMetaData;
 
@@ -95,6 +97,30 @@ public class PciDeviceInventory  {
     }
     public PciDeviceVirtStatus getVirtStatus() {
         return this.virtStatus;
+    }
+
+    public PciDeviceVirtState virtState;
+    public void setVirtState(PciDeviceVirtState virtState) {
+        this.virtState = virtState;
+    }
+    public PciDeviceVirtState getVirtState() {
+        return this.virtState;
+    }
+
+    public java.util.List virtCapabilities;
+    public void setVirtCapabilities(java.util.List virtCapabilities) {
+        this.virtCapabilities = virtCapabilities;
+    }
+    public java.util.List getVirtCapabilities() {
+        return this.virtCapabilities;
+    }
+
+    public PciDeviceVirtMode virtMode;
+    public void setVirtMode(PciDeviceVirtMode virtMode) {
+        this.virtMode = virtMode;
+    }
+    public PciDeviceVirtMode getVirtMode() {
+        return this.virtMode;
     }
 
     public PciDeviceChooser chooser;

--- a/sdk/src/main/java/org/zstack/sdk/PciDeviceVirtMode.java
+++ b/sdk/src/main/java/org/zstack/sdk/PciDeviceVirtMode.java
@@ -1,0 +1,8 @@
+package org.zstack.sdk;
+
+public enum PciDeviceVirtMode {
+	SRIOV,
+	VFIO_MDEV,
+	TENSORFUSION,
+	HAMI,
+}

--- a/sdk/src/main/java/org/zstack/sdk/PciDeviceVirtState.java
+++ b/sdk/src/main/java/org/zstack/sdk/PciDeviceVirtState.java
@@ -1,0 +1,8 @@
+package org.zstack.sdk;
+
+public enum PciDeviceVirtState {
+	UNVIRTUALIZABLE,
+	VIRTUALIZABLE,
+	VIRTUALIZED,
+	VIRTUAL,
+}


### PR DESCRIPTION
Add virt mode and capability persistence to the PCI
virtualization schema upgrade for the new lifecycle
model.

Resolves: ZSTAC-83477
Change-Id: I834770000000000000000000000000000000003

sync from gitlab !9426