### PR TITLE
<feature>[kvm]: add online snapshot support for VM host files

### DIFF
--- a/header/src/main/java/org/zstack/header/storage/snapshot/TakeVolumesSnapshotOnKvmMsg.java
+++ b/header/src/main/java/org/zstack/header/storage/snapshot/TakeVolumesSnapshotOnKvmMsg.java
@@ -2,6 +2,7 @@ package org.zstack.header.storage.snapshot;
 
 import org.zstack.header.host.HostMessage;
 import org.zstack.header.message.NeedReplyMessage;
+import org.zstack.header.vm.additions.VmHostFileBackupJob;
 
 import java.util.List;
 
@@ -11,6 +12,7 @@ import java.util.List;
 public class TakeVolumesSnapshotOnKvmMsg extends NeedReplyMessage implements HostMessage {
     private List<TakeSnapshotsOnKvmJobStruct> snapshotJobs;
     private String hostUuid;
+    private List<VmHostFileBackupJob> vmHostFileBackupJobs;
 
     @Override
     public String getHostUuid() {
@@ -28,4 +30,13 @@ public class TakeVolumesSnapshotOnKvmMsg extends NeedReplyMessage implements Hos
     public void setSnapshotJobs(List<TakeSnapshotsOnKvmJobStruct> snapshotJobs) {
         this.snapshotJobs = snapshotJobs;
     }
+
+    public List<VmHostFileBackupJob> getVmHostFileBackupJobs() {
+        return vmHostFileBackupJobs;
+    }
+
+    public void setVmHostFileBackupJobs(List<VmHostFileBackupJob> vmHostFileBackupJobs) {
+        this.vmHostFileBackupJobs = vmHostFileBackupJobs;
+    }
+
 }

--- a/header/src/main/java/org/zstack/header/storage/snapshot/TakeVolumesSnapshotOnKvmReply.java
+++ b/header/src/main/java/org/zstack/header/storage/snapshot/TakeVolumesSnapshotOnKvmReply.java
@@ -9,6 +9,7 @@ import java.util.List;
  */
 public class TakeVolumesSnapshotOnKvmReply extends MessageReply {
     private List<TakeSnapshotsOnKvmResultStruct> snapshotsResults;
+    private String hostBackupTempResourceUuid;
 
     public List<TakeSnapshotsOnKvmResultStruct> getSnapshotsResults() {
         return snapshotsResults;
@@ -16,5 +17,13 @@ public class TakeVolumesSnapshotOnKvmReply extends MessageReply {
 
     public void setSnapshotsResults(List<TakeSnapshotsOnKvmResultStruct> snapshotsResults) {
         this.snapshotsResults = snapshotsResults;
+    }
+
+    public String getHostBackupTempResourceUuid() {
+        return hostBackupTempResourceUuid;
+    }
+
+    public void setHostBackupTempResourceUuid(String hostBackupTempResourceUuid) {
+        this.hostBackupTempResourceUuid = hostBackupTempResourceUuid;
     }
 }

--- a/header/src/main/java/org/zstack/header/vm/additions/VmHostFileBackupJob.java
+++ b/header/src/main/java/org/zstack/header/vm/additions/VmHostFileBackupJob.java
@@ -1,0 +1,36 @@
+package org.zstack.header.vm.additions;
+
+/**
+ * @author Zdream
+ * @date 2026-03-28
+ * @since 0.0.5
+ */
+public class VmHostFileBackupJob {
+    private String srcPath;
+    private String destPath;
+    private String type;
+
+    public String getSrcPath() {
+        return srcPath;
+    }
+
+    public void setSrcPath(String srcPath) {
+        this.srcPath = srcPath;
+    }
+
+    public String getDestPath() {
+        return destPath;
+    }
+
+    public void setDestPath(String destPath) {
+        this.destPath = destPath;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+}

--- a/plugin/kvm/src/main/java/org/zstack/kvm/KVMConstant.java
+++ b/plugin/kvm/src/main/java/org/zstack/kvm/KVMConstant.java
@@ -219,6 +219,25 @@ public interface KVMConstant {
         }
     }
 
+    public static final String NV_RAM_SNAPSHOT_BACKUP_FILE_PATH_FORMAT = "/var/lib/libvirt/qemu/nvram/%s-host-files/%s.fd.snapshot-backup";
+    public static String buildNvramSnapshotBackupFilePath(String vmUuid) {
+        return String.format(NV_RAM_SNAPSHOT_BACKUP_FILE_PATH_FORMAT, vmUuid, vmUuid);
+    }
+
+    public static final String TPM_STATE_SNAPSHOT_BACKUP_FILE_PATH_FORMAT = "/var/lib/libvirt/swtpm/%s.snapshot-backup/";
+    public static String buildTpmStateSnapshotBackupFilePath(String vmUuid) {
+        String vmUuidWithHyphen = vmUuid.replaceFirst("(\\w{8})(\\w{4})(\\w{4})(\\w{4})(\\w{12})", "$1-$2-$3-$4-$5");
+        return String.format(TPM_STATE_SNAPSHOT_BACKUP_FILE_PATH_FORMAT, vmUuidWithHyphen);
+    }
+
+    public static String buildSnapshotBackupPathForVmHostFileType(VmHostFileType type, String vmUuid) {
+        switch (type) {
+            case NvRam: return buildNvramSnapshotBackupFilePath(vmUuid);
+            case TpmState: return buildTpmStateSnapshotBackupFilePath(vmUuid);
+            default: throw new CloudRuntimeException("unsupported VmHostFileType: " + type);
+        }
+    }
+
     public static final String DHCP_BIN_FILE_PATH = "/usr/local/zstack/dnsmasq";
 
     enum KvmVmState {

--- a/plugin/kvm/src/main/java/org/zstack/kvm/efi/KvmSecureBootExtensions.java
+++ b/plugin/kvm/src/main/java/org/zstack/kvm/efi/KvmSecureBootExtensions.java
@@ -26,6 +26,8 @@ import org.zstack.header.tpm.entity.TpmVO;
 import org.zstack.header.tpm.entity.TpmVO_;
 import org.zstack.header.vm.DiskAO;
 import org.zstack.header.vm.PreVmInstantiateResourceExtensionPoint;
+import org.zstack.header.vm.VmInstanceVO;
+import org.zstack.header.vm.VmInstanceVO_;
 import org.zstack.header.vm.VmInstanceConstant;
 import org.zstack.header.vm.AfterReimageVmInstanceExtensionPoint;
 import org.zstack.header.vm.VmInstanceInventory;
@@ -44,6 +46,12 @@ import org.zstack.header.vm.additions.VmHostFileOperation;
 import org.zstack.header.vm.additions.VmHostFileType;
 import org.zstack.header.vm.additions.VmHostFileVO;
 import org.zstack.header.vm.additions.VmHostFileVO_;
+import org.zstack.header.storage.snapshot.ConsistentType;
+import org.zstack.header.storage.snapshot.CreateVolumesSnapshotOverlayInnerMsg;
+import org.zstack.header.storage.snapshot.TakeVolumesSnapshotOnKvmReply;
+import org.zstack.header.storage.snapshot.VolumeSnapshotCreationExtensionPoint;
+import org.zstack.header.storage.snapshot.VolumeSnapshotInventory;
+import org.zstack.header.storage.snapshot.group.VolumeSnapshotGroupInventory;
 import org.zstack.header.volume.VolumeInventory;
 import org.zstack.kvm.KVMAgentCommands;
 import org.zstack.kvm.KVMAgentCommands.*;
@@ -82,7 +90,8 @@ public class KvmSecureBootExtensions implements KVMStartVmExtensionPoint,
         VmPreMigrationExtensionPoint,
         AfterReimageVmInstanceExtensionPoint,
         VmReleaseResourceExtensionPoint,
-        VmInstanceMigrateExtensionPoint {
+        VmInstanceMigrateExtensionPoint,
+        VolumeSnapshotCreationExtensionPoint {
     private static final CLogger logger = Utils.getLogger(KvmSecureBootExtensions.class);
 
     @Autowired
@@ -613,5 +622,87 @@ public class KvmSecureBootExtensions implements KVMStartVmExtensionPoint,
                 completion.done();
             }
         });
+    }
+
+    @Override
+    public void afterVolumeLiveSnapshotGroupCreatedOnBackend(CreateVolumesSnapshotOverlayInnerMsg msg,
+                                                             TakeVolumesSnapshotOnKvmReply treply,
+                                                             Completion completion) {
+        if (treply == null || !treply.isSuccess()) {
+            completion.success();
+            return;
+        }
+
+        if (!msg.isBackupHostFileIfNeeded()) {
+            completion.success();
+            return;
+        }
+
+        String vmUuid = msg.getLockedVmInstanceUuids().get(0);
+        String hostUuid = Q.New(VmInstanceVO.class)
+                .select(VmInstanceVO_.hostUuid)
+                .eq(VmInstanceVO_.uuid, vmUuid)
+                .findValue();
+
+        List<VmHostFileVO> hostFiles = Q.New(VmHostFileVO.class)
+                .eq(VmHostFileVO_.vmInstanceUuid, vmUuid)
+                .eq(VmHostFileVO_.hostUuid, hostUuid)
+                .list();
+
+        if (hostFiles.isEmpty()) {
+            completion.success();
+            return;
+        }
+
+        String tempResourceUuid = Platform.getUuid();
+
+        SyncVmHostFilesFromHostMsg syncMsg = new SyncVmHostFilesFromHostMsg();
+        syncMsg.setVmUuid(vmUuid);
+        syncMsg.setHostUuid(hostUuid);
+
+        for (VmHostFileVO file : hostFiles) {
+            if (file.getType() == VmHostFileType.NvRam) {
+                syncMsg.setNvRamPath(buildNvramSnapshotBackupFilePath(vmUuid));
+            } else if (file.getType() == VmHostFileType.TpmState) {
+                syncMsg.setTpmStateFolder(buildTpmStateSnapshotBackupFilePath(vmUuid));
+            }
+        }
+
+        syncMsg.setSyncReason("snapshot-group-online-backup");
+        syncMsg.setSyncToBackup(true);
+        syncMsg.setBackupResourceUuid(tempResourceUuid);
+        bus.makeLocalServiceId(syncMsg, VmInstanceConstant.SECURE_BOOT_SERVICE_ID);
+        bus.send(syncMsg, new CloudBusCallBack(completion) {
+            @Override
+            public void run(MessageReply reply) {
+                if (reply.isSuccess()) {
+                    treply.setHostBackupTempResourceUuid(tempResourceUuid);
+                    logger.debug(String.format("synced backup host files for vm[uuid:%s] to VmHostBackupFileVO[resourceUuid:%s]",
+                            vmUuid, tempResourceUuid));
+                } else {
+                    logger.warn(String.format("failed to sync backup host files for vm[uuid:%s] during online snapshot, " +
+                            "but tolerated: %s", vmUuid, reply.getError().getReadableDetails()));
+                }
+                completion.success();
+            }
+        });
+    }
+
+    @Override
+    public void afterVolumeLiveSnapshotGroupCreationFailsOnBackend(CreateVolumesSnapshotOverlayInnerMsg msg,
+                                                                    TakeVolumesSnapshotOnKvmReply treply) {
+        // No cleanup needed — backup files on agent side are ephemeral
+    }
+
+    @Override
+    public void afterVolumeSnapshotGroupCreated(VolumeSnapshotGroupInventory snapshotGroup,
+                                                 ConsistentType consistentType,
+                                                 Completion completion) {
+        completion.success();
+    }
+
+    @Override
+    public void afterVolumeSnapshotCreated(VolumeSnapshotInventory snapshot, Completion completion) {
+        completion.success();
     }
 }

--- a/plugin/kvm/src/main/java/org/zstack/kvm/efi/KvmSecureBootManager.java
+++ b/plugin/kvm/src/main/java/org/zstack/kvm/efi/KvmSecureBootManager.java
@@ -44,6 +44,7 @@ import org.zstack.header.vm.additions.VmHostFileType;
 import org.zstack.header.vm.additions.VmHostFileVO;
 import org.zstack.header.vm.additions.VmHostFileVO_;
 import org.zstack.kvm.KVMAgentCommands;
+import org.zstack.kvm.KVMConstant;
 import org.zstack.kvm.KvmCommandSender;
 import org.zstack.kvm.KvmResponseWrapper;
 import org.zstack.resourceconfig.ResourceConfig;
@@ -222,87 +223,15 @@ public class KvmSecureBootManager extends AbstractService {
                     return;
                 }
 
-                final List<VmHostFileVO> existsFiles = Q.New(VmHostFileVO.class)
-                        .eq(VmHostFileVO_.vmInstanceUuid, msg.getVmUuid())
-                        .eq(VmHostFileVO_.hostUuid, msg.getHostUuid())
-                        .in(VmHostFileVO_.path, cmd.getPaths())
-                        .list();
-                final List<String> existsContentUuid;
-                if (!existsFiles.isEmpty()) {
-                    existsContentUuid = Q.New(VmHostFileContentVO.class)
-                            .in(VmHostFileContentVO_.uuid, transform(existsFiles, VmHostFileVO::getUuid))
-                            .select(VmHostFileContentVO_.uuid)
-                            .listValues();
+                ErrorCode error;
+                if (msg.isSyncToBackup()) {
+                    error = syncToBackupFiles(msg, readRsp);
                 } else {
-                    existsContentUuid = Collections.emptyList();
+                    error = syncToHostFiles(msg, cmd, readRsp);
                 }
 
-                List<ErrorCode> errors = new ArrayList<>();
-                for (String path : cmd.getPaths()) {
-                    KVMAgentCommands.VmHostFileTO to = findOneOrNull(readRsp.getHostFiles(), item -> item.getPath().equals(path));
-                    if (to == null) {
-                        continue;
-                    }
-                    if (to.getError() != null) {
-                        errors.add(operr("failed to read file %s", path)
-                                .withOpaque("path", path)
-                                .withException(to.getError()));
-                        continue;
-                    }
-
-                    VmHostFileType type = Objects.equals(path, msg.getNvRamPath()) ?
-                            VmHostFileType.NvRam : VmHostFileType.TpmState;
-
-                    VmHostFileVO file = findOneOrNull(existsFiles, item -> item.getPath().equals(path));
-                    boolean fileExists = file != null;
-
-                    Timestamp now = Timestamp.from(Instant.now());
-                    if (fileExists) {
-                        SQL.New(VmHostFileVO.class)
-                                .eq(VmHostFileVO_.uuid, file.getUuid())
-                                .set(VmHostFileVO_.lastOpDate, now)
-                                .set(VmHostFileVO_.lastSyncReason, msg.getSyncReason())
-                                .update();
-                    } else {
-                        file = new VmHostFileVO();
-                        file.setUuid(Platform.getUuid());
-                        file.setHostUuid(msg.getHostUuid());
-                        file.setVmInstanceUuid(msg.getVmUuid());
-                        file.setPath(path);
-                        file.setType(type);
-                        file.setLastSyncReason(msg.getSyncReason());
-                        file.setCreateDate(now);
-                        file.setLastOpDate(now);
-                        file.setResourceName(String.format("%s file for %s", type, msg.getVmUuid()));
-                        databaseFacade.persist(file);
-                    }
-
-                    byte[] bytes = Base64.getDecoder().decode(to.getContentBase64());
-                    if (existsContentUuid.contains(file.getUuid())) {
-                        SQL.New(VmHostFileContentVO.class)
-                                .eq(VmHostFileContentVO_.uuid, file.getUuid())
-                                .set(VmHostFileContentVO_.content, bytes)
-                                .set(VmHostFileContentVO_.format, VmHostFileContentFormat.valueOf(to.getFileFormat()))
-                                .set(VmHostFileContentVO_.lastOpDate, now)
-                                .update();
-                    } else {
-                        VmHostFileContentVO content = new VmHostFileContentVO();
-                        content.setUuid(file.getUuid());
-                        content.setContent(bytes);
-                        content.setFormat(VmHostFileContentFormat.valueOf(to.getFileFormat()));
-                        content.setCreateDate(now);
-                        content.setLastOpDate(now);
-                        databaseFacade.persist(content);
-                    }
-
-                    if (logger.isTraceEnabled()) {
-                        logger.trace(String.format("persist/update VmHostFileContentVO [uuid=%s]", file.getUuid()));
-                    }
-                }
-
-                if (!errors.isEmpty()) {
-                    reply.setError(operr("failed to read file content from host[uuid=%s]", msg.getHostUuid())
-                            .withCause(errors));
+                if (error != null) {
+                    reply.setError(error);
                 }
                 bus.reply(msg, reply);
             }
@@ -315,6 +244,199 @@ public class KvmSecureBootManager extends AbstractService {
         });
     }
 
+    private ErrorCode syncToHostFiles(SyncVmHostFilesFromHostMsg msg,
+                                      KVMAgentCommands.ReadVmHostFileContentCmd cmd,
+                                      KVMAgentCommands.ReadVmHostFileContentResponse readRsp) {
+        final List<VmHostFileVO> existsFiles = Q.New(VmHostFileVO.class)
+                .eq(VmHostFileVO_.vmInstanceUuid, msg.getVmUuid())
+                .eq(VmHostFileVO_.hostUuid, msg.getHostUuid())
+                .in(VmHostFileVO_.path, cmd.getPaths())
+                .list();
+        final List<String> existsContentUuid;
+        if (!existsFiles.isEmpty()) {
+            existsContentUuid = Q.New(VmHostFileContentVO.class)
+                    .in(VmHostFileContentVO_.uuid, transform(existsFiles, VmHostFileVO::getUuid))
+                    .select(VmHostFileContentVO_.uuid)
+                    .listValues();
+        } else {
+            existsContentUuid = Collections.emptyList();
+        }
+
+        List<ErrorCode> errors = new ArrayList<>();
+        for (String path : cmd.getPaths()) {
+            KVMAgentCommands.VmHostFileTO to = findOneOrNull(readRsp.getHostFiles(), item -> item.getPath().equals(path));
+            if (to == null) {
+                continue;
+            }
+            if (to.getError() != null) {
+                errors.add(operr("failed to read file %s", path)
+                        .withOpaque("path", path)
+                        .withException(to.getError()));
+                continue;
+            }
+
+            VmHostFileType type = Objects.equals(path, msg.getNvRamPath()) ?
+                    VmHostFileType.NvRam : VmHostFileType.TpmState;
+
+            VmHostFileVO file = findOneOrNull(existsFiles, item -> item.getPath().equals(path));
+            boolean fileExists = file != null;
+
+            Timestamp now = Timestamp.from(Instant.now());
+            if (fileExists) {
+                SQL.New(VmHostFileVO.class)
+                        .eq(VmHostFileVO_.uuid, file.getUuid())
+                        .set(VmHostFileVO_.lastOpDate, now)
+                        .set(VmHostFileVO_.lastSyncReason, msg.getSyncReason())
+                        .update();
+            } else {
+                file = new VmHostFileVO();
+                file.setUuid(Platform.getUuid());
+                file.setHostUuid(msg.getHostUuid());
+                file.setVmInstanceUuid(msg.getVmUuid());
+                file.setPath(path);
+                file.setType(type);
+                file.setLastSyncReason(msg.getSyncReason());
+                file.setCreateDate(now);
+                file.setLastOpDate(now);
+                file.setResourceName(String.format("%s file for %s", type, msg.getVmUuid()));
+                databaseFacade.persist(file);
+            }
+
+            byte[] bytes = Base64.getDecoder().decode(to.getContentBase64());
+            if (existsContentUuid.contains(file.getUuid())) {
+                SQL.New(VmHostFileContentVO.class)
+                        .eq(VmHostFileContentVO_.uuid, file.getUuid())
+                        .set(VmHostFileContentVO_.content, bytes)
+                        .set(VmHostFileContentVO_.format, VmHostFileContentFormat.valueOf(to.getFileFormat()))
+                        .set(VmHostFileContentVO_.lastOpDate, now)
+                        .update();
+            } else {
+                VmHostFileContentVO content = new VmHostFileContentVO();
+                content.setUuid(file.getUuid());
+                content.setContent(bytes);
+                content.setFormat(VmHostFileContentFormat.valueOf(to.getFileFormat()));
+                content.setCreateDate(now);
+                content.setLastOpDate(now);
+                databaseFacade.persist(content);
+            }
+
+            if (logger.isTraceEnabled()) {
+                logger.trace(String.format("persist/update VmHostFileContentVO [uuid=%s]", file.getUuid()));
+            }
+        }
+
+        if (errors.isEmpty()) {
+            return null;
+        }
+
+        return operr("failed to read file content from host[uuid=%s]", msg.getHostUuid())
+                .withCause(errors);
+    }
+
+    private ErrorCode syncToBackupFiles(SyncVmHostFilesFromHostMsg msg,
+                                        KVMAgentCommands.ReadVmHostFileContentResponse readRsp) {
+        if (msg.getBackupResourceUuid() == null || msg.getBackupResourceUuid().isEmpty()) {
+            return operr("backupResourceUuid is required when syncToBackup is true");
+        }
+
+        // Query the source VmHostFileVO records for afterBackup callback
+        final List<VmHostFileVO> sourceHostFiles = Q.New(VmHostFileVO.class)
+                .eq(VmHostFileVO_.vmInstanceUuid, msg.getVmUuid())
+                .eq(VmHostFileVO_.hostUuid, msg.getHostUuid())
+                .list();
+
+        List<VmHostBackupFileVO> backupFilesToPersist = new ArrayList<>();
+        List<VmHostFileContentVO> contentsToPersist = new ArrayList<>();
+        Map<VmHostBackupFileVO, VmHostFileVO> backupFromMap = new HashMap<>();
+
+        List<ErrorCode> errors = new ArrayList<>();
+        Timestamp now = Timestamp.from(Instant.now());
+
+        for (KVMAgentCommands.VmHostFileTO to : readRsp.getHostFiles()) {
+            if (to == null) {
+                continue;
+            }
+            if (to.getError() != null) {
+                errors.add(operr("failed to read backup file %s", to.getPath())
+                        .withOpaque("path", to.getPath())
+                        .withException(to.getError()));
+                continue;
+            }
+            if (to.getContentBase64() == null) {
+                errors.add(operr("backup file %s returns empty content", to.getPath())
+                        .withOpaque("path", to.getPath()));
+                continue;
+            }
+
+            VmHostFileType type = VmHostFileType.valueOf(to.getType());
+            String expectPath = KVMConstant.buildSnapshotBackupPathForVmHostFileType(type, msg.getVmUuid());
+            if (!(Objects.equals(to.getPath(), expectPath))) {
+                errors.add(operr("unexpected path %s for backup file type %s", to.getPath(), to.getType())
+                        .withOpaque("path", to.getPath())
+                        .withOpaque("type", to.getType()));
+                continue;
+            }
+
+            VmHostBackupFileVO backupFile = new VmHostBackupFileVO();
+            backupFile.setUuid(Platform.getUuid());
+            backupFile.setResourceUuid(msg.getBackupResourceUuid());
+            backupFile.setType(type);
+            backupFile.setCreateDate(now);
+            backupFile.setLastOpDate(now);
+            backupFilesToPersist.add(backupFile);
+
+            VmHostFileContentVO content = new VmHostFileContentVO();
+            content.setUuid(backupFile.getUuid());
+            content.setContent(Base64.getDecoder().decode(to.getContentBase64()));
+            content.setFormat(VmHostFileContentFormat.valueOf(to.getFileFormat()));
+            content.setCreateDate(now);
+            content.setLastOpDate(now);
+            contentsToPersist.add(content);
+
+            VmHostFileVO sourceFile = findOneOrNull(sourceHostFiles, item -> item.getType() == type);
+            if (sourceFile != null) {
+                backupFromMap.put(backupFile, sourceFile);
+            }
+        }
+
+        new SQLBatch() {
+            @Override
+            protected void scripts() {
+                for (VmHostBackupFileVO bf : backupFilesToPersist) {
+                    sql(VmHostBackupFileVO.class)
+                            .eq(VmHostBackupFileVO_.resourceUuid, bf.getResourceUuid())
+                            .eq(VmHostBackupFileVO_.type, bf.getType())
+                            .delete();
+                }
+
+                if (!backupFilesToPersist.isEmpty()) {
+                    databaseFacade.persistCollection(backupFilesToPersist);
+                }
+                if (!contentsToPersist.isEmpty()) {
+                    databaseFacade.persistCollection(contentsToPersist);
+                }
+            }
+        }.execute();
+
+        for (VmHostBackupFileVO backup : backupFilesToPersist) {
+            VmHostFileVO source = backupFromMap.get(backup);
+            if (source != null) {
+                try {
+                    vmHostFileFactory.createBackupBase(backup).afterBackup(source);
+                } catch (Exception e) {
+                    logger.warn(String.format("failed to execute afterBackup hook for VmHostBackupFileVO[uuid:%s, type:%s]: %s",
+                            backup.getUuid(), backup.getType(), e.getMessage()), e);
+                }
+            }
+        }
+
+        if (errors.isEmpty()) {
+            return null;
+        }
+
+        return operr("failed to read backup file content from host[uuid=%s]", msg.getHostUuid())
+                .withCause(errors);
+    }
 
     @SuppressWarnings("rawtypes")
     private void handle(CloneVmHostFileMsg msg) {

--- a/plugin/kvm/src/main/java/org/zstack/kvm/efi/SyncVmHostFilesFromHostMsg.java
+++ b/plugin/kvm/src/main/java/org/zstack/kvm/efi/SyncVmHostFilesFromHostMsg.java
@@ -8,6 +8,8 @@ public class SyncVmHostFilesFromHostMsg extends NeedReplyMessage {
     private String nvRamPath;
     private String tpmStateFolder;
     private String syncReason;
+    private boolean syncToBackup;
+    private String backupResourceUuid;
 
     public String getHostUuid() {
         return hostUuid;
@@ -47,5 +49,21 @@ public class SyncVmHostFilesFromHostMsg extends NeedReplyMessage {
 
     public void setSyncReason(String syncReason) {
         this.syncReason = syncReason;
+    }
+
+    public boolean isSyncToBackup() {
+        return syncToBackup;
+    }
+
+    public void setSyncToBackup(boolean syncToBackup) {
+        this.syncToBackup = syncToBackup;
+    }
+
+    public String getBackupResourceUuid() {
+        return backupResourceUuid;
+    }
+
+    public void setBackupResourceUuid(String backupResourceUuid) {
+        this.backupResourceUuid = backupResourceUuid;
     }
 }


### PR DESCRIPTION
Add VmHostFileBackupJob class to define VM host file backup tasks.
Add vmHostFileBackupJobs field to TakeVolumesSnapshotOnKvmMsg and
hostBackupTempResourceUuid to TakeVolumesSnapshotOnKvmReply for
tracking backup files during online snapshots. Add snapshot backup
path building methods in KVMConstant. Implement
VolumeSnapshotCreationExtensionPoint in KvmSecureBootExtensions to
backup VM host files after online snapshot. Refactor sync logic in
KvmSecureBootManager to support syncing to backup files. Add
syncToBackup and backupResourceUuid fields to
SyncVmHostFilesFromHostMsg.

Related: ZSV-11310
Resolves: ZSV-11441

Change-Id: I6e6f7062697867706b616b6c7567707771676179

sync from gitlab !9485