### PR TITLE
<fix>[conf]: MySQL timeout is not defined

### DIFF
--- a/conf/springConfigXml/DatabaseFacade.xml
+++ b/conf/springConfigXml/DatabaseFacade.xml
@@ -52,6 +52,7 @@
         <property name="testConnectionOnCheckout" value="${DbFacadeDataSource.testConnectionOnCheckout:true}"/>
         <property name="connectionTesterClassName" value="${DbFacadeDataSource.connectionTesterClassName:org.zstack.core.db.C3p0ConnectionTester}"/>
         <property name="maxIdleTime" value="${ExtraDataSource.maxIdleTime:3600}"/>
+        <property name="checkoutTimeout" value="${ExtraDataSource.checkoutTimeout:5000}"/>
     </bean>
 
     <bean id="entityManagerFactory"


### PR DESCRIPTION
MySQL timeout is not defined，when MySQL stop,
the heartbeat and zstack-hamon hang.

Resolves: ZSTAC-83499

Change-Id: I746a6f696e66696873646c7161766563646f7378

sync from gitlab !9491