### PR TITLE
<feature>[log]: add LongText type for logging long content safely

### DIFF
--- a/core/src/main/java/org/zstack/core/log/LogSafeGson.java
+++ b/core/src/main/java/org/zstack/core/log/LogSafeGson.java
@@ -99,6 +99,10 @@ public class LogSafeGson {
                 return "*****";
             } else if (annotation.type().tag()) {
                 return tagInfoHider.call(raw);
+            } else if (annotation.type().longText()) {
+                if (raw == null)
+                    return null;
+                return (raw.length() < 20) ? raw : raw.substring(0, 10) + "..." + raw.substring(raw.length() - 10);
             } else {
                 return Utils.getLogMaskWords().getOrDefault(raw, uriPattern.matcher(raw).replaceFirst(":*****@"));
             }

--- a/header/src/main/java/org/zstack/header/log/NoLogging.java
+++ b/header/src/main/java/org/zstack/header/log/NoLogging.java
@@ -26,7 +26,9 @@ public @interface NoLogging {
     enum Type {
         Simple,
         Tag,
-        Uri;
+        Uri,
+        LongText,
+        ;
 
         public boolean simple() {
             return this == Simple;
@@ -38,6 +40,10 @@ public @interface NoLogging {
 
         public boolean uri() {
             return this == Uri;
+        }
+
+        public boolean longText() {
+            return this == LongText;
         }
     }
 

--- a/header/src/main/java/org/zstack/header/vm/APITakeVmConsoleScreenshotEvent.java
+++ b/header/src/main/java/org/zstack/header/vm/APITakeVmConsoleScreenshotEvent.java
@@ -1,5 +1,6 @@
 package org.zstack.header.vm;
 
+import org.zstack.header.log.NoLogging;
 import org.zstack.header.message.APIEvent;
 import org.zstack.header.rest.RestResponse;
 
@@ -9,6 +10,7 @@ import org.zstack.header.rest.RestResponse;
  */
 @RestResponse(fieldsTo = {"imageData"})
 public class APITakeVmConsoleScreenshotEvent extends APIEvent {
+    @NoLogging(type = NoLogging.Type.LongText)
     private String imageData;
 
     public APITakeVmConsoleScreenshotEvent() {

--- a/header/src/main/java/org/zstack/header/vm/TakeVmConsoleScreenshotReply.java
+++ b/header/src/main/java/org/zstack/header/vm/TakeVmConsoleScreenshotReply.java
@@ -1,5 +1,6 @@
 package org.zstack.header.vm;
 
+import org.zstack.header.log.NoLogging;
 import org.zstack.header.message.MessageReply;
 
 /**
@@ -7,6 +8,7 @@ import org.zstack.header.message.MessageReply;
  * @date 2023-09-11
  */
 public class TakeVmConsoleScreenshotReply extends MessageReply {
+    @NoLogging(type = NoLogging.Type.LongText)
     private String imageData;
 
     public String getImageData() {

--- a/plugin/kvm/src/main/java/org/zstack/kvm/KVMAgentCommands.java
+++ b/plugin/kvm/src/main/java/org/zstack/kvm/KVMAgentCommands.java
@@ -2844,7 +2844,7 @@ public class KVMAgentCommands {
         /**
          * null if operation is Prepare or Delete
          */
-        @NoLogging
+        @NoLogging(type = NoLogging.Type.LongText)
         private String contentBase64;
         private String error;
 
@@ -4760,6 +4760,7 @@ public class KVMAgentCommands {
     }
 
     public static class TakeVmConsoleScreenshotRsp extends AgentResponse {
+        @NoLogging(type = NoLogging.Type.LongText)
         private String imageData;
 
         public String getImageData() {


### PR DESCRIPTION
Add LongText type to NoLogging annotation to handle long content
like base64-encoded image data in logs. When content length >= 20
characters, only show first 10 and last 10 characters with ... in
between to improve log readability.

Applied to:
- APITakeVmConsoleScreenshotEvent.imageData
- TakeVmConsoleScreenshotReply.imageData
- KVMAgentCommands.VmHostFileTO.contentBase64
- KVMAgentCommands.TakeVmConsoleScreenshotRsp.imageData

Related: ZSV-11310
Resolves: ZSV-11443

Change-Id: I747a68626a717563727373767975647863786977

sync from gitlab !9528