### PR TITLE
<refactor>[kvm]: extract NvRam preparation logic before migration

### DIFF
--- a/plugin/kvm/src/main/java/org/zstack/kvm/efi/KvmSecureBootExtensions.java
+++ b/plugin/kvm/src/main/java/org/zstack/kvm/efi/KvmSecureBootExtensions.java
@@ -163,12 +163,21 @@ public class KvmSecureBootExtensions implements KVMStartVmExtensionPoint,
     }
 
     @Override
+    public void preMigrateVm(VmInstanceInventory inv, String destHostUuid, Completion completion) {
+        completion.success(); // use preVmMigration instead of preMigrateVm to prevent from handle twice
+    }
+
+    @Override
     public void preVmMigration(VmInstanceInventory vm, VmMigrationType type, String dstHostUuid, Completion completion) {
         if (HostMigration != type && PrimaryStorageMigration != type) {
             completion.success();
             return;
         }
 
+        prepareNvRamBeforeMigration(vm, dstHostUuid, completion);
+    }
+
+    private void prepareNvRamBeforeMigration(VmInstanceInventory vm, String dstHostUuid, Completion completion) {
         if (dstHostUuid == null) {
             completion.success();
             return;


### PR DESCRIPTION
Extract NvRam preparation logic into a separate method to
handle both preMigrateVm and preVmMigration scenarios.
This ensures consistent NvRam setup before any VM migration
operations, preventing potential issues with EFI NvRam
state transfer between hosts.

Resolves: ZSV-11524
Related: ZSV-11430
Related: ZSV-11310

Change-Id: I6e736c676b726a776f7961756b6f636f6b797369

sync from gitlab !9545