### PR TITLE
<fix>[sdk]: align sdk and tests

### DIFF
--- a/sdk/src/main/java/SourceClassMap.java
+++ b/sdk/src/main/java/SourceClassMap.java
@@ -71,6 +71,7 @@ public class SourceClassMap {
 			put("org.zstack.crypto.ccs.CCSCertificateAccountRefInventory", "org.zstack.sdk.CCSCertificateAccountRefInventory");
 			put("org.zstack.crypto.ccs.CCSCertificateInventory", "org.zstack.sdk.CCSCertificateInventory");
 			put("org.zstack.crypto.keyprovider.api.RekeyFailedResource", "org.zstack.sdk.keyprovider.api.RekeyFailedResource");
+			put("org.zstack.crypto.keyprovider.api.RekeyProviderResult", "org.zstack.sdk.keyprovider.api.RekeyProviderResult");
 			put("org.zstack.crypto.keyprovider.api.RekeySkippedResource", "org.zstack.sdk.keyprovider.api.RekeySkippedResource");
 			put("org.zstack.crypto.securitymachine.thirdparty.aisino.AiSiNoSecretResourcePoolInventory", "org.zstack.sdk.AiSiNoSecretResourcePoolInventory");
 			put("org.zstack.crypto.securitymachine.thirdparty.flkSec.FlkSecSecretResourcePoolInventory", "org.zstack.sdk.FlkSecSecretResourcePoolInventory");
@@ -1269,6 +1270,7 @@ public class SourceClassMap {
 			put("org.zstack.sdk.identity.role.RoleAccountRefInventory", "org.zstack.header.identity.role.RoleAccountRefInventory");
 			put("org.zstack.sdk.identity.role.RoleInventory", "org.zstack.header.identity.role.RoleInventory");
 			put("org.zstack.sdk.keyprovider.api.RekeyFailedResource", "org.zstack.crypto.keyprovider.api.RekeyFailedResource");
+			put("org.zstack.sdk.keyprovider.api.RekeyProviderResult", "org.zstack.crypto.keyprovider.api.RekeyProviderResult");
 			put("org.zstack.sdk.keyprovider.api.RekeySkippedResource", "org.zstack.crypto.keyprovider.api.RekeySkippedResource");
 			put("org.zstack.sdk.license.entity.LicenseHistoryInventory", "org.zstack.license.entity.LicenseHistoryInventory");
 			put("org.zstack.sdk.license.entity.LicenseUsageView", "org.zstack.license.entity.LicenseUsageView");

--- a/sdk/src/main/java/org/zstack/sdk/keyprovider/api/RekeyKeyProviderRefsResult.java
+++ b/sdk/src/main/java/org/zstack/sdk/keyprovider/api/RekeyKeyProviderRefsResult.java
@@ -35,20 +35,12 @@ public class RekeyKeyProviderRefsResult {
         return this.failedCount;
     }
 
-    public java.util.List skippedResources;
-    public void setSkippedResources(java.util.List skippedResources) {
-        this.skippedResources = skippedResources;
+    public java.util.List providerResults;
+    public void setProviderResults(java.util.List providerResults) {
+        this.providerResults = providerResults;
     }
-    public java.util.List getSkippedResources() {
-        return this.skippedResources;
-    }
-
-    public java.util.List failedResources;
-    public void setFailedResources(java.util.List failedResources) {
-        this.failedResources = failedResources;
-    }
-    public java.util.List getFailedResources() {
-        return this.failedResources;
+    public java.util.List getProviderResults() {
+        return this.providerResults;
     }
 
 }

--- a/sdk/src/main/java/org/zstack/sdk/keyprovider/api/RekeyProviderResult.java
+++ b/sdk/src/main/java/org/zstack/sdk/keyprovider/api/RekeyProviderResult.java
@@ -1,0 +1,71 @@
+package org.zstack.sdk.keyprovider.api;
+
+
+
+public class RekeyProviderResult  {
+
+    public java.lang.String providerUuid;
+    public void setProviderUuid(java.lang.String providerUuid) {
+        this.providerUuid = providerUuid;
+    }
+    public java.lang.String getProviderUuid() {
+        return this.providerUuid;
+    }
+
+    public java.lang.String providerName;
+    public void setProviderName(java.lang.String providerName) {
+        this.providerName = providerName;
+    }
+    public java.lang.String getProviderName() {
+        return this.providerName;
+    }
+
+    public int totalRefCount;
+    public void setTotalRefCount(int totalRefCount) {
+        this.totalRefCount = totalRefCount;
+    }
+    public int getTotalRefCount() {
+        return this.totalRefCount;
+    }
+
+    public int successRefCount;
+    public void setSuccessRefCount(int successRefCount) {
+        this.successRefCount = successRefCount;
+    }
+    public int getSuccessRefCount() {
+        return this.successRefCount;
+    }
+
+    public int skippedRefCount;
+    public void setSkippedRefCount(int skippedRefCount) {
+        this.skippedRefCount = skippedRefCount;
+    }
+    public int getSkippedRefCount() {
+        return this.skippedRefCount;
+    }
+
+    public int failedRefCount;
+    public void setFailedRefCount(int failedRefCount) {
+        this.failedRefCount = failedRefCount;
+    }
+    public int getFailedRefCount() {
+        return this.failedRefCount;
+    }
+
+    public java.util.List skippedResources;
+    public void setSkippedResources(java.util.List skippedResources) {
+        this.skippedResources = skippedResources;
+    }
+    public java.util.List getSkippedResources() {
+        return this.skippedResources;
+    }
+
+    public java.util.List failedResources;
+    public void setFailedResources(java.util.List failedResources) {
+        this.failedResources = failedResources;
+    }
+    public java.util.List getFailedResources() {
+        return this.failedResources;
+    }
+
+}


### PR DESCRIPTION
Sync SDK rekey result schema to providerResults
and add RekeyProviderResult model. Update premium
rekey test assertions for provider-level counts
and unbound-provider split behavior.

Resolves: ZSV-11757

Change-Id: I68676e706f6a786773627074636f6e6a617a6e44

sync from gitlab !9568