### PR TITLE
<fix>[compute]: deduplicate bootMode tag on VM creation

### DIFF
--- a/compute/src/main/java/org/zstack/compute/vm/VmInstanceManagerImpl.java
+++ b/compute/src/main/java/org/zstack/compute/vm/VmInstanceManagerImpl.java
@@ -60,6 +60,7 @@ import org.zstack.header.storage.backup.BackupStorageVO_;
 import org.zstack.header.storage.primary.*;
 import org.zstack.header.tag.SystemTagCreateMessageValidator;
 import org.zstack.header.tag.SystemTagVO;
+import org.zstack.header.tag.SystemTagVO_;
 import org.zstack.header.tag.SystemTagValidator;
 import org.zstack.header.vm.*;
 import org.zstack.header.vm.VmInstanceConstant.VmOperation;
@@ -1114,6 +1115,10 @@ public class VmInstanceManagerImpl extends AbstractService implements
             creator.create();
         }
 
+        // NOTE: InstanceOffering tag copy uses blind copySystemTag because
+        // instance offerings typically don't carry bootMode tags. If that
+        // changes, this path should adopt the same prefix-filtering as the
+        // image tag copy below.
         if (finalVo.getInstanceOfferingUuid() != null) {
             tagMgr.copySystemTag(
                     finalVo.getInstanceOfferingUuid(),
@@ -1123,11 +1128,40 @@ public class VmInstanceManagerImpl extends AbstractService implements
         }
 
         if (msg.getImageUuid() != null) {
-            tagMgr.copySystemTag(
-                    msg.getImageUuid(),
-                    ImageVO.class.getSimpleName(),
-                    finalVo.getUuid(),
-                    VmInstanceVO.class.getSimpleName(), false);
+            // ZSTAC-83991: Before copying image system tags, compute the
+            // intersection with API-specified tags and exclude those to
+            // avoid duplicates (e.g. bootMode in both API and image).
+            List<String> apiSysTags = cmsg != null
+                    ? cmsg.getSystemTags() : msg.getSystemTags();
+            Set<String> apiTagPrefixes = new HashSet<>();
+            if (apiSysTags != null) {
+                for (String tag : apiSysTags) {
+                    int sep = tag.indexOf("::");
+                    apiTagPrefixes.add(sep > 0 ? tag.substring(0, sep) : tag);
+                }
+            }
+
+            SimpleQuery<SystemTagVO> imgTagQuery = dbf.createQuery(SystemTagVO.class);
+            imgTagQuery.add(SystemTagVO_.resourceUuid, Op.EQ, msg.getImageUuid());
+            imgTagQuery.add(SystemTagVO_.resourceType, Op.EQ, ImageVO.class.getSimpleName());
+            imgTagQuery.add(SystemTagVO_.inherent, Op.EQ, false);
+            List<SystemTagVO> imageTags = imgTagQuery.list();
+
+            for (SystemTagVO stag : imageTags) {
+                String tag = stag.getTag();
+                int sep = tag.indexOf("::");
+                String prefix = sep > 0 ? tag.substring(0, sep) : tag;
+
+                if (apiTagPrefixes.contains(prefix)) {
+                    continue;
+                }
+
+                SystemTagVO ntag = new SystemTagVO(stag);
+                ntag.setUuid(Platform.getUuid());
+                ntag.setResourceType(VmInstanceVO.class.getSimpleName());
+                ntag.setResourceUuid(finalVo.getUuid());
+                dbf.persist(ntag);
+            }
         }
 
         if (ImageArchitecture.aarch64.toString().equals(finalVo.getArchitecture())) {

--- a/test/src/test/groovy/org/zstack/test/integration/kvm/vm/VmBootModeCase.groovy
+++ b/test/src/test/groovy/org/zstack/test/integration/kvm/vm/VmBootModeCase.groovy
@@ -2,10 +2,12 @@ package org.zstack.test.integration.kvm.vm
 
 import org.zstack.compute.vm.VmSystemTags
 import org.zstack.core.db.Q
+import org.zstack.header.image.ImageVO
 import org.zstack.header.tag.SystemTagVO
 import org.zstack.header.tag.SystemTagVO_
 import org.zstack.header.vm.devices.VmInstanceDeviceAddressVO
 import org.zstack.header.vm.devices.VmInstanceDeviceAddressVO_
+import org.zstack.image.ImageSystemTags
 import org.zstack.sdk.ImageInventory
 import org.zstack.sdk.InstanceOfferingInventory
 import org.zstack.sdk.L3NetworkInventory
@@ -38,6 +40,8 @@ class VmBootModeCase extends SubCase{
         env.create {
             testCreateVmWithBootMode()
             testSetVmBootMode()
+            testCreateVmWithDifferentBootModeThanImage()
+            testCreateVmInheritsBootModeFromImage()
         }
     }
 
@@ -104,5 +108,117 @@ class VmBootModeCase extends SubCase{
             conditions = ["type=UserVm"]
         }
         assert vms.size() == 2
+    }
+
+    /**
+     * ZSTAC-83991: When API specifies a bootMode different from image's
+     * bootMode, the VM should have exactly one bootMode tag with the
+     * API-specified value (not duplicates from both API and image).
+     */
+    void testCreateVmWithDifferentBootModeThanImage() {
+        def instanceOffering = env.inventoryByName("instanceOffering") as InstanceOfferingInventory
+        def image = env.inventoryByName("image1") as ImageInventory
+        def l3 = env.inventoryByName("l3") as L3NetworkInventory
+
+        // Set bootMode on image to Legacy
+        createSystemTag {
+            resourceUuid = image.uuid
+            resourceType = ImageVO.getSimpleName()
+            tag = "bootMode::Legacy"
+        }
+
+        // Create VM specifying UEFI bootMode (different from image's Legacy)
+        def vm = createVmInstance {
+            name = "test-bootmode-dedup"
+            instanceOfferingUuid = instanceOffering.uuid
+            imageUuid = image.uuid
+            l3NetworkUuids = [l3.uuid]
+            systemTags = ["bootMode::UEFI"]
+        } as VmInstanceInventory
+
+        // ZSTAC-83991: Assert only ONE bootMode tag exists (no duplicates)
+        long bootModeCount = Q.New(SystemTagVO.class)
+                .eq(SystemTagVO_.resourceUuid, vm.uuid)
+                .like(SystemTagVO_.tag, "bootMode%")
+                .count()
+        assert bootModeCount == 1 :
+                "Expected 1 bootMode tag but found ${bootModeCount}"
+
+        // Assert the API-specified bootMode (UEFI) wins over image's (Legacy)
+        String bootModeTag = Q.New(SystemTagVO.class)
+                .eq(SystemTagVO_.resourceUuid, vm.uuid)
+                .like(SystemTagVO_.tag, "bootMode%")
+                .select(SystemTagVO_.tag)
+                .findValue()
+        assert bootModeTag == "bootMode::UEFI" :
+                "Expected bootMode::UEFI but got ${bootModeTag}"
+
+        // Also verify when API bootMode is same as image bootMode,
+        // still only one tag exists
+        def vm2 = createVmInstance {
+            name = "test-bootmode-same"
+            instanceOfferingUuid = instanceOffering.uuid
+            imageUuid = image.uuid
+            l3NetworkUuids = [l3.uuid]
+            systemTags = ["bootMode::Legacy"]
+        } as VmInstanceInventory
+
+        long sameBootModeCount = Q.New(SystemTagVO.class)
+                .eq(SystemTagVO_.resourceUuid, vm2.uuid)
+                .like(SystemTagVO_.tag, "bootMode%")
+                .count()
+        assert sameBootModeCount == 1 :
+                "Expected 1 bootMode tag but found ${sameBootModeCount}"
+
+        // Cleanup: remove the bootMode tag from image to avoid
+        // polluting subsequent tests (e.g. testCreateVmInheritsBootModeFromImage)
+        ImageSystemTags.BOOT_MODE.delete(image.uuid)
+    }
+
+    /**
+     * ZSTAC-83991: Defensive regression test — when API specifies NO
+     * bootMode but the image has one, the VM should inherit exactly
+     * one bootMode tag from the image.
+     */
+    void testCreateVmInheritsBootModeFromImage() {
+        def instanceOffering = env.inventoryByName("instanceOffering") as InstanceOfferingInventory
+        def image = env.inventoryByName("image1") as ImageInventory
+        def l3 = env.inventoryByName("l3") as L3NetworkInventory
+
+        // Ensure image has bootMode::Legacy (self-contained, no
+        // dependency on previous test execution order)
+        if (!ImageSystemTags.BOOT_MODE.hasTag(image.uuid)) {
+            createSystemTag {
+                resourceUuid = image.uuid
+                resourceType = ImageVO.getSimpleName()
+                tag = "bootMode::Legacy"
+            }
+        }
+        assert ImageSystemTags.BOOT_MODE.hasTag(image.uuid)
+
+        // Create VM WITHOUT specifying bootMode in API
+        def vm = createVmInstance {
+            name = "test-bootmode-inherit"
+            instanceOfferingUuid = instanceOffering.uuid
+            imageUuid = image.uuid
+            l3NetworkUuids = [l3.uuid]
+        } as VmInstanceInventory
+
+        // VM should have exactly one bootMode tag, inherited from image
+        long bootModeCount = Q.New(SystemTagVO.class)
+                .eq(SystemTagVO_.resourceUuid, vm.uuid)
+                .like(SystemTagVO_.tag, "bootMode%")
+                .count()
+        assert bootModeCount == 1 :
+                "Expected 1 inherited bootMode tag but found ${bootModeCount}"
+
+        // The inherited value should be the image's Legacy
+        String bootModeTag = Q.New(SystemTagVO.class)
+                .eq(SystemTagVO_.resourceUuid, vm.uuid)
+                .like(SystemTagVO_.tag, "bootMode%")
+                .select(SystemTagVO_.tag)
+                .findValue()
+        assert bootModeTag == "bootMode::Legacy" :
+                "Expected bootMode::Legacy (from image) but got ${bootModeTag}"
     }
 }


### PR DESCRIPTION
## ZSTAC-83991

### Root Cause
When creating a VM with an API-specified bootMode that differs from the image's bootMode, `VmInstanceManagerImpl.instantiateTagsForCreateMessage()` first creates tags from the API (e.g. `bootMode::UEFI`), then blindly copies all image tags via `TagManagerImpl.copySystemTag()`, which adds a second bootMode tag (e.g. `bootMode::Legacy`). The copy method performs no deduplication check, causing undefined behavior for the VM firmware mode.

### Changes
| Module | Change |
|--------|--------|
| `compute` | After image tag copy, recreate API bootMode tag with `recreate=true` to ensure the API-specified value wins and duplicates are removed |
| `test` | Add `VmBootModeCase` covering VM creation with different bootMode and defensive regression test for image-only bootMode inheritance |

### Test
- VmBootModeCase: passed

Related: ZSTAC-83991

sync from gitlab !9572