### PR TITLE
<fix>[compute]: deduplicate bootMode tag on VM creation

### DIFF
--- a/compute/src/main/java/org/zstack/compute/vm/VmInstanceManagerImpl.java
+++ b/compute/src/main/java/org/zstack/compute/vm/VmInstanceManagerImpl.java
@@ -1128,6 +1128,24 @@ public class VmInstanceManagerImpl extends AbstractService implements
                     ImageVO.class.getSimpleName(),
                     finalVo.getUuid(),
                     VmInstanceVO.class.getSimpleName(), false);
+
+            // ZSTAC-83991: copySystemTag blindly copies all image tags
+            // including bootMode, which may duplicate the API-specified
+            // bootMode. Use recreate to ensure only one bootMode tag.
+            List<String> apiSysTags = cmsg != null ? cmsg.getSystemTags() : msg.getSystemTags();
+            if (apiSysTags != null) {
+                apiSysTags.stream()
+                        .filter(VmSystemTags.BOOT_MODE::isMatch)
+                        .findFirst()
+                        .ifPresent(bootModeTag -> {
+                            String bootMode = VmSystemTags.BOOT_MODE.getTokenByTag(
+                                    bootModeTag, VmSystemTags.BOOT_MODE_TOKEN);
+                            SystemTagCreator c = VmSystemTags.BOOT_MODE.newSystemTagCreator(finalVo.getUuid());
+                            c.setTagByTokens(Collections.singletonMap(VmSystemTags.BOOT_MODE_TOKEN, bootMode));
+                            c.recreate = true;
+                            c.create();
+                        });
+            }
         }
 
         if (ImageArchitecture.aarch64.toString().equals(finalVo.getArchitecture())) {

--- a/test/src/test/groovy/org/zstack/test/integration/kvm/vm/VmBootModeCase.groovy
+++ b/test/src/test/groovy/org/zstack/test/integration/kvm/vm/VmBootModeCase.groovy
@@ -2,10 +2,12 @@ package org.zstack.test.integration.kvm.vm
 
 import org.zstack.compute.vm.VmSystemTags
 import org.zstack.core.db.Q
+import org.zstack.header.image.ImageVO
 import org.zstack.header.tag.SystemTagVO
 import org.zstack.header.tag.SystemTagVO_
 import org.zstack.header.vm.devices.VmInstanceDeviceAddressVO
 import org.zstack.header.vm.devices.VmInstanceDeviceAddressVO_
+import org.zstack.image.ImageSystemTags
 import org.zstack.sdk.ImageInventory
 import org.zstack.sdk.InstanceOfferingInventory
 import org.zstack.sdk.L3NetworkInventory
@@ -38,6 +40,8 @@ class VmBootModeCase extends SubCase{
         env.create {
             testCreateVmWithBootMode()
             testSetVmBootMode()
+            testCreateVmWithDifferentBootModeThanImage()
+            testCreateVmInheritsBootModeFromImage()
         }
     }
 
@@ -104,5 +108,117 @@ class VmBootModeCase extends SubCase{
             conditions = ["type=UserVm"]
         }
         assert vms.size() == 2
+    }
+
+    /**
+     * ZSTAC-83991: When API specifies a bootMode different from image's
+     * bootMode, the VM should have exactly one bootMode tag with the
+     * API-specified value (not duplicates from both API and image).
+     */
+    void testCreateVmWithDifferentBootModeThanImage() {
+        def instanceOffering = env.inventoryByName("instanceOffering") as InstanceOfferingInventory
+        def image = env.inventoryByName("image1") as ImageInventory
+        def l3 = env.inventoryByName("l3") as L3NetworkInventory
+
+        // Set bootMode on image to Legacy
+        createSystemTag {
+            resourceUuid = image.uuid
+            resourceType = ImageVO.getSimpleName()
+            tag = "bootMode::Legacy"
+        }
+
+        // Create VM specifying UEFI bootMode (different from image's Legacy)
+        def vm = createVmInstance {
+            name = "test-bootmode-dedup"
+            instanceOfferingUuid = instanceOffering.uuid
+            imageUuid = image.uuid
+            l3NetworkUuids = [l3.uuid]
+            systemTags = ["bootMode::UEFI"]
+        } as VmInstanceInventory
+
+        // ZSTAC-83991: Assert only ONE bootMode tag exists (no duplicates)
+        long bootModeCount = Q.New(SystemTagVO.class)
+                .eq(SystemTagVO_.resourceUuid, vm.uuid)
+                .like(SystemTagVO_.tag, "bootMode%")
+                .count()
+        assert bootModeCount == 1 :
+                "Expected 1 bootMode tag but found ${bootModeCount}"
+
+        // Assert the API-specified bootMode (UEFI) wins over image's (Legacy)
+        String bootModeTag = Q.New(SystemTagVO.class)
+                .eq(SystemTagVO_.resourceUuid, vm.uuid)
+                .like(SystemTagVO_.tag, "bootMode%")
+                .select(SystemTagVO_.tag)
+                .findValue()
+        assert bootModeTag == "bootMode::UEFI" :
+                "Expected bootMode::UEFI but got ${bootModeTag}"
+
+        // Also verify when API bootMode is same as image bootMode,
+        // still only one tag exists
+        def vm2 = createVmInstance {
+            name = "test-bootmode-same"
+            instanceOfferingUuid = instanceOffering.uuid
+            imageUuid = image.uuid
+            l3NetworkUuids = [l3.uuid]
+            systemTags = ["bootMode::Legacy"]
+        } as VmInstanceInventory
+
+        long sameBootModeCount = Q.New(SystemTagVO.class)
+                .eq(SystemTagVO_.resourceUuid, vm2.uuid)
+                .like(SystemTagVO_.tag, "bootMode%")
+                .count()
+        assert sameBootModeCount == 1 :
+                "Expected 1 bootMode tag but found ${sameBootModeCount}"
+
+        // Cleanup: remove the bootMode tag from image to avoid
+        // polluting subsequent tests (e.g. testCreateVmInheritsBootModeFromImage)
+        ImageSystemTags.BOOT_MODE.delete(image.uuid)
+    }
+
+    /**
+     * ZSTAC-83991: Defensive regression test — when API specifies NO
+     * bootMode but the image has one, the VM should inherit exactly
+     * one bootMode tag from the image.
+     */
+    void testCreateVmInheritsBootModeFromImage() {
+        def instanceOffering = env.inventoryByName("instanceOffering") as InstanceOfferingInventory
+        def image = env.inventoryByName("image1") as ImageInventory
+        def l3 = env.inventoryByName("l3") as L3NetworkInventory
+
+        // Ensure image has bootMode::Legacy (self-contained, no
+        // dependency on previous test execution order)
+        if (!ImageSystemTags.BOOT_MODE.hasTag(image.uuid)) {
+            createSystemTag {
+                resourceUuid = image.uuid
+                resourceType = ImageVO.getSimpleName()
+                tag = "bootMode::Legacy"
+            }
+        }
+        assert ImageSystemTags.BOOT_MODE.hasTag(image.uuid)
+
+        // Create VM WITHOUT specifying bootMode in API
+        def vm = createVmInstance {
+            name = "test-bootmode-inherit"
+            instanceOfferingUuid = instanceOffering.uuid
+            imageUuid = image.uuid
+            l3NetworkUuids = [l3.uuid]
+        } as VmInstanceInventory
+
+        // VM should have exactly one bootMode tag, inherited from image
+        long bootModeCount = Q.New(SystemTagVO.class)
+                .eq(SystemTagVO_.resourceUuid, vm.uuid)
+                .like(SystemTagVO_.tag, "bootMode%")
+                .count()
+        assert bootModeCount == 1 :
+                "Expected 1 inherited bootMode tag but found ${bootModeCount}"
+
+        // The inherited value should be the image's Legacy
+        String bootModeTag = Q.New(SystemTagVO.class)
+                .eq(SystemTagVO_.resourceUuid, vm.uuid)
+                .like(SystemTagVO_.tag, "bootMode%")
+                .select(SystemTagVO_.tag)
+                .findValue()
+        assert bootModeTag == "bootMode::Legacy" :
+                "Expected bootMode::Legacy (from image) but got ${bootModeTag}"
     }
 }


### PR DESCRIPTION
## ZSTAC-83991

### Root Cause
When creating a VM with an API-specified bootMode that differs from the image's bootMode, `VmInstanceManagerImpl.instantiateTagsForCreateMessage()` first creates tags from the API (e.g. `bootMode::UEFI`), then blindly copies all image tags via `TagManagerImpl.copySystemTag()`, which adds a second bootMode tag (e.g. `bootMode::Legacy`). The copy method performs no deduplication check, causing undefined behavior for the VM firmware mode.

### Changes
| Module | Change |
|--------|--------|
| `compute` | After image tag copy, use `PatternedSystemTag.newSystemTagCreator` with `recreate=true` to delete all existing bootMode tags and recreate with the API-specified value, ensuring only one bootMode tag exists on the VM |
| `test` | Add `VmBootModeCase` with tests for VM creation with different bootMode and defensive regression test for image-only bootMode inheritance |

### Test
- VmBootModeCase: passed

Related: ZSTAC-83991

sync from gitlab !9580