### PR TITLE
<fix>[kvm]: fix NPE in VmHostFileTracker sync

### DIFF
--- a/plugin/kvm/src/main/java/org/zstack/kvm/vmfiles/VmHostFileTracker.java
+++ b/plugin/kvm/src/main/java/org/zstack/kvm/vmfiles/VmHostFileTracker.java
@@ -269,7 +269,8 @@ public class VmHostFileTracker implements Component {
                 // check if force sync is needed based on lastSyncDate
                 Timestamp oldestLastSync = group.stream()
                         .map(VmHostFileVO::getLastSyncDate)
-                        .min(Comparator.nullsFirst(Comparator.naturalOrder()))
+                        .filter(Objects::nonNull)
+                        .min(Comparator.naturalOrder())
                         .orElse(null);
 
                 if (oldestLastSync != null && (now - oldestLastSync.getTime()) < forceSyncThresholdMs) {


### PR DESCRIPTION
When all getLastSyncDate() values in the stream are null, the
min() operation with Comparator.nullsFirst() throws NPE
because Optional.of() doesn't accept null. Filter null values
before calling min() to avoid this issue.

Resolves: ZSV-11371
Related: ZSV-11310

Change-Id: I646a65776a717465636e75616c70746763727862

sync from gitlab !9583