### PR TITLE
<fix>[kvm]: disable host status check when syncing VM host files

### DIFF
--- a/plugin/kvm/src/main/java/org/zstack/kvm/KvmCommandSender.java
+++ b/plugin/kvm/src/main/java/org/zstack/kvm/KvmCommandSender.java
@@ -69,6 +69,11 @@ public class KvmCommandSender {
         DebugUtils.Assert(hostUuid != null, "hostUuid cannot be null");
     }
 
+    public KvmCommandSender disableHostStatusCheck() {
+        this.noStatusCheck = true;
+        return this;
+    }
+
     public void send(final Object cmd, final String path, final KvmCommandFailureChecker checker, final SteppingSendCallback<KvmResponseWrapper> completion) {
         List<KVMHostAsyncHttpCallMsg> msgs = hostUuids.stream().map(huuid -> {
             KVMHostAsyncHttpCallMsg msg = new KVMHostAsyncHttpCallMsg();

--- a/plugin/kvm/src/main/java/org/zstack/kvm/efi/KvmSecureBootManager.java
+++ b/plugin/kvm/src/main/java/org/zstack/kvm/efi/KvmSecureBootManager.java
@@ -204,7 +204,8 @@ public class KvmSecureBootManager extends AbstractService {
     }
 
     private void handle(SyncVmHostFilesFromHostMsg msg) {
-        KvmCommandSender sender = new KvmCommandSender(msg.getHostUuid());
+        KvmCommandSender sender = new KvmCommandSender(msg.getHostUuid())
+                .disableHostStatusCheck();
 
         KVMAgentCommands.ReadVmHostFileContentCmd cmd = new KVMAgentCommands.ReadVmHostFileContentCmd();
         cmd.setHostFiles(new ArrayList<>());


### PR DESCRIPTION
Add disableHostStatusCheck() method to KvmCommandSender
to allow skipping host status validation. Apply it in
KvmSecureBootManager when syncing VM host files, so the
sync can proceed regardless of host connection state.

Resolves: ZSV-11767
Related: ZSV-11310

Change-Id: I6c68756c7378636a6c6669656869717077716268

sync from gitlab !9591