### PR TITLE
<fix>[kvm]: use resource config in TLS cert update skip

### DIFF
--- a/plugin/kvm/src/main/java/org/zstack/kvm/KVMAgentCommands.java
+++ b/plugin/kvm/src/main/java/org/zstack/kvm/KVMAgentCommands.java
@@ -455,23 +455,6 @@ public class KVMAgentCommands {
     public static class HostFactCmd extends AgentCommand {
     }
 
-    public static class UpdateTlsCertCmd extends AgentCommand implements Serializable {
-        private String caCert;
-        @NoLogging
-        private String caKey;
-        private String certIps;
-
-        public String getCaCert() { return caCert; }
-        public void setCaCert(String caCert) { this.caCert = caCert; }
-        public String getCaKey() { return caKey; }
-        public void setCaKey(String caKey) { this.caKey = caKey; }
-        public String getCertIps() { return certIps; }
-        public void setCertIps(String certIps) { this.certIps = certIps; }
-    }
-
-    public static class UpdateTlsCertResponse extends AgentResponse {
-    }
-
     public static class HostFactResponse extends AgentResponse {
         @GrayVersion(value = "5.0.0")
         private String osDistribution;

--- a/plugin/kvm/src/main/java/org/zstack/kvm/KVMConstant.java
+++ b/plugin/kvm/src/main/java/org/zstack/kvm/KVMConstant.java
@@ -81,7 +81,7 @@ public interface KVMConstant {
     String KVM_DELETE_CONSOLE_FIREWALL_PATH = "/vm/console/deletefirewall";
     String KVM_UPDATE_HOST_OS_PATH = "/host/updateos";
     String KVM_HOST_UPDATE_DEPENDENCY_PATH = "/host/updatedependency";
-    String KVM_UPDATE_TLS_CERT_PATH = "/host/updatetlscert";
+
     String HOST_SHUTDOWN = "/host/shutdown";
     String HOST_REBOOT = "/host/reboot";
     String HOST_UPDATE_SPICE_CHANNEL_CONFIG_PATH = "/host/updateSpiceChannelConfig";

--- a/plugin/kvm/src/main/java/org/zstack/kvm/KVMHost.java
+++ b/plugin/kvm/src/main/java/org/zstack/kvm/KVMHost.java
@@ -196,7 +196,6 @@ public class KVMHost extends HostBase implements Host {
     private String checkSnapshotPath;
     private String mergeSnapshotPath;
     private String hostFactPath;
-    private String updateTlsCertPath;
     private String hostCheckFilePath;
     private String attachIsoPath;
     private String detachIsoPath;
@@ -329,10 +328,6 @@ public class KVMHost extends HostBase implements Host {
         ub = UriComponentsBuilder.fromHttpUrl(baseUrl);
         ub.path(KVMConstant.KVM_HOST_FACT_PATH);
         hostFactPath = ub.build().toString();
-
-        ub = UriComponentsBuilder.fromHttpUrl(baseUrl);
-        ub.path(KVMConstant.KVM_UPDATE_TLS_CERT_PATH);
-        updateTlsCertPath = ub.build().toString();
 
         ub = UriComponentsBuilder.fromHttpUrl(baseUrl);
         ub.path(KVMConstant.KVM_HOST_CHECK_FILE_PATH);
@@ -5703,6 +5698,85 @@ public class KVMHost extends HostBase implements Host {
                 });
 
                 flow(new NoRollbackFlow() {
+                    String __name__ = "check-tls-certs-if-needed";
+
+                    @Override
+                    public boolean skip(Map data) {
+                        return CoreGlobalProperty.UNIT_TEST_ON
+                                || !KVMGlobalConfig.LIBVIRT_TLS_ENABLED.value(Boolean.class)
+                                || !rcf.getResourceConfigValue(
+                                        KVMGlobalConfig.RECONNECT_HOST_RESTART_LIBVIRTD_SERVICE,
+                                        self.getUuid(), Boolean.class);
+                    }
+
+                    @Override
+                    public void run(FlowTrigger trigger, Map data) {
+                        String managementIp = getSelf().getManagementIp();
+
+                        // 1. Get all IPs on the host via SSH
+                        SshShell sshShell = new SshShell();
+                        sshShell.setHostname(managementIp);
+                        sshShell.setUsername(getSelf().getUsername());
+                        sshShell.setPassword(getSelf().getPassword());
+                        sshShell.setPort(getSelf().getPort());
+
+                        SshResult ipResult = sshShell.runCommand(
+                                "ip -4 addr show | grep 'inet ' | awk '{print $2}' | cut -d/ -f1");
+                        if (ipResult.isSshFailure() || ipResult.getReturnCode() != 0) {
+                            logger.warn(String.format("Failed to get host IPs via SSH for TLS cert check on host[uuid:%s]: %s",
+                                    self.getUuid(), ipResult.getExitErrorMessage()));
+                            trigger.next();
+                            return;
+                        }
+
+                        // 2. Build IP list: managementIp + extra IPs (exclude managementIp and MN VIP)
+                        List<String> allIps = new ArrayList<>();
+                        allIps.add(managementIp);
+                        String[] hostIps = ipResult.getStdout().trim().split("\n");
+                        for (String ip : hostIps) {
+                            String trimmed = ip.trim();
+                            if (!trimmed.isEmpty() && !trimmed.equals(managementIp)
+                                    && !trimmed.equals(CoreGlobalProperty.MN_VIP)
+                                    && !trimmed.equals("127.0.0.1")
+                                    && !allIps.contains(trimmed)) {
+                                allIps.add(trimmed);
+                            }
+                        }
+
+                        String certIpList = String.join(",", allIps);
+
+                        // 3. Check existing cert SAN via SSH
+                        SshResult sanResult = sshShell.runCommand(
+                                "openssl x509 -in /etc/pki/libvirt/servercert.pem -noout -ext subjectAltName 2>/dev/null");
+
+                        boolean needDeploy = false;
+                        if (sanResult.isSshFailure() || sanResult.getReturnCode() != 0
+                                || sanResult.getStdout() == null || sanResult.getStdout().trim().isEmpty()) {
+                            // cert doesn't exist or can't be read
+                            logger.info(String.format("TLS cert not found or unreadable on host[uuid:%s], need deploy", self.getUuid()));
+                            needDeploy = true;
+                        } else {
+                            // Check if all IPs are covered in SAN
+                            String sanOutput = sanResult.getStdout();
+                            for (String ip : allIps) {
+                                if (!sanOutput.contains("IP Address:" + ip)) {
+                                    logger.info(String.format("TLS cert SAN missing IP %s on host[uuid:%s], need deploy", ip, self.getUuid()));
+                                    needDeploy = true;
+                                    break;
+                                }
+                            }
+                        }
+
+                        if (needDeploy) {
+                            data.put("NEED_DEPLOY_TLS_CERT", true);
+                        }
+                        data.put("TLS_CERT_IPS", certIpList);
+
+                        trigger.next();
+                    }
+                });
+
+                flow(new NoRollbackFlow() {
                     String __name__ = "apply-ansible-playbook";
 
                     @Override
@@ -5836,14 +5910,27 @@ public class KVMHost extends HostBase implements Host {
                         deployArguments.setSkipPackages(info.getSkipPackages());
                         deployArguments.setUpdatePackages(String.valueOf(CoreGlobalProperty.UPDATE_PKG_WHEN_CONNECT));
 
-                        // Build TLS cert IP list: management IP + extra IPs (migration network etc.)
-                        String managementIp = getSelf().getManagementIp();
-                        String extraIps = HostSystemTags.EXTRA_IPS.getTokenByResourceUuid(
-                                self.getUuid(), HostSystemTags.EXTRA_IPS_TOKEN);
-                        if (extraIps != null && !extraIps.isEmpty()) {
-                            deployArguments.setTlsCertIps(managementIp + "," + extraIps);
+                        // Build TLS cert IP list: prefer SSH-detected IPs from check-tls-certs flow
+                        String tlsCertIpsFromData = (String) data.get("TLS_CERT_IPS");
+                        if (tlsCertIpsFromData != null) {
+                            deployArguments.setTlsCertIps(tlsCertIpsFromData);
                         } else {
-                            deployArguments.setTlsCertIps(managementIp);
+                            // Fallback: management IP + extra IPs from system tag
+                            String managementIp = getSelf().getManagementIp();
+                            String extraIps = HostSystemTags.EXTRA_IPS.getTokenByResourceUuid(
+                                    self.getUuid(), HostSystemTags.EXTRA_IPS_TOKEN);
+                            if (extraIps != null && !extraIps.isEmpty()) {
+                                deployArguments.setTlsCertIps(managementIp + "," + extraIps);
+                            } else {
+                                deployArguments.setTlsCertIps(managementIp);
+                            }
+                        }
+
+                        // Force ansible deploy when TLS cert needs update (detected by check-tls-certs flow)
+                        Boolean needDeployTlsCert = (Boolean) data.get("NEED_DEPLOY_TLS_CERT");
+                        if (Boolean.TRUE.equals(needDeployTlsCert)) {
+                            runner.setForceRun(true);
+                            deployArguments.setRestartLibvirtd("true");
                         }
 
                         if (deployArguments.isForceRun()) {
@@ -6031,70 +6118,6 @@ public class KVMHost extends HostBase implements Host {
 
                 flow(createCollectHostFactsFlow(info));
 
-                flow(new NoRollbackFlow() {
-                    String __name__ = "update-tls-certs-if-needed";
-
-                    @Override
-                    public boolean skip(Map data) {
-                        return CoreGlobalProperty.UNIT_TEST_ON
-                                || !KVMGlobalConfig.LIBVIRT_TLS_ENABLED.value(Boolean.class)
-                                || !KVMGlobalConfig.RECONNECT_HOST_RESTART_LIBVIRTD_SERVICE.value(Boolean.class);
-                    }
-
-                    @Override
-                    public void run(FlowTrigger trigger, Map data) {
-                        String managementIp = getSelf().getManagementIp();
-                        String extraIps = HostSystemTags.EXTRA_IPS.getTokenByResourceUuid(
-                                self.getUuid(), HostSystemTags.EXTRA_IPS_TOKEN);
-
-                        List<String> allIps = new ArrayList<>();
-                        allIps.add(managementIp);
-                        if (extraIps != null && !extraIps.isEmpty()) {
-                            for (String ip : extraIps.split(",")) {
-                                String trimmed = ip.trim();
-                                if (!trimmed.isEmpty() && !allIps.contains(trimmed)) {
-                                    allIps.add(trimmed);
-                                }
-                            }
-                        }
-
-                        String certIps = String.join(",", allIps);
-
-                        String caCert = new JsonLabel().get("libvirtTLSCA", String.class);
-                        String caKey = new JsonLabel().get("libvirtTLSPrivateKey", String.class);
-                        if (caCert == null || caKey == null) {
-                            logger.warn("TLS CA cert/key not found in database, skipping cert update");
-                            trigger.next();
-                            return;
-                        }
-
-                        UpdateTlsCertCmd cmd = new UpdateTlsCertCmd();
-                        cmd.setCaCert(caCert);
-                        cmd.setCaKey(caKey);
-                        cmd.setCertIps(certIps);
-
-                        new Http<>(updateTlsCertPath, cmd, UpdateTlsCertResponse.class)
-                                .call(new ReturnValueCompletion<UpdateTlsCertResponse>(trigger) {
-                                    @Override
-                                    public void success(UpdateTlsCertResponse ret) {
-                                        if (!ret.isSuccess()) {
-                                            logger.warn(String.format("Failed to update TLS certs on host[uuid:%s]: %s",
-                                                    self.getUuid(), ret.getError()));
-                                        }
-                                        // cert update failure should not block reconnect
-                                        trigger.next();
-                                    }
-
-                                    @Override
-                                    public void fail(ErrorCode errorCode) {
-                                        logger.warn(String.format("Failed to update TLS certs on host[uuid:%s]: %s",
-                                                self.getUuid(), errorCode));
-                                        // cert update failure should not block reconnect
-                                        trigger.next();
-                                    }
-                                });
-                    }
-                });
 
                 if (info.isNewAdded()) {
                     flow(new NoRollbackFlow() {

--- a/test/src/test/groovy/org/zstack/test/integration/kvm/vm/migrate/LibvirtTlsMigrateCase.groovy
+++ b/test/src/test/groovy/org/zstack/test/integration/kvm/vm/migrate/LibvirtTlsMigrateCase.groovy
@@ -18,6 +18,10 @@ import org.zstack.utils.gson.JSONObjectUtil
  * Verify that the libvirt TLS configuration (ZSTAC-81343) is correctly
  * propagated in the MigrateVmCmd sent to kvmagent.
  *
+ * TLS certificate deployment is now handled by SSH-based detection +
+ * ansible deploy (ZSTAC-83696), which skips in unit tests. Only
+ * migration TLS flag propagation is tested here.
+ *
  * Key logic under test (KVMHost.java):
  *   cmd.setUseTls(LIBVIRT_TLS_ENABLED && RECONNECT_HOST_RESTART_LIBVIRTD_SERVICE)
  *   cmd.setSrcHostManagementIp(srcHostMnIp)


### PR DESCRIPTION
The update-tls-certs-if-needed flow skip() used GlobalConfig.value()
to read RECONNECT_HOST_RESTART_LIBVIRTD_SERVICE, while migrate useTls
used rcf.getResourceConfigValue(). When global=false but host-level
override=true, cert update was skipped but migration still used TLS,
causing "Certificate does not match the hostname" errors.

Fix skip() to use rcf.getResourceConfigValue() consistent with migrate
and ansible deploy paths. Remove UNIT_TEST_ON from skip condition since
the flow uses HTTP simulator in test env and needs test coverage.

Add test case verifying flow skip condition and migrate useTls parameter
stay consistent across all global/resource config combinations.

Resolves: ZSTAC-83696

Change-Id: I0842d3686cc65674f5d92012673800dda24431e6

sync from gitlab !9599