### PR TITLE
<fix>[ha]: defer skip-trace list cleanup on MN departure to prevent split-brain

### DIFF
--- a/plugin/kvm/src/main/java/org/zstack/kvm/KVMGlobalConfig.java
+++ b/plugin/kvm/src/main/java/org/zstack/kvm/KVMGlobalConfig.java
@@ -120,6 +120,10 @@ public class KVMGlobalConfig {
     @GlobalConfigDef(defaultValue = "false", type = Boolean.class, description = "enable install host shutdown hook")
     public static GlobalConfig INSTALL_HOST_SHUTDOWN_HOOK = new GlobalConfig(CATEGORY, "install.host.shutdown.hook");
 
+    @GlobalConfigValidation(numberGreaterThan = 0)
+    @GlobalConfigDef(defaultValue = "600", type = Long.class, description = "timeout in seconds for orphaned VM skip entries from departed management nodes")
+    public static GlobalConfig ORPHANED_VM_SKIP_TIMEOUT = new GlobalConfig(CATEGORY, "vm.orphanedSkipTimeout");
+
     @GlobalConfigValidation(validValues = {"true", "false"})
     @GlobalConfigDef(defaultValue = "false", type = Boolean.class, description = "enable memory auto balloon")
     @BindResourceConfig({VmInstanceVO.class})

--- a/plugin/kvm/src/main/java/org/zstack/kvm/KvmVmSyncPingTask.java
+++ b/plugin/kvm/src/main/java/org/zstack/kvm/KvmVmSyncPingTask.java
@@ -496,7 +496,7 @@ public class KvmVmSyncPingTask extends VmTracer implements KVMPingAgentNoFailure
                 return true;
             } else {
                 // Expired, clean up
-                orphanedSkipVms.remove(vmUuid);
+                orphanedSkipVms.remove(vmUuid, orphanedAt);
                 logger.info(String.format("orphaned skip entry for VM[uuid:%s] expired after %d minutes, resuming trace",
                         vmUuid, ORPHAN_TTL_MS / 60000));
             }
@@ -512,11 +512,9 @@ public class KvmVmSyncPingTask extends VmTracer implements KVMPingAgentNoFailure
         }
 
         long now = System.currentTimeMillis();
-        Iterator<Map.Entry<String, Long>> it = orphanedSkipVms.entrySet().iterator();
-        while (it.hasNext()) {
-            Map.Entry<String, Long> entry = it.next();
+        for (Map.Entry<String, Long> entry : orphanedSkipVms.entrySet()) {
             if (now - entry.getValue() >= ORPHAN_TTL_MS) {
-                it.remove();
+                orphanedSkipVms.remove(entry.getKey(), entry.getValue());
                 logger.info(String.format("cleaned up expired orphaned skip entry for VM[uuid:%s]", entry.getKey()));
             }
         }

--- a/plugin/kvm/src/main/java/org/zstack/kvm/KvmVmSyncPingTask.java
+++ b/plugin/kvm/src/main/java/org/zstack/kvm/KvmVmSyncPingTask.java
@@ -68,6 +68,12 @@ public class KvmVmSyncPingTask extends VmTracer implements KVMPingAgentNoFailure
     private List<Class> skipVmTracerReplies = new ArrayList<>();
     private Map<String, Integer> vmInShutdownMap = new ConcurrentHashMap<>();
 
+    // Orphaned skip entries from departed MN nodes. Key=vmUuid, Value=timestamp when orphaned.
+    // These VMs remain in skip-trace state for ORPHAN_TTL_MS to avoid false HA triggers
+    // when a MN restarts and its in-flight VM operations haven't completed yet. See ZSTAC-80821.
+    private final ConcurrentHashMap<String, Long> orphanedSkipVms = new ConcurrentHashMap<>();
+    private static final long ORPHAN_TTL_MS = 10 * 60 * 1000; // 10 minutes
+
     {
         getReflections().getTypesAnnotatedWith(SkipVmTracer.class).forEach(clz -> {
             skipVmTracerMessages.add(clz.asSubclass(Message.class));
@@ -195,8 +201,13 @@ public class KvmVmSyncPingTask extends VmTracer implements KVMPingAgentNoFailure
         // Get vms to skip before send command to host to confirm the vm will be skipped after sync command finished.
         // The problem is if one vm-sync skipped operation is started and finished during vm sync command's handling
         // vm state would still be sync to mn
+        // ZSTAC-80821: clean up expired orphaned entries each sync cycle
+        cleanupExpiredOrphanedSkipVms();
+
         Set<String> vmsToSkipSetHostSide = new HashSet<>();
         vmsToSkip.values().forEach(vmsToSkipSetHostSide::addAll);
+        // ZSTAC-80821: also skip VMs from departed MN nodes that are still within TTL
+        vmsToSkipSetHostSide.addAll(orphanedSkipVms.keySet());
 
         // if the vm is not running on host when sync command executing but started as soon as possible
         // before response handling of vm sync, mgmtSideStates will including the running vm but not result in
@@ -227,6 +238,8 @@ public class KvmVmSyncPingTask extends VmTracer implements KVMPingAgentNoFailure
 
                     // Get vms to skip after sync result returned.
                     vmsToSkip.values().forEach(vmsToSkipSetHostSide::addAll);
+                    // ZSTAC-80821: include orphaned entries from departed MN nodes
+                    vmsToSkipSetHostSide.addAll(orphanedSkipVms.keySet());
 
                     Collection<String> vmUuidsInDeleteVmGC = DeleteVmGC.queryVmInGC(host.getUuid(), ret.getStates().keySet());
 
@@ -445,7 +458,19 @@ public class KvmVmSyncPingTask extends VmTracer implements KVMPingAgentNoFailure
     @Override
     public void nodeLeft(ManagementNodeInventory inv) {
         vmApis.remove(inv.getUuid());
-        vmsToSkip.remove(inv.getUuid());
+
+        // ZSTAC-80821: Instead of immediately removing skip list entries, move them
+        // to the orphaned set with a TTL. This prevents false HA triggers for VMs that
+        // are still being started by kvmagent but whose controlling MN has restarted.
+        Set<String> skippedVms = vmsToSkip.remove(inv.getUuid());
+        if (skippedVms != null && !skippedVms.isEmpty()) {
+            long now = System.currentTimeMillis();
+            for (String vmUuid : skippedVms) {
+                orphanedSkipVms.put(vmUuid, now);
+                logger.info(String.format("moved VM[uuid:%s] from departed MN[uuid:%s] skip list to orphaned set" +
+                        " (will expire in %d minutes)", vmUuid, inv.getUuid(), ORPHAN_TTL_MS / 60000));
+            }
+        }
     }
 
     @Override
@@ -456,5 +481,44 @@ public class KvmVmSyncPingTask extends VmTracer implements KVMPingAgentNoFailure
     public void iJoin(ManagementNodeInventory inv) {
         vmApis.putIfAbsent(inv.getUuid(), new ConcurrentHashMap<>());
         vmsToSkip.putIfAbsent(inv.getUuid(), ConcurrentHashMap.newKeySet());
+    }
+
+    public boolean isVmDoNotNeedToTrace(String vmUuid) {
+        if (vmsToSkip.values().stream().anyMatch(vmsToSkipSet -> vmsToSkipSet.contains(vmUuid))) {
+            return true;
+        }
+
+        // ZSTAC-80821: Also check orphaned skip entries from departed MN nodes
+        Long orphanedAt = orphanedSkipVms.get(vmUuid);
+        if (orphanedAt != null) {
+            if (System.currentTimeMillis() - orphanedAt < ORPHAN_TTL_MS) {
+                logger.debug(String.format("VM[uuid:%s] is in orphaned skip set, skipping trace", vmUuid));
+                return true;
+            } else {
+                // Expired, clean up
+                orphanedSkipVms.remove(vmUuid);
+                logger.info(String.format("orphaned skip entry for VM[uuid:%s] expired after %d minutes, resuming trace",
+                        vmUuid, ORPHAN_TTL_MS / 60000));
+            }
+        }
+
+        return false;
+    }
+
+    // Periodically clean up expired orphaned entries. Called from VM sync cycle.
+    private void cleanupExpiredOrphanedSkipVms() {
+        if (orphanedSkipVms.isEmpty()) {
+            return;
+        }
+
+        long now = System.currentTimeMillis();
+        Iterator<Map.Entry<String, Long>> it = orphanedSkipVms.entrySet().iterator();
+        while (it.hasNext()) {
+            Map.Entry<String, Long> entry = it.next();
+            if (now - entry.getValue() >= ORPHAN_TTL_MS) {
+                it.remove();
+                logger.info(String.format("cleaned up expired orphaned skip entry for VM[uuid:%s]", entry.getKey()));
+            }
+        }
     }
 }

--- a/plugin/kvm/src/main/java/org/zstack/kvm/KvmVmSyncPingTask.java
+++ b/plugin/kvm/src/main/java/org/zstack/kvm/KvmVmSyncPingTask.java
@@ -69,10 +69,13 @@ public class KvmVmSyncPingTask extends VmTracer implements KVMPingAgentNoFailure
     private Map<String, Integer> vmInShutdownMap = new ConcurrentHashMap<>();
 
     // Orphaned skip entries from departed MN nodes. Key=vmUuid, Value=timestamp when orphaned.
-    // These VMs remain in skip-trace state for ORPHAN_TTL_MS to avoid false HA triggers
+    // These VMs remain in skip-trace state to avoid false HA triggers
     // when a MN restarts and its in-flight VM operations haven't completed yet. See ZSTAC-80821.
     private final ConcurrentHashMap<String, Long> orphanedSkipVms = new ConcurrentHashMap<>();
-    private static final long ORPHAN_TTL_MS = 10 * 60 * 1000; // 10 minutes
+
+    private long getOrphanTtlMs() {
+        return KVMGlobalConfig.ORPHANED_VM_SKIP_TIMEOUT.value(Long.class) * 1000;
+    }
 
     {
         getReflections().getTypesAnnotatedWith(SkipVmTracer.class).forEach(clz -> {
@@ -468,7 +471,7 @@ public class KvmVmSyncPingTask extends VmTracer implements KVMPingAgentNoFailure
             for (String vmUuid : skippedVms) {
                 orphanedSkipVms.put(vmUuid, now);
                 logger.info(String.format("moved VM[uuid:%s] from departed MN[uuid:%s] skip list to orphaned set" +
-                        " (will expire in %d minutes)", vmUuid, inv.getUuid(), ORPHAN_TTL_MS / 60000));
+                        " (will expire in %d minutes)", vmUuid, inv.getUuid(), getOrphanTtlMs() / 60000));
             }
         }
     }
@@ -491,14 +494,14 @@ public class KvmVmSyncPingTask extends VmTracer implements KVMPingAgentNoFailure
         // ZSTAC-80821: Also check orphaned skip entries from departed MN nodes
         Long orphanedAt = orphanedSkipVms.get(vmUuid);
         if (orphanedAt != null) {
-            if (System.currentTimeMillis() - orphanedAt < ORPHAN_TTL_MS) {
+            if (System.currentTimeMillis() - orphanedAt < getOrphanTtlMs()) {
                 logger.debug(String.format("VM[uuid:%s] is in orphaned skip set, skipping trace", vmUuid));
                 return true;
             } else {
                 // Expired, clean up
                 orphanedSkipVms.remove(vmUuid, orphanedAt);
                 logger.info(String.format("orphaned skip entry for VM[uuid:%s] expired after %d minutes, resuming trace",
-                        vmUuid, ORPHAN_TTL_MS / 60000));
+                        vmUuid, getOrphanTtlMs() / 60000));
             }
         }
 
@@ -513,7 +516,7 @@ public class KvmVmSyncPingTask extends VmTracer implements KVMPingAgentNoFailure
 
         long now = System.currentTimeMillis();
         for (Map.Entry<String, Long> entry : orphanedSkipVms.entrySet()) {
-            if (now - entry.getValue() >= ORPHAN_TTL_MS) {
+            if (now - entry.getValue() >= getOrphanTtlMs()) {
                 orphanedSkipVms.remove(entry.getKey(), entry.getValue());
                 logger.info(String.format("cleaned up expired orphaned skip entry for VM[uuid:%s]", entry.getKey()));
             }


### PR DESCRIPTION
When a management node departs, its VM skip-trace entries were
immediately removed. If VMs were still being started by kvmagent,
the next VM sync would falsely detect them as Stopped and trigger
HA, causing split-brain.

Fix: transfer departed MN skip-trace entries to an orphaned set with
10-minute TTL instead of immediate deletion. VMs in the orphaned set
remain skip-traced until the TTL expires or they are explicitly
continued, preventing false HA triggers during MN restart scenarios.

Resolves: ZSTAC-80821

Change-Id: I3222e260b2d7b33dc43aba0431ce59a788566b34

Conflicts:
	plugin/kvm/src/main/java/org/zstack/kvm/KvmVmSyncPingTask.java

sync from gitlab !9626