### PR TITLE
<feature>[sdk]: add SDK for GetOAuthClientSecret API

### DIFF
--- a/sdk/src/main/java/org/zstack/sdk/GetOAuthClientSecretAction.java
+++ b/sdk/src/main/java/org/zstack/sdk/GetOAuthClientSecretAction.java
@@ -1,0 +1,95 @@
+package org.zstack.sdk;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.zstack.sdk.*;
+
+public class GetOAuthClientSecretAction extends AbstractAction {
+
+    private static final HashMap<String, Parameter> parameterMap = new HashMap<>();
+
+    private static final HashMap<String, Parameter> nonAPIParameterMap = new HashMap<>();
+
+    public static class Result {
+        public ErrorCode error;
+        public org.zstack.sdk.GetOAuthClientSecretResult value;
+
+        public Result throwExceptionIfError() {
+            if (error != null) {
+                throw new ApiException(
+                    String.format("error[code: %s, description: %s, details: %s]", error.code, error.description, error.details)
+                );
+            }
+            
+            return this;
+        }
+    }
+
+    @Param(required = true, nonempty = false, nullElements = false, emptyString = true, noTrim = false)
+    public java.lang.String uuid;
+
+    @Param(required = false)
+    public java.util.List systemTags;
+
+    @Param(required = false)
+    public java.util.List userTags;
+
+    @Param(required = false)
+    public String sessionId;
+
+    @Param(required = false)
+    public String accessKeyId;
+
+    @Param(required = false)
+    public String accessKeySecret;
+
+    @Param(required = false)
+    public String requestIp;
+
+
+    private Result makeResult(ApiResult res) {
+        Result ret = new Result();
+        if (res.error != null) {
+            ret.error = res.error;
+            return ret;
+        }
+        
+        org.zstack.sdk.GetOAuthClientSecretResult value = res.getResult(org.zstack.sdk.GetOAuthClientSecretResult.class);
+        ret.value = value == null ? new org.zstack.sdk.GetOAuthClientSecretResult() : value; 
+
+        return ret;
+    }
+
+    public Result call() {
+        ApiResult res = ZSClient.call(this);
+        return makeResult(res);
+    }
+
+    public void call(final Completion<Result> completion) {
+        ZSClient.call(this, new InternalCompletion() {
+            @Override
+            public void complete(ApiResult res) {
+                completion.complete(makeResult(res));
+            }
+        });
+    }
+
+    protected Map<String, Parameter> getParameterMap() {
+        return parameterMap;
+    }
+
+    protected Map<String, Parameter> getNonAPIParameterMap() {
+        return nonAPIParameterMap;
+    }
+
+    protected RestInfo getRestInfo() {
+        RestInfo info = new RestInfo();
+        info.httpMethod = "GET";
+        info.path = "/oauth2/clients/{uuid}/client-secret";
+        info.needSession = true;
+        info.needPoll = false;
+        info.parameterName = "";
+        return info;
+    }
+
+}

--- a/sdk/src/main/java/org/zstack/sdk/GetOAuthClientSecretResult.java
+++ b/sdk/src/main/java/org/zstack/sdk/GetOAuthClientSecretResult.java
@@ -1,0 +1,14 @@
+package org.zstack.sdk;
+
+
+
+public class GetOAuthClientSecretResult {
+    public java.lang.String clientSecret;
+    public void setClientSecret(java.lang.String clientSecret) {
+        this.clientSecret = clientSecret;
+    }
+    public java.lang.String getClientSecret() {
+        return this.clientSecret;
+    }
+
+}


### PR DESCRIPTION
Add GetOAuthClientSecretAction and GetOAuthClientSecretResult to
the SDK module, enabling clients to retrieve OAuth2 client secrets
via GET /oauth2/clients/{uuid}/client-secret.

Resolves: ZSV-11595

Change-Id: I79787373757170776666687465686767656d6f71

sync from gitlab !9637