### PR TITLE
<fix>[ceph]: Add a task to promptly check,update the latest status of ps and host

### DIFF
--- a/conf/globalConfig/primaryStorage.xml
+++ b/conf/globalConfig/primaryStorage.xml
@@ -71,4 +71,12 @@
         <type>java.lang.Integer</type>
         <category>primaryStorage</category>
     </config>
+
+    <config>
+        <name>primarystorage.host.status.refresh.interval</name>
+        <category>primaryStorage</category>
+        <description>The interval to refresh ps and host connection status, in seconds</description>
+        <defaultValue>60</defaultValue>
+        <type>java.lang.Integer</type>
+    </config>
 </globalConfig>

--- a/header/src/main/java/org/zstack/header/storage/primary/PrimaryStorageType.java
+++ b/header/src/main/java/org/zstack/header/storage/primary/PrimaryStorageType.java
@@ -23,6 +23,7 @@ public class PrimaryStorageType {
     private int order;
     private PrimaryStorageFindBackupStorage primaryStorageFindBackupStorage;
     private  boolean supportCreateVolumeSnapshotCheckCapacity = true;
+    private boolean supportCheckHostStatus = false;
 
     public boolean isSupportSharedVolume() {
         return supportSharedVolume;
@@ -199,5 +200,13 @@ public class PrimaryStorageType {
 
     public void setSupportStorageTrash(boolean supportStorageTrash) {
         this.supportStorageTrash = supportStorageTrash;
+    }
+
+    public boolean isSupportCheckHostStatus() {
+        return supportCheckHostStatus;
+    }
+
+    public void setSupportCheckHostStatus(boolean supportCheckHostStatus) {
+        this.supportCheckHostStatus = supportCheckHostStatus;
     }
 }

--- a/plugin/ceph/src/main/java/org/zstack/storage/ceph/primary/CephKvmExtension.java
+++ b/plugin/ceph/src/main/java/org/zstack/storage/ceph/primary/CephKvmExtension.java
@@ -24,6 +24,7 @@ import org.zstack.kvm.KVMConstant;
 import org.zstack.kvm.KVMHostConnectExtensionPoint;
 import org.zstack.kvm.KVMHostConnectedContext;
 import org.zstack.kvm.KVMHostFactory;
+import org.zstack.storage.primary.CheckHostStorageConnectionMsg;
 import org.zstack.storage.ceph.CephConstants;
 
 import javax.persistence.TypedQuery;

--- a/plugin/ceph/src/main/java/org/zstack/storage/ceph/primary/CephPrimaryStorageFactory.java
+++ b/plugin/ceph/src/main/java/org/zstack/storage/ceph/primary/CephPrimaryStorageFactory.java
@@ -97,6 +97,7 @@ public class CephPrimaryStorageFactory implements PrimaryStorageFactory, CephCap
 
     {
         type.setSupportSharedVolume(true);
+        type.setSupportCheckHostStatus(true);
     }
 
     @Autowired

--- a/storage/src/main/java/org/zstack/storage/primary/CheckHostStorageConnectionMsg.java
+++ b/storage/src/main/java/org/zstack/storage/primary/CheckHostStorageConnectionMsg.java
@@ -1,4 +1,4 @@
-package org.zstack.storage.ceph.primary;
+package org.zstack.storage.primary;
 
 import org.zstack.header.message.NeedReplyMessage;
 import org.zstack.header.storage.primary.PrimaryStorageMessage;

--- a/storage/src/main/java/org/zstack/storage/primary/CheckHostStorageConnectionReply.java
+++ b/storage/src/main/java/org/zstack/storage/primary/CheckHostStorageConnectionReply.java
@@ -1,4 +1,4 @@
-package org.zstack.storage.ceph.primary;
+package org.zstack.storage.primary;
 
 import org.zstack.header.message.MessageReply;
 

--- a/storage/src/main/java/org/zstack/storage/primary/PrimaryStorageGlobalConfig.java
+++ b/storage/src/main/java/org/zstack/storage/primary/PrimaryStorageGlobalConfig.java
@@ -56,4 +56,6 @@ public class PrimaryStorageGlobalConfig {
     @GlobalConfigDef(defaultValue = "1", type = Long.class)
     public static GlobalConfig COLLECT_AND_FORECAST_INTERVAL = new GlobalConfig(CATEGORY, "collect.forecast.interval");
 
+    @GlobalConfigValidation(numberGreaterThan = 0)
+    public static GlobalConfig PRIMARY_STORAGE_HOST_STATUS_REFRESH_INTERVAL = new GlobalConfig(CATEGORY, "primarystorage.host.status.refresh.interval");
 }

--- a/storage/src/main/java/org/zstack/storage/primary/PrimaryStorageManagerImpl.java
+++ b/storage/src/main/java/org/zstack/storage/primary/PrimaryStorageManagerImpl.java
@@ -34,6 +34,7 @@ import org.zstack.header.configuration.userconfig.DiskOfferingUserConfigValidato
 import org.zstack.header.configuration.userconfig.InstanceOfferingUserConfig;
 import org.zstack.header.configuration.userconfig.InstanceOfferingUserConfigValidator;
 import org.zstack.header.core.NoErrorCompletion;
+import org.zstack.header.core.NopeWhileDoneCompletion;
 import org.zstack.header.core.ReturnValueCompletion;
 import org.zstack.header.core.WhileDoneCompletion;
 import org.zstack.header.core.trash.InstallPathRecycleVO;
@@ -110,6 +111,7 @@ public class PrimaryStorageManagerImpl extends AbstractService implements Primar
     private final Map<String, AutoDeleteTrashTask> autoDeleteTrashTask = new HashMap<>();
     private static final Map<String, List<PrimaryStorageExtensionFactory>> extensionFactories = Maps.newConcurrentMap();
     private AutoDeleteTrashTask globalTrashTask;
+    private Future refreshPrimaryStorageHostStatusTask;
 
     static {
         allowedMessageAfterSoftDeletion.add(PrimaryStorageDeletionMsg.class);
@@ -1198,6 +1200,73 @@ public class PrimaryStorageManagerImpl extends AbstractService implements Primar
         return true;
     }
 
+    private void startPeriodTasks() {
+        PrimaryStorageGlobalConfig.PRIMARY_STORAGE_HOST_STATUS_REFRESH_INTERVAL.installUpdateExtension((oldConfig, newConfig) -> startRefreshPrimaryStorageHostStatusTask());
+        startRefreshPrimaryStorageHostStatusTask();
+    }
+
+    private synchronized void startRefreshPrimaryStorageHostStatusTask() {
+        if (refreshPrimaryStorageHostStatusTask != null) {
+            refreshPrimaryStorageHostStatusTask.cancel(true);
+        }
+
+        refreshPrimaryStorageHostStatusTask = thdf.submitPeriodicTask(new PeriodicTask() {
+            @Override
+            public TimeUnit getTimeUnit() {
+                return TimeUnit.SECONDS;
+            }
+
+            @Override
+            public long getInterval() {
+                return PrimaryStorageGlobalConfig.PRIMARY_STORAGE_HOST_STATUS_REFRESH_INTERVAL.value(Integer.class).longValue();
+            }
+
+            @Override
+            public String getName() {
+                return "update-host-storage-connection-status";
+            }
+
+            @Override
+            public void run() {
+                Map<String, List<String>> disconnectedHostsByPsUuid = new HashMap<>();
+
+                List<PrimaryStorageHostRefVO> refs = Q.New(PrimaryStorageHostRefVO.class)
+                        .eq(PrimaryStorageHostRefVO_.status, PrimaryStorageHostStatus.Disconnected)
+                        .list();
+
+                refs.forEach(ref -> {
+                    disconnectedHostsByPsUuid.computeIfAbsent(ref.getPrimaryStorageUuid(), key -> new ArrayList<>()).add(ref.getHostUuid());
+                });
+
+                List<CheckHostStorageConnectionMsg> msgs = new ArrayList<>();
+                for (Map.Entry<String, List<String>> entry : disconnectedHostsByPsUuid.entrySet()) {
+                    PrimaryStorageVO storageVO = dbf.findByUuid(entry.getKey(), PrimaryStorageVO.class);
+                    if (!PrimaryStorageType.valueOf(storageVO.getType()).isSupportCheckHostStatus()){
+                        continue;
+                    }
+                    CheckHostStorageConnectionMsg msg = new CheckHostStorageConnectionMsg();
+                    msg.setPrimaryStorageUuid(entry.getKey());
+                    msg.setHostUuids(entry.getValue());
+                    bus.makeTargetServiceIdByResourceUuid(msg, PrimaryStorageConstant.SERVICE_ID, entry.getKey());
+                    msgs.add(msg);
+                }
+
+                new While<>(msgs).step((msg, comp) -> {
+                    bus.send(msg, new CloudBusCallBack(comp) {
+                        @Override
+                        public void run(MessageReply reply) {
+                            if (!reply.isSuccess()) {
+                                logger.error(String.format("Failed to check host storage connection for primary storage %s and host %s due to: %s",
+                                        msg.getPrimaryStorageUuid(), msg.getHostUuids().get(0), reply.getError()));
+                            }
+                            comp.done();
+                        }
+                    });
+                }, 10).run(new NopeWhileDoneCompletion());
+            }
+        });
+    }
+
     private void populateExtensions() {
         for (PrimaryStorageAllocatorStrategyFactory f : pluginRgty.getExtensionList(PrimaryStorageAllocatorStrategyFactory.class)) {
             PrimaryStorageAllocatorStrategyFactory old = allocatorFactories.get(f.getPrimaryStorageAllocatorStrategyType().toString());
@@ -1304,6 +1373,7 @@ public class PrimaryStorageManagerImpl extends AbstractService implements Primar
                 Platform.getManagementServerId()));
         loadPrimaryStorage(false);
         initResourcePrimaryStorageAutoDeleteTrash();
+        startPeriodTasks();
     }
 
     private void checkVmAllVolumePrimaryStorageState(String vmUuid) {


### PR DESCRIPTION
After a Ceph dead and fail, the host dis
connects from the PS, potentially becoming
offline.

Post-failure, if the host-storage link isn't
restored promptly, issues may arise where
healthy hosts are wrongly filtered out.

Thus,Mn needs to actively identify these
states of disconnections.

so wrote a scheduled task in PrimaryStorage
-ManagerImpl to check and update the latest
connection status between the host and ps on
 a scheduled basis.

GlobalConfigImpact

Resolves: ZSTAC-64050
Resolves: ZSV-8248

Change-Id: I76676a656d6a61796e6a657161757a6a64706568

sync from gitlab !9696