### PR TITLE
<fix>[compute]: clean up cdrom metadata on deleteVmCdRom

### DIFF
--- a/compute/src/main/java/org/zstack/compute/vm/VmInstanceBase.java
+++ b/compute/src/main/java/org/zstack/compute/vm/VmInstanceBase.java
@@ -8780,6 +8780,13 @@ public class VmInstanceBase extends AbstractVmInstance {
             return;
         }
 
+        // Align with VmDetachNicFlow: clean up the device address metadata
+        // before the owning VO is removed, otherwise
+        // VmInstanceResourceMetadataManager#checkParams can no longer locate
+        // the device and refuses to delete the row. Leaving the orphan
+        // metadata later breaks memory snapshot archive / revert because the
+        // archived device no longer exists.
+        vidm.deleteVmResourceMetadata(cdRomUuid, self.getUuid());
         dbf.removeByPrimaryKey(cdRomUuid, VmCdRomVO.class);
         completion.success();
     }


### PR DESCRIPTION
Symmetric with VmDetachNicFlow: remove the VmInstanceResourceMetadataVO
row when a cdrom is deleted. Otherwise the orphan address row breaks
memory snapshot archive/revert because the archived device no longer
exists.

Resolves: ZSV-11374

Change-Id: I7577657264756a726373676a796574717a797871

sync from gitlab !9709