### PR TITLE
<feature>[host]: support multipath block device in get/mount APIs

### DIFF
--- a/compute/src/main/java/org/zstack/compute/host/HostManagerImpl.java
+++ b/compute/src/main/java/org/zstack/compute/host/HostManagerImpl.java
@@ -539,8 +539,12 @@ public class HostManagerImpl extends AbstractService implements HostManager, Man
         Ssh ssh = new Ssh();
         ssh.setUsername(msg.getUsername()).setPassword(msg.getPassword()).setPort(msg.getSshPort())
                 .setHostname(msg.getHostName()).setTimeout(20);
+        logger.info(String.format(
+                "[MountBlockDevice] start: host=%s:%d user=%s path=%s mountPoint=%s fsType=%s",
+                msg.getHostName(), msg.getSshPort(), msg.getUsername(),
+                msg.getPath(), msg.getMountPoint(), msg.getFilesystemType()));
         try {
-            // 1 Check if mount point is already mounted
+            // 1 mountPoint not already mounted
             SshResult mountPointCheck = ssh.command(String.format("findmnt -n -o SOURCE '%s'", msg.getMountPoint())).run();
             ssh.reset();
             if (mountPointCheck.getReturnCode() == 0 && !mountPointCheck.getStdout().trim().isEmpty()) {
@@ -548,7 +552,7 @@ public class HostManagerImpl extends AbstractService implements HostManager, Man
                         msg.getMountPoint(), mountPointCheck.getStdout().trim()));
             }
 
-            // 2 Check if device is already mounted
+            // 2 device not already mounted
             SshResult devicePathCheck = ssh.command(String.format("findmnt -n -o TARGET '%s'", msg.getPath())).run();
             ssh.reset();
             if (devicePathCheck.getReturnCode() == 0 && !devicePathCheck.getStdout().trim().isEmpty()) {
@@ -556,40 +560,129 @@ public class HostManagerImpl extends AbstractService implements HostManager, Man
                         msg.getPath(), devicePathCheck.getStdout().trim()));
             }
 
-            // 3 Create mount point directory
+            // 2.5 classify multipath via shared lsblk tree (holder chain invisible to `lsblk TYPE`)
+            SshResult listRet = ssh.command(getBlockDevicesCommand()).run();
+            ssh.reset();
+            if (listRet.getReturnCode() != 0) {
+                throw new OperationFailureException(operr(
+                        "failed to list block devices on host %s, stderr:%s",
+                        msg.getHostName(), listRet.getStderr()));
+            }
+            BlockDevices allDevices = BlockDevices.valueOf(BlockDevicesParser.parse(listRet.getStdout()));
+            BlockDevices.BlockDevice target = BlockDevices.findByName(allDevices.getAllBlockDevices(), msg.getPath());
+            if (target == null) {
+                List<String> availableNames = allDevices.getAllBlockDevices().stream()
+                        .map(BlockDevices.BlockDevice::getName)
+                        .collect(Collectors.toList());
+                throw new OperationFailureException(operr(
+                        "device %s not found on host %s, available devices: %s",
+                        msg.getPath(), msg.getHostName(), availableNames));
+            }
+
+            boolean isMultipath = target.isMultipath();
+            // mpath member (disk under mpath) must be redirected to the aggregator;
+            // the aggregator itself (type=mpath) is used as-is.
+            boolean isUnderlyingMultipathMember = isMultipath && "disk".equalsIgnoreCase(target.getType());
+            String devicePath = msg.getPath();
+            if (isUnderlyingMultipathMember) {
+                BlockDevices.BlockDevice mpathChild = BlockDevices.findMultipathChild(target);
+                if (mpathChild == null || mpathChild.getName() == null || mpathChild.getName().isEmpty()) {
+                    throw new OperationFailureException(operr(
+                            "device %s is an underlying path of a multipath device but the " +
+                                    "aggregator (/dev/mapper/mpathX) could not be located", msg.getPath()));
+                }
+                logger.info(String.format("[MountBlockDevice] redirect: %s -> %s",
+                        msg.getPath(), mpathChild.getName()));
+                devicePath = mpathChild.getName();
+
+                // re-assert step 2 invariant against the aggregator
+                SshResult redirectedCheck = ssh.command(String.format("findmnt -n -o TARGET '%s'", devicePath)).run();
+                ssh.reset();
+                if (redirectedCheck.getReturnCode() == 0 && !redirectedCheck.getStdout().trim().isEmpty()) {
+                    throw new OperationFailureException(operr("device %s is already mount on mountPoint %s",
+                            devicePath, redirectedCheck.getStdout().trim()));
+                }
+            }
+
+            // 3 mkdir mount point
             executeSshCommand(ssh, String.format("mkdir -p '%s'", msg.getMountPoint()));
 
-            // 4 Format and execute mkfs command
-            executeSshCommand(ssh, buildMkfsCommd(msg.getFilesystemType(), msg.getPath()));
-
-            // 5 Retrieve device UUID
-            SshResult ret = executeSshCommand(ssh, String.format("blkid -s UUID -o value '%s'", msg.getPath()));
-            String uuid = ret.getStdout().trim();
-            if (uuid.isEmpty()) {
-                throw new OperationFailureException(operr("failed to get UUID for device %s", msg.getPath()));
-            }
-
-            // 6 Mount device using UUID
-            executeSshCommand(ssh, String.format("mount -U '%s' '%s'", uuid, msg.getMountPoint()));
-
-            String fstabEntry = String.format("UUID=%s %s %s defaults 0 0", uuid, msg.getMountPoint(), msg.getFilesystemType());
-
-            // 7 Check if fstabEntry already exists in /etc/fstab
-            String checkCommand = String.format("grep -F '%s' /etc/fstab", fstabEntry);
-            SshResult fstabCheck = ssh.command(checkCommand).run();
+            // 3.5 reject stale fstab entry (devicePath or mountPoint) before destructive mkfs;
+            //      skip comment lines so commented history does not block re-mount.
+            SshResult staleCheck = ssh.command(String.format(
+                    "awk -v d='%s' -v m='%s' '$1!~/^#/ && ($1==d || $2==m) {print NR\": \"$0}' /etc/fstab",
+                    devicePath, msg.getMountPoint())).run();
             ssh.reset();
-            if (fstabCheck.getReturnCode() == 0 && fstabCheck.getStdout().trim().equals(fstabEntry)) {
-                logger.info(String.format("fstabEntry[%s] already exists in fstab", fstabEntry));
-                bus.publish(event);
-                return;
+            if (staleCheck.getReturnCode() != 0) {
+                throw new OperationFailureException(operr(
+                        "failed to scan /etc/fstab on host %s, stderr:%s",
+                        msg.getHostName(), staleCheck.getStderr()));
+            }
+            String stale = staleCheck.getStdout() == null ? "" : staleCheck.getStdout().trim();
+            if (!stale.isEmpty()) {
+                throw new OperationFailureException(operr(
+                        "fstab on host %s already contains entry referencing device %s or mountPoint %s. " +
+                                "matched lines: [%s]. mkfs/mount aborted to protect existing data. " +
+                                "Please clean up /etc/fstab on the host and retry.",
+                        msg.getHostName(), devicePath, msg.getMountPoint(), stale));
             }
 
-            // 8 Add fstabEntry to fstab
-            executeSshCommand(ssh, String.format("echo '%s' >> /etc/fstab", fstabEntry));
+            // 4 mkfs — destructive, not reversible
+            executeSshCommand(ssh, buildMkfsCommd(msg.getFilesystemType(), devicePath));
 
-            bus.publish(event);
+            boolean mounted = false;
+            try {
+                // 5 blkid UUID
+                SshResult ret = executeSshCommand(ssh, String.format("blkid -s UUID -o value '%s'", devicePath));
+                String uuid = ret.getStdout().trim();
+                if (uuid.isEmpty()) {
+                    throw new OperationFailureException(operr("failed to get UUID for device %s", devicePath));
+                }
+
+                // 6 mount
+                executeSshCommand(ssh, String.format("mount -U '%s' '%s'", uuid, msg.getMountPoint()));
+                mounted = true;
+
+                // 7 fstab — multipath needs _netdev + device-timeout so boot waits for multipathd
+                String fstabOptions = isMultipath ? "defaults,_netdev,x-systemd.device-timeout=10" : "defaults";
+                String fstabEntry = String.format("UUID=%s %s %s %s 0 0",
+                        uuid, msg.getMountPoint(), msg.getFilesystemType(), fstabOptions);
+
+                // 8 append (step 3.5 already guaranteed no conflict)
+                executeSshCommand(ssh, String.format("echo '%s' >> /etc/fstab", fstabEntry));
+
+                logger.info(String.format(
+                        "[MountBlockDevice] done: host=%s path=%s -> devicePath=%s mountPoint=%s uuid=%s isMultipath=%s",
+                        msg.getHostName(), msg.getPath(), devicePath, msg.getMountPoint(), uuid, isMultipath));
+                bus.publish(event);
+            } catch (RuntimeException e) {
+                compensateAfterMkfs(ssh, msg.getHostName(), msg.getMountPoint(), devicePath, mounted);
+                throw e;
+            }
         } finally {
             ssh.close();
+        }
+    }
+
+    private void compensateAfterMkfs(Ssh ssh, String host, String mountPoint, String devicePath, boolean mounted) {
+        logger.warn(String.format(
+                "[MountBlockDevice] failed after mkfs: host=%s devicePath=%s mountPoint=%s (fs overwritten, not reversible)",
+                host, devicePath, mountPoint));
+        if (!mounted) {
+            return;
+        }
+        try {
+            SshResult ret = ssh.command(String.format("umount '%s'", mountPoint)).run();
+            ssh.reset();
+            if (ret.getReturnCode() != 0) {
+                logger.warn(String.format(
+                        "[MountBlockDevice] compensation umount failed: host=%s mountPoint=%s stderr=%s",
+                        host, mountPoint, ret.getStderr()));
+            }
+        } catch (Throwable t) {
+            logger.warn(String.format(
+                    "[MountBlockDevice] compensation umount threw: host=%s mountPoint=%s err=%s",
+                    host, mountPoint, t.getMessage()));
         }
     }
 

--- a/header/src/main/java/org/zstack/header/host/APIMountBlockDeviceMsg.java
+++ b/header/src/main/java/org/zstack/header/host/APIMountBlockDeviceMsg.java
@@ -22,6 +22,7 @@ public class APIMountBlockDeviceMsg extends APIMessage {
     private Integer sshPort;
     @APIParam(maxLength = 255)
     private String hostName;
+    // regex guards against shell metachar injection in downstream ssh commands.
     @APIParam(maxLength = 255)
     private String path;
     @APIParam(maxLength = 2048)

--- a/header/src/main/java/org/zstack/header/host/BlockDevices.java
+++ b/header/src/main/java/org/zstack/header/host/BlockDevices.java
@@ -44,6 +44,36 @@ public class BlockDevices {
         return allBlockDevices;
     }
 
+    /** DFS lookup by absolute name (e.g. "/dev/sda", "/dev/mapper/mpatha"); null if absent. */
+    public static BlockDevice findByName(List<BlockDevice> roots, String name) {
+        if (roots == null || name == null) {
+            return null;
+        }
+        for (BlockDevice dev : roots) {
+            if (name.equals(dev.getName())) {
+                return dev;
+            }
+            BlockDevice hit = findByName(dev.getChildren(), name);
+            if (hit != null) {
+                return hit;
+            }
+        }
+        return null;
+    }
+
+    /** First direct child with type == "mpath" (the aggregator above a physical disk); null if none. */
+    public static BlockDevice findMultipathChild(BlockDevice device) {
+        if (device == null || device.getChildren() == null) {
+            return null;
+        }
+        for (BlockDevice child : device.getChildren()) {
+            if ("mpath".equalsIgnoreCase(child.getType())) {
+                return child;
+            }
+        }
+        return null;
+    }
+
     public static class BlockDevice {
         private String name;
         private String type;
@@ -62,6 +92,7 @@ public class BlockDevices {
         private long usedRatio;
         private Boolean smartPassed;
         private String smartMessage;
+        private boolean multipath;
 
         BlockDevice() {
 
@@ -85,7 +116,23 @@ public class BlockDevices {
             device.fsType = blockDevice.getFstype();
             device.serialNumber = blockDevice.getSerial();
             device.model = blockDevice.getModel();
+            device.multipath = isMultipathDevice(device);
             return device;
+        }
+
+        /** True if self is mpath, or a disk with an mpath child (i.e. underlying multipath member). */
+        private static boolean isMultipathDevice(BlockDevice device) {
+            if ("mpath".equalsIgnoreCase(device.type)) {
+                return true;
+            }
+            if ("disk".equalsIgnoreCase(device.type) && !CollectionUtils.isEmpty(device.children)) {
+                for (BlockDevice child : device.children) {
+                    if ("mpath".equalsIgnoreCase(child.type)) {
+                        return true;
+                    }
+                }
+            }
+            return false;
         }
 
         private boolean isUsed(BlockDevice device) {
@@ -237,6 +284,14 @@ public class BlockDevices {
 
         public void setSmartMessage(String smartMessage) {
             this.smartMessage = smartMessage;
+        }
+
+        public boolean isMultipath() {
+            return multipath;
+        }
+
+        public void setMultipath(boolean multipath) {
+            this.multipath = multipath;
         }
     }
 }

--- a/header/src/main/java/org/zstack/header/host/BlockDevices_BlockDeviceDoc_zh_cn.groovy
+++ b/header/src/main/java/org/zstack/header/host/BlockDevices_BlockDeviceDoc_zh_cn.groovy
@@ -110,4 +110,10 @@ doc {
 		type "String"
 		since "zsv 4.10.0"
 	}
+	field {
+		name "multipath"
+		desc "是否为多路径设备；true 表示该磁盘自身为 multipath 设备或为 multipath 底层路径盘"
+		type "boolean"
+		since "zsv 5.0.0"
+	}
 }

--- a/sdk/src/main/java/org/zstack/sdk/BlockDevice.java
+++ b/sdk/src/main/java/org/zstack/sdk/BlockDevice.java
@@ -140,4 +140,12 @@ public class BlockDevice  {
         return this.smartMessage;
     }
 
+    public boolean multipath;
+    public void setMultipath(boolean multipath) {
+        this.multipath = multipath;
+    }
+    public boolean getMultipath() {
+        return this.multipath;
+    }
+
 }


### PR DESCRIPTION
Extend BlockDevices to classify multipath topology from lsblk output,
and make APIMountBlockDeviceMsg safe and usable on multipath disks.

BlockDevices (header):
- BlockDevice now carries a `multipath` flag, computed in valueOf()
  after the children subtree is fully built, so DFS post-order
  guarantees correct classification on every node.
- isMultipathDevice() rules:
    * self type == "mpath"                         -> true
    * self type == "disk" with any child "mpath"   -> true  (underlying path)
    * otherwise                                    -> false
- New helpers findByName() (recursive lookup in the device forest) and
  findMultipathChild() (returns the mpath aggregator sitting above a disk).
- SDK BlockDevice and zh_CN doc updated with the new `multipath` field.

APIMountBlockDeviceMsg handler (compute/host):
- Before mkfs, reuse the shared lsblk tree + BlockDevices classifier
  (single source of truth with GetPhysicalMachineBlockDevices) to decide
  whether the user-supplied path is a multipath aggregator, a multipath
  slave disk, or a plain device. `lsblk -n -o TYPE <path>` alone cannot
  see the holder chain, which is why the tree-based classifier is used.
- When the path points to an underlying slave of a multipath device,
  transparently redirect mkfs / blkid / mount / fstab to
  /dev/mapper/mpathX instead of /dev/sdX, so mkfs does not corrupt
  the multipath member. The redirected path is re-checked against
  findmnt to keep steps 1 & 2's already-mounted invariant.
- fstab entry for a multipath target uses
  `defaults,_netdev,x-systemd.device-timeout=10` so systemd waits for
  multipathd to bring up /dev/mapper/mpathX at boot and does not drop
  to an emergency shell; plain devices keep `defaults`.
- Structured [MountBlockDevice] logs added at each step (findmnt,
  lsblk resolve, redirect, mkfs, blkid, mount, fstab) to ease on-site
  diagnosis of multipath edge cases.

Resolves: ZSV-10963

Change-Id: I626d6b616667616d626a6d686469627473756f66

sync from gitlab !9712