### PR TITLE
&lt;fix&gt;[conf]: enable recovery for legacy AI alarm records on upgrade (ZSTAC-84784)

### DIFF
--- a/conf/db/upgrade/V5.5.16__schema.sql
+++ b/conf/db/upgrade/V5.5.16__schema.sql
@@ -365,3 +365,10 @@ CREATE TABLE IF NOT EXISTS `zstack`.`VmModelMountVO` (
         FOREIGN KEY (`modelUuid`) REFERENCES `zstack`.`ModelVO`(`uuid`) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
+-- ZSTAC-84784: turn on recovery notification for the 3 AI system alarms seeded by AISystemAlarmManagerImpl
+UPDATE `zstack`.`AlarmVO` SET `enableRecovery` = 1 WHERE `uuid` IN (
+    'a617248f3f5f42ea985f41fc7b79d7c9', -- ModelCenter cache directory available capacity
+    'bec5013b64c04fc99dc456da2f571c00', -- ZDFS metadata server clients available
+    '230aa324cf0b430a841465bb05c9145a'  -- ZDFS metadata server memory available
+);
+


### PR DESCRIPTION
## ZSTAC-84784

http://jira.zstack.io/browse/ZSTAC-84784

### 改动
`conf/db/upgrade/V5.5.16__schema.sql` 末尾新增 UPDATE：把 3 个 AI 系统报警器（按 UUID 定位）`AlarmVO.enableRecovery` 改为 1。

```sql
UPDATE `zstack`.`AlarmVO` SET `enableRecovery` = 1 WHERE `uuid` IN (
    'a617248f3f5f42ea985f41fc7b79d7c9', -- ModelCenter cache directory available capacity
    'bec5013b64c04fc99dc456da2f571c00', -- ZDFS metadata server clients available
    '230aa324cf0b430a841465bb05c9145a'  -- ZDFS metadata server memory available
);
```

### 联动 MR
- premium（builder + AISystemAlarmManagerImpl）：`fix/ZSTAC-84784`

### 影响
旧环境升级到含本提交版本时，3 个 AI 报警器自动开启恢复通知；其他报警器不受影响。

sync from gitlab !9735