### PR TITLE
[refactor][volumeCache]: align REST URLs with new class names (zstack)

### DIFF
--- a/sdk/src/main/java/org/zstack/sdk/ChangeHostCacheStoreStateAction.java
+++ b/sdk/src/main/java/org/zstack/sdk/ChangeHostCacheStoreStateAction.java
@@ -97,7 +97,7 @@ public class ChangeHostCacheStoreStateAction extends AbstractAction {
     protected RestInfo getRestInfo() {
         RestInfo info = new RestInfo();
         info.httpMethod = "PUT";
-        info.path = "/hosts/{hostUuid}/local-volume-cache-pools/{uuid}/actions";
+        info.path = "/hosts/{hostUuid}/host-cache-stores/{uuid}/actions";
         info.needSession = true;
         info.needPoll = true;
         info.parameterName = "changeHostCacheStoreState";

--- a/sdk/src/main/java/org/zstack/sdk/CreateHostCacheStoreAction.java
+++ b/sdk/src/main/java/org/zstack/sdk/CreateHostCacheStoreAction.java
@@ -109,7 +109,7 @@ public class CreateHostCacheStoreAction extends AbstractAction {
     protected RestInfo getRestInfo() {
         RestInfo info = new RestInfo();
         info.httpMethod = "POST";
-        info.path = "/hosts/{hostUuid}/local-volume-cache-pools";
+        info.path = "/hosts/{hostUuid}/host-cache-stores";
         info.needSession = true;
         info.needPoll = true;
         info.parameterName = "params";

--- a/sdk/src/main/java/org/zstack/sdk/DeleteHostCacheStoreAction.java
+++ b/sdk/src/main/java/org/zstack/sdk/DeleteHostCacheStoreAction.java
@@ -94,7 +94,7 @@ public class DeleteHostCacheStoreAction extends AbstractAction {
     protected RestInfo getRestInfo() {
         RestInfo info = new RestInfo();
         info.httpMethod = "DELETE";
-        info.path = "/hosts/{hostUuid}/local-volume-cache-pools/{uuid}";
+        info.path = "/hosts/{hostUuid}/host-cache-stores/{uuid}";
         info.needSession = true;
         info.needPoll = true;
         info.parameterName = "";

--- a/sdk/src/main/java/org/zstack/sdk/DisableVolumeCacheAction.java
+++ b/sdk/src/main/java/org/zstack/sdk/DisableVolumeCacheAction.java
@@ -91,7 +91,7 @@ public class DisableVolumeCacheAction extends AbstractAction {
     protected RestInfo getRestInfo() {
         RestInfo info = new RestInfo();
         info.httpMethod = "PUT";
-        info.path = "/volumes/{volumeUuid}/local-volume-cache/actions";
+        info.path = "/volumes/{volumeUuid}/volume-cache/actions";
         info.needSession = true;
         info.needPoll = true;
         info.parameterName = "disableVolumeCache";

--- a/sdk/src/main/java/org/zstack/sdk/EnableVolumeCacheAction.java
+++ b/sdk/src/main/java/org/zstack/sdk/EnableVolumeCacheAction.java
@@ -97,7 +97,7 @@ public class EnableVolumeCacheAction extends AbstractAction {
     protected RestInfo getRestInfo() {
         RestInfo info = new RestInfo();
         info.httpMethod = "PUT";
-        info.path = "/volumes/{volumeUuid}/local-volume-cache/actions";
+        info.path = "/volumes/{volumeUuid}/volume-cache/actions";
         info.needSession = true;
         info.needPoll = true;
         info.parameterName = "enableVolumeCache";

--- a/sdk/src/main/java/org/zstack/sdk/ExtendHostCacheStoreAction.java
+++ b/sdk/src/main/java/org/zstack/sdk/ExtendHostCacheStoreAction.java
@@ -97,7 +97,7 @@ public class ExtendHostCacheStoreAction extends AbstractAction {
     protected RestInfo getRestInfo() {
         RestInfo info = new RestInfo();
         info.httpMethod = "PUT";
-        info.path = "/hosts/{hostUuid}/local-volume-cache-pools/{uuid}/actions";
+        info.path = "/hosts/{hostUuid}/host-cache-stores/{uuid}/actions";
         info.needSession = true;
         info.needPoll = true;
         info.parameterName = "extendHostCacheStore";

--- a/sdk/src/main/java/org/zstack/sdk/QueryHostCacheStoreAction.java
+++ b/sdk/src/main/java/org/zstack/sdk/QueryHostCacheStoreAction.java
@@ -65,7 +65,7 @@ public class QueryHostCacheStoreAction extends QueryAction {
     protected RestInfo getRestInfo() {
         RestInfo info = new RestInfo();
         info.httpMethod = "GET";
-        info.path = "/hosts/local-volume-cache-pools";
+        info.path = "/hosts/host-cache-stores";
         info.needSession = true;
         info.needPoll = false;
         info.parameterName = "";

--- a/sdk/src/main/java/org/zstack/sdk/ReconnectHostCacheStoreAction.java
+++ b/sdk/src/main/java/org/zstack/sdk/ReconnectHostCacheStoreAction.java
@@ -94,7 +94,7 @@ public class ReconnectHostCacheStoreAction extends AbstractAction {
     protected RestInfo getRestInfo() {
         RestInfo info = new RestInfo();
         info.httpMethod = "PUT";
-        info.path = "/hosts/{hostUuid}/local-volume-cache-pools/{uuid}/actions";
+        info.path = "/hosts/{hostUuid}/host-cache-stores/{uuid}/actions";
         info.needSession = true;
         info.needPoll = true;
         info.parameterName = "reconnectHostCacheStore";

--- a/sdk/src/main/java/org/zstack/sdk/SyncHostCacheStoreCapacityAction.java
+++ b/sdk/src/main/java/org/zstack/sdk/SyncHostCacheStoreCapacityAction.java
@@ -94,7 +94,7 @@ public class SyncHostCacheStoreCapacityAction extends AbstractAction {
     protected RestInfo getRestInfo() {
         RestInfo info = new RestInfo();
         info.httpMethod = "PUT";
-        info.path = "/hosts/{hostUuid}/local-volume-cache-pools/{uuid}/actions";
+        info.path = "/hosts/{hostUuid}/host-cache-stores/{uuid}/actions";
         info.needSession = true;
         info.needPoll = true;
         info.parameterName = "syncHostCacheStoreCapacity";

--- a/sdk/src/main/java/org/zstack/sdk/UpdateHostCacheStoreAction.java
+++ b/sdk/src/main/java/org/zstack/sdk/UpdateHostCacheStoreAction.java
@@ -100,7 +100,7 @@ public class UpdateHostCacheStoreAction extends AbstractAction {
     protected RestInfo getRestInfo() {
         RestInfo info = new RestInfo();
         info.httpMethod = "PUT";
-        info.path = "/hosts/{hostUuid}/local-volume-cache-pools/{uuid}/actions";
+        info.path = "/hosts/{hostUuid}/host-cache-stores/{uuid}/actions";
         info.needSession = true;
         info.needPoll = true;
         info.parameterName = "updateHostCacheStore";


### PR DESCRIPTION
## 背景

跟进 zstack!9674 / premium!13604（HostCacheStore/VolumeCache 重命名）。Java/SDK 类名已全部迁移，但 REST URL 仍保留旧 `local-volume-cache-pools` / `local-volume-cache` 路径，文档/URL 视觉不一致。

## 主要改动

对齐到新资源命名 + ZStack REST 复数惯例（image-stores、primary-storages）：

```
/hosts/{hostUuid}/local-volume-cache-pools[/{uuid}[/actions]]
  -> /hosts/{hostUuid}/host-cache-stores[/{uuid}[/actions]]
/hosts/local-volume-cache-pools[/{uuid}]
  -> /hosts/host-cache-stores[/{uuid}]
/volumes/{volumeUuid}/local-volume-cache/actions
  -> /volumes/{volumeUuid}/volume-cache/actions
```

本仓只动 SDK Action 文件（10 个）。@RestRequest 注解 + Doc groovy 在配对的 premium MR。

## 关联仓库 MR

- premium：同名分支 `refactor/volumeCache-api-url-rename@@2`

## 验证

- `grep -rn 'local-volume-cache' sdk/` 已清零
- 新 URL 已更新到所有 SDK Action 的 `info.path`

## Jira

ZSTAC-81715

## Note

替代 !9740（source branch 加 @@2 以与 premium 配对）。

sync from gitlab !9742