### PR TITLE
<fix>[identity]: surface clear error when quota config is corrupt

### DIFF
--- a/identity/src/main/java/org/zstack/identity/Account.java
+++ b/identity/src/main/java/org/zstack/identity/Account.java
@@ -5,6 +5,7 @@ import org.zstack.core.config.GlobalConfigVO;
 import org.zstack.core.config.GlobalConfigVO_;
 import org.zstack.core.db.Q;
 import org.zstack.core.db.SQLBatchWithReturn;
+import org.zstack.header.exception.CloudRuntimeException;
 import org.zstack.header.identity.*;
 import org.zstack.header.message.Message;
 import org.zstack.utils.DebugUtils;
@@ -70,6 +71,26 @@ public interface Account {
                 .eq(AccountResourceRefVO_.resourceUuid, resUuid).findValue();
     }
 
+    /**
+     * Parse a quota global-config raw value into a long, or surface a
+     * diagnostic CloudRuntimeException when the row is corrupt.
+     *
+     * Shared by {@link #create(AccountBuilder)} (IAM2 / test helper path)
+     * and {@code AccountManagerImpl.createAccount(CreateAccountMsg)}
+     * (the APICreateAccountMsg path users actually hit), so that any
+     * future quota persistence path inherits the same diagnostic tokens
+     * (category / name / raw value / account name) automatically.
+     */
+    static long parseQuotaValueOrThrow(String quotaName, String rawValue, String accountName) {
+        try {
+            return Long.parseLong(rawValue);
+        } catch (NumberFormatException e) {
+            throw new CloudRuntimeException(String.format(
+                    "global config quota[category=%s, name=%s] has invalid value[%s]; cannot create account[name=%s]",
+                    AccountConstant.QUOTA_GLOBAL_CONFIG_CATETORY, quotaName, rawValue, accountName), e);
+        }
+    }
+
     static AccountInventory create(AccountBuilder builder) {
         DebugUtils.Assert(builder.name != null, "name cannot be null");
         DebugUtils.Assert(builder.type != null, "type cannot be null");
@@ -90,7 +111,7 @@ public interface Account {
 
                 for (Tuple t : ts) {
                     String rtype = t.get(0, String.class);
-                    long quota = Long.parseLong(t.get(1, String.class));
+                    long quota = parseQuotaValueOrThrow(rtype, t.get(1, String.class), builder.name);
 
                     if (builder.quota != null && builder.quota.containsKey(rtype)) {
                         quota = builder.quota.get(rtype);

--- a/identity/src/main/java/org/zstack/identity/AccountManagerImpl.java
+++ b/identity/src/main/java/org/zstack/identity/AccountManagerImpl.java
@@ -596,7 +596,7 @@ public class AccountManagerImpl extends AbstractService implements AccountManage
 
                 for (Tuple t : ts) {
                     String rtype = t.get(0, String.class);
-                    long quota = Long.parseLong(t.get(1, String.class));
+                    long quota = Account.parseQuotaValueOrThrow(rtype, t.get(1, String.class), msg.getName());
 
                     QuotaVO qvo = new QuotaVO();
                     qvo.setUuid(Platform.getUuid());

--- a/test/src/test/groovy/org/zstack/test/integration/identity/account/CreateAccountWithCorruptQuotaConfigCase.groovy
+++ b/test/src/test/groovy/org/zstack/test/integration/identity/account/CreateAccountWithCorruptQuotaConfigCase.groovy
@@ -1,0 +1,175 @@
+package org.zstack.test.integration.identity.account
+
+import org.zstack.compute.vm.VmQuotaGlobalConfig
+import org.zstack.core.config.GlobalConfigVO
+import org.zstack.core.config.GlobalConfigVO_
+import org.zstack.core.db.Q
+import org.zstack.core.db.SQL
+import org.zstack.header.exception.CloudRuntimeException
+import org.zstack.header.identity.AccountConstant
+import org.zstack.header.identity.AccountType
+import org.zstack.identity.Account
+import org.zstack.test.integration.ZStackTest
+import org.zstack.testlib.EnvSpec
+import org.zstack.testlib.SubCase
+
+/**
+ * Regression test for ZSTAC-84863: account creation must surface a clear
+ * CloudRuntimeException when a quota global config row is corrupt
+ * (non-numeric value), instead of letting an uncaught NumberFormatException
+ * propagate and roll back the transaction with no diagnostic context.
+ *
+ * Covers both code paths that build QuotaVOs from quota global configs:
+ *   1. {@link Account#create(Account.AccountBuilder)} — IAM2 / test helper path.
+ *   2. {@code APICreateAccountMsg} → {@code AccountManagerImpl.createAccount(CreateAccountMsg)}
+ *      — the SDK / REST path users actually hit.
+ */
+class CreateAccountWithCorruptQuotaConfigCase extends SubCase {
+    EnvSpec env
+
+    @Override
+    void clean() {
+        env.delete()
+    }
+
+    @Override
+    void setup() {
+        useSpring(ZStackTest.springSpec)
+    }
+
+    @Override
+    void environment() {
+        env = env {}
+    }
+
+    @Override
+    void test() {
+        env.create {
+            testCreateAccountFailsOnNonNumericQuota()
+            testCreateAccountFailsOnEmptyQuotaValue()
+            testCreateAccountApiFailsOnNonNumericQuota()
+        }
+    }
+
+    /**
+     * Inject a non-numeric value into a quota global config row by direct
+     * SQL update (bypassing the validator), then assert Account.create
+     * fails with a CloudRuntimeException whose message identifies the
+     * offending category, config name and raw value.
+     */
+    void testCreateAccountFailsOnNonNumericQuota() {
+        assertCorruptQuotaFailsAccountCreate("not-a-number", "corruptQuotaTest1")
+    }
+
+    /**
+     * Long.parseLong("") throws NumberFormatException too — make sure the
+     * empty-string flavour of corruption is also turned into a clear error,
+     * with the same diagnostic tokens as the non-numeric case.
+     */
+    void testCreateAccountFailsOnEmptyQuotaValue() {
+        assertCorruptQuotaFailsAccountCreate("", "corruptQuotaTest2")
+    }
+
+    /**
+     * API path coverage: drives APICreateAccountMsg through the SDK so the
+     * failure surfaces from {@code AccountManagerImpl.createAccount(CreateAccountMsg)}.
+     * This is the path users actually hit — verify the same four diagnostic
+     * tokens (category / config name / raw value / account name) reach the
+     * SDK error response, not just the static {@code Account.create} helper.
+     */
+    void testCreateAccountApiFailsOnNonNumericQuota() {
+        String quotaName = VmQuotaGlobalConfig.VM_TOTAL_NUM.name
+        String corruptValue = "not-a-number-api"
+        String accountName = "corruptQuotaApiTest"
+        String original = readQuotaValue(quotaName)
+        try {
+            writeQuotaValueRaw(quotaName, corruptValue)
+
+            // ApiHelper.createAccount asserts res.error == null, so an API
+            // failure surfaces as AssertionError carrying the JSON-serialized
+            // ErrorCode (whose description embeds our CloudRuntimeException msg).
+            AssertionError caught = null
+            try {
+                createAccount {
+                    delegate.name = accountName
+                    delegate.password = "password"
+                }
+            } catch (AssertionError e) {
+                caught = e
+            }
+
+            assert caught != null:
+                    "expected API failure when quota config has invalid value[${corruptValue}]"
+            assertDiagnosticTokensPresent(caught.message, quotaName, corruptValue, accountName)
+        } finally {
+            writeQuotaValueRaw(quotaName, original)
+        }
+    }
+
+    /**
+     * Drives the corruption→create→assert→restore lifecycle for one
+     * corrupt value via the static {@code Account.create} helper. Asserts
+     * the resulting CloudRuntimeException carries all four diagnostic
+     * tokens (category, config name, raw value, account name) so failure
+     * messages stay actionable for operators.
+     */
+    private void assertCorruptQuotaFailsAccountCreate(String corruptValue, String accountName) {
+        String quotaName = VmQuotaGlobalConfig.VM_TOTAL_NUM.name
+        String original = readQuotaValue(quotaName)
+        try {
+            writeQuotaValueRaw(quotaName, corruptValue)
+
+            CloudRuntimeException caught = null
+            try {
+                Account.create(Account.AccountBuilder.New()
+                        .name(accountName)
+                        .type(AccountType.Normal)
+                        .password("password"))
+            } catch (CloudRuntimeException e) {
+                caught = e
+            }
+
+            assert caught != null:
+                    "expected CloudRuntimeException when quota config has invalid value[${corruptValue}]"
+            assertDiagnosticTokensPresent(caught.message, quotaName, corruptValue, accountName)
+        } finally {
+            writeQuotaValueRaw(quotaName, original)
+        }
+    }
+
+    /**
+     * Shared assertion: every failure path must surface the same four
+     * tokens so operators can pinpoint the offending row and account
+     * without grepping logs. Kept here so both the static-helper path
+     * and the API path stay in lockstep.
+     */
+    private static void assertDiagnosticTokensPresent(String msg,
+                                                      String quotaName,
+                                                      String corruptValue,
+                                                      String accountName) {
+        assert msg.contains(AccountConstant.QUOTA_GLOBAL_CONFIG_CATETORY):
+                "error message should include quota category, got: ${msg}"
+        assert msg.contains(quotaName):
+                "error message should include config name, got: ${msg}"
+        assert msg.contains(corruptValue):
+                "error message should include raw value, got: ${msg}"
+        assert msg.contains(accountName):
+                "error message should include account name, got: ${msg}"
+    }
+
+    private static String readQuotaValue(String name) {
+        return Q.New(GlobalConfigVO.class)
+                .eq(GlobalConfigVO_.category, AccountConstant.QUOTA_GLOBAL_CONFIG_CATETORY)
+                .eq(GlobalConfigVO_.name, name)
+                .select(GlobalConfigVO_.value)
+                .findValue()
+    }
+
+    private static void writeQuotaValueRaw(String name, String value) {
+        SQL.New(GlobalConfigVO.class)
+                .eq(GlobalConfigVO_.category, AccountConstant.QUOTA_GLOBAL_CONFIG_CATETORY)
+                .eq(GlobalConfigVO_.name, name)
+                .set(GlobalConfigVO_.value, value)
+                .update()
+    }
+}


### PR DESCRIPTION
## ZSTAC-84863

### Root Cause
`Account.create()` reads every quota global config row and parses its value with `Long.parseLong`. If the `quota_global_config` table happens to hold a non-numeric value (legacy data, manual SQL edit, or partial migration), the uncaught `NumberFormatException` propagated out of the create-account transaction. The caller only saw a generic transaction rollback with no indication of which category, config name, or value was responsible — making the issue impossible to triage from logs.

### Changes
| Module | Change |
|--------|--------|
| `core/src/main/java/org/zstack/identity/Account.java` | Wrap `Long.parseLong` of quota global config values in try/catch; rethrow as `CloudRuntimeException` carrying the offending category, config name, raw value, and target account name. Transaction rollback behavior is unchanged. |
| `test/src/test/groovy/.../CreateAccountWithCorruptQuotaConfigCase.groovy` | New SubCase under the identity test suite: injects a non-numeric value and an empty string into a quota global config row via direct SQL update (bypassing the validator) and asserts `CloudRuntimeException` carries category, config name, raw value, and account name. |

### Test
- `CreateAccountWithCorruptQuotaConfigCase`: passed locally

### Side Effects
None. The exception type observed by callers changes from `NumberFormatException` to `CloudRuntimeException`, but outer transaction behavior is identical (rollback, no half-created account or quota row). Negative quota values remain a follow-up — the existing config validator already rejects them on update.

Related: ZSTAC-84863

sync from gitlab !9757