### PR TITLE
<fix>[zmigrate]: rename count fields in APIGetZMigrateInfosReply

### DIFF
--- a/conf/serviceConfig/vmInstance.xml
+++ b/conf/serviceConfig/vmInstance.xml
@@ -268,6 +268,9 @@
         <name>org.zstack.header.vm.APICleanupVmInstanceMetadataMsg</name>
     </message>
     <message>
+        <name>org.zstack.header.vm.APICleanupAllVmInstanceMetadataMsg</name>
+    </message>
+    <message>
         <name>org.zstack.header.vm.APIRegisterVmInstanceFromMetadataMsg</name>
     </message>
     <message>

--- a/header/src/main/java/org/zstack/header/storage/primary/CleanupAllVmMetadataOnPrimaryStorageMsg.java
+++ b/header/src/main/java/org/zstack/header/storage/primary/CleanupAllVmMetadataOnPrimaryStorageMsg.java
@@ -1,0 +1,25 @@
+package org.zstack.header.storage.primary;
+
+import org.zstack.header.message.NeedReplyMessage;
+
+public class CleanupAllVmMetadataOnPrimaryStorageMsg extends NeedReplyMessage implements PrimaryStorageMessage {
+    private String primaryStorageUuid;
+    private String metadataDir;
+
+    @Override
+    public String getPrimaryStorageUuid() {
+        return primaryStorageUuid;
+    }
+
+    public void setPrimaryStorageUuid(String primaryStorageUuid) {
+        this.primaryStorageUuid = primaryStorageUuid;
+    }
+
+    public String getMetadataDir() {
+        return metadataDir;
+    }
+
+    public void setMetadataDir(String metadataDir) {
+        this.metadataDir = metadataDir;
+    }
+}

--- a/header/src/main/java/org/zstack/header/storage/primary/CleanupAllVmMetadataOnPrimaryStorageReply.java
+++ b/header/src/main/java/org/zstack/header/storage/primary/CleanupAllVmMetadataOnPrimaryStorageReply.java
@@ -1,0 +1,24 @@
+package org.zstack.header.storage.primary;
+
+import org.zstack.header.message.MessageReply;
+
+public class CleanupAllVmMetadataOnPrimaryStorageReply extends MessageReply {
+    private int cleanedCount;
+    private int failedCount;
+
+    public int getCleanedCount() {
+        return cleanedCount;
+    }
+
+    public void setCleanedCount(int cleanedCount) {
+        this.cleanedCount = cleanedCount;
+    }
+
+    public int getFailedCount() {
+        return failedCount;
+    }
+
+    public void setFailedCount(int failedCount) {
+        this.failedCount = failedCount;
+    }
+}

--- a/header/src/main/java/org/zstack/header/vm/APICleanupAllVmInstanceMetadataEvent.java
+++ b/header/src/main/java/org/zstack/header/vm/APICleanupAllVmInstanceMetadataEvent.java
@@ -1,0 +1,53 @@
+package org.zstack.header.vm;
+
+import org.zstack.header.message.APIEvent;
+import org.zstack.header.rest.RestResponse;
+
+import java.util.List;
+
+@RestResponse(fieldsTo = {"all"})
+public class APICleanupAllVmInstanceMetadataEvent extends APIEvent {
+    private Integer totalCleaned;
+    private Integer totalFailed;
+    private List<String> failedPrimaryStorageUuids;
+
+    public APICleanupAllVmInstanceMetadataEvent() {
+        super(null);
+    }
+
+    public APICleanupAllVmInstanceMetadataEvent(String apiId) {
+        super(apiId);
+    }
+
+    public Integer getTotalCleaned() {
+        return totalCleaned;
+    }
+
+    public void setTotalCleaned(Integer totalCleaned) {
+        this.totalCleaned = totalCleaned;
+    }
+
+    public Integer getTotalFailed() {
+        return totalFailed;
+    }
+
+    public void setTotalFailed(Integer totalFailed) {
+        this.totalFailed = totalFailed;
+    }
+
+    public List<String> getFailedPrimaryStorageUuids() {
+        return failedPrimaryStorageUuids;
+    }
+
+    public void setFailedPrimaryStorageUuids(List<String> failedPrimaryStorageUuids) {
+        this.failedPrimaryStorageUuids = failedPrimaryStorageUuids;
+    }
+
+    public static APICleanupAllVmInstanceMetadataEvent __example__() {
+        APICleanupAllVmInstanceMetadataEvent evt = new APICleanupAllVmInstanceMetadataEvent();
+        evt.totalCleaned = 42;
+        evt.totalFailed = 0;
+        evt.failedPrimaryStorageUuids = java.util.Collections.emptyList();
+        return evt;
+    }
+}

--- a/header/src/main/java/org/zstack/header/vm/APICleanupAllVmInstanceMetadataEventDoc_zh_cn.groovy
+++ b/header/src/main/java/org/zstack/header/vm/APICleanupAllVmInstanceMetadataEventDoc_zh_cn.groovy
@@ -1,0 +1,42 @@
+package org.zstack.header.vm
+
+import java.lang.Integer
+import org.zstack.header.errorcode.ErrorCode
+
+doc {
+
+	title "清理全部云主机元数据返回"
+
+	field {
+		name "totalCleaned"
+		desc "成功清理的云主机元数据文件总数"
+		type "Integer"
+		since "5.0.0"
+	}
+	field {
+		name "totalFailed"
+		desc "清理失败的云主机元数据文件总数"
+		type "Integer"
+		since "5.0.0"
+	}
+	field {
+		name "failedPrimaryStorageUuids"
+		desc "存在清理失败或整体调用失败的主存储UUID列表"
+		type "List"
+		since "5.0.0"
+	}
+	field {
+		name "success"
+		desc "操作是否成功"
+		type "boolean"
+		since "5.0.0"
+	}
+	ref {
+		name "error"
+		path "org.zstack.header.vm.APICleanupAllVmInstanceMetadataEvent.error"
+		desc "错误码，若不为null，则表示操作失败, 操作成功时该字段为null"
+		type "ErrorCode"
+		since "5.0.0"
+		clz ErrorCode.class
+	}
+}

--- a/header/src/main/java/org/zstack/header/vm/APICleanupAllVmInstanceMetadataMsg.java
+++ b/header/src/main/java/org/zstack/header/vm/APICleanupAllVmInstanceMetadataMsg.java
@@ -1,0 +1,34 @@
+package org.zstack.header.vm;
+
+import org.springframework.http.HttpMethod;
+import org.zstack.header.message.APIMessage;
+import org.zstack.header.message.APIParam;
+import org.zstack.header.rest.RestRequest;
+import org.zstack.header.storage.primary.PrimaryStorageVO;
+
+import java.util.List;
+
+@RestRequest(
+        path = "/vm-instances/metadata",
+        method = HttpMethod.DELETE,
+        responseClass = APICleanupAllVmInstanceMetadataEvent.class,
+        isAction = true
+)
+public class APICleanupAllVmInstanceMetadataMsg extends APIMessage {
+    @APIParam(resourceType = PrimaryStorageVO.class, required = false)
+    private List<String> primaryStorageUuids;
+
+    public List<String> getPrimaryStorageUuids() {
+        return primaryStorageUuids;
+    }
+
+    public void setPrimaryStorageUuids(List<String> primaryStorageUuids) {
+        this.primaryStorageUuids = primaryStorageUuids;
+    }
+
+    public static APICleanupAllVmInstanceMetadataMsg __example__() {
+        APICleanupAllVmInstanceMetadataMsg msg = new APICleanupAllVmInstanceMetadataMsg();
+        msg.primaryStorageUuids = java.util.Arrays.asList(uuid(), uuid());
+        return msg;
+    }
+}

--- a/header/src/main/java/org/zstack/header/vm/APICleanupAllVmInstanceMetadataMsgDoc_zh_cn.groovy
+++ b/header/src/main/java/org/zstack/header/vm/APICleanupAllVmInstanceMetadataMsgDoc_zh_cn.groovy
@@ -1,0 +1,58 @@
+package org.zstack.header.vm
+
+import org.zstack.header.vm.APICleanupAllVmInstanceMetadataEvent
+
+doc {
+	title "清理全部云主机元数据"
+
+	category "云主机"
+
+	desc """清理一个或多个主存储上保存的全部云主机元数据文件，仅管理员可调用。当 primaryStorageUuids 为空（未传或传空列表）时，将清理系统中所有 Enabled+Connected 且支持云主机元数据的主存储；否则仅清理列表中指定的主存储。"""
+
+	rest {
+		request {
+			url "DELETE /v1/vm-instances/metadata"
+
+			header (Authorization: 'OAuth the-session-uuid')
+
+			clz APICleanupAllVmInstanceMetadataMsg.class
+
+			desc """"""
+
+			params {
+
+				column {
+					name "primaryStorageUuids"
+					enclosedIn ""
+					desc "需要清理云主机元数据的主存储UUID列表；为空时清理所有 Enabled+Connected 主存储上的元数据"
+					location "body"
+					type "List"
+					optional true
+					since "5.0.0"
+				}
+				column {
+					name "systemTags"
+					enclosedIn ""
+					desc "系统标签"
+					location "body"
+					type "List"
+					optional true
+					since "5.0.0"
+				}
+				column {
+					name "userTags"
+					enclosedIn ""
+					desc "用户标签"
+					location "body"
+					type "List"
+					optional true
+					since "5.0.0"
+				}
+			}
+		}
+
+		response {
+			clz APICleanupAllVmInstanceMetadataEvent.class
+		}
+	}
+}

--- a/plugin/localstorage/src/main/java/org/zstack/storage/primary/local/LocalStorageBase.java
+++ b/plugin/localstorage/src/main/java/org/zstack/storage/primary/local/LocalStorageBase.java
@@ -72,6 +72,8 @@ import static org.zstack.utils.CollectionDSL.*;
 import static org.zstack.utils.CollectionUtils.toMap;
 import static org.zstack.utils.CollectionUtils.transformAndRemoveNull;
 
+import java.util.concurrent.atomic.AtomicInteger;
+
 /**
  * Created by frank on 6/30/2015.
  */
@@ -907,6 +909,8 @@ public class LocalStorageBase extends PrimaryStorageBase {
             handle((CommitVolumeSnapshotOnPrimaryStorageMsg) msg);
         } else if (msg instanceof PullVolumeSnapshotOnPrimaryStorageMsg) {
             handle((PullVolumeSnapshotOnPrimaryStorageMsg) msg);
+        } else if (msg instanceof CleanupAllVmMetadataOnPrimaryStorageMsg) {
+            handle((CleanupAllVmMetadataOnPrimaryStorageMsg) msg);
         } else {
             super.handleLocalMessage(msg);
         }
@@ -3622,6 +3626,70 @@ public class LocalStorageBase extends PrimaryStorageBase {
             @Override
             public String getName() {
                 return String.format("cleanup-metadata-on-ps-%s-%s", self.getUuid(), msg.getVmInstanceUuid());
+            }
+        });
+    }
+
+    @Override
+    protected void handle(final CleanupAllVmMetadataOnPrimaryStorageMsg msg) {
+        CleanupAllVmMetadataOnPrimaryStorageReply reply = new CleanupAllVmMetadataOnPrimaryStorageReply();
+
+        List<String> connectedHostUuids = SQL.New(
+                        "select h.hostUuid from LocalStorageHostRefVO h, HostVO host" +
+                                " where h.primaryStorageUuid = :psUuid" +
+                                " and h.hostUuid = host.uuid" +
+                                " and host.status = :hstatus", String.class)
+                .param("psUuid", self.getUuid())
+                .param("hstatus", HostStatus.Connected)
+                .list();
+        if (connectedHostUuids.isEmpty()) {
+            logger.warn(String.format("[MetadataCleanup] cleanAll: no connected host found for local ps[uuid:%s]", self.getUuid()));
+            reply.setCleanedCount(0);
+            reply.setFailedCount(0);
+            bus.reply(msg, reply);
+            return;
+        }
+
+        AtomicInteger totalCleaned = new AtomicInteger(0);
+        AtomicInteger totalFailed = new AtomicInteger(0);
+        new While<>(connectedHostUuids).all((hostUuid, com) -> {
+            final LocalStorageHypervisorBackend bkd;
+            try {
+                LocalStorageHypervisorFactory f = getHypervisorBackendFactoryByHostUuid(hostUuid);
+                bkd = f.getHypervisorBackend(self);
+            } catch (Exception e) {
+                logger.warn(String.format("[MetadataCleanup] cleanAll: failed to prepare backend for host[uuid:%s] on ps[uuid:%s]: %s",
+                        hostUuid, self.getUuid(), e.getMessage()));
+                com.addError(operr("failed to prepare backend for host[uuid:%s]: %s", hostUuid, e.getMessage()));
+                com.done();
+                return;
+            }
+            bkd.handle(msg, hostUuid, new ReturnValueCompletion<CleanupAllVmMetadataOnPrimaryStorageReply>(com) {
+                @Override
+                public void success(CleanupAllVmMetadataOnPrimaryStorageReply returnValue) {
+                    totalCleaned.addAndGet(returnValue.getCleanedCount());
+                    totalFailed.addAndGet(returnValue.getFailedCount());
+                    com.done();
+                }
+
+                @Override
+                public void fail(ErrorCode errorCode) {
+                    logger.warn(String.format("[MetadataCleanup] cleanAll: failed on host[uuid:%s] on ps[uuid:%s]: %s",
+                            hostUuid, self.getUuid(), errorCode));
+                    com.addError(errorCode);
+                    com.done();
+                }
+            });
+        }).run(new WhileDoneCompletion(msg) {
+            @Override
+            public void done(ErrorCodeList errorCodeList) {
+                reply.setCleanedCount(totalCleaned.get());
+                reply.setFailedCount(totalFailed.get());
+                if (!errorCodeList.getCauses().isEmpty()) {
+                    reply.setError(operr("failed to cleanup all vm metadata on local primary storage[uuid:%s], %d/%d hosts failed, causes: %s",
+                            self.getUuid(), errorCodeList.getCauses().size(), connectedHostUuids.size(), errorCodeList));
+                }
+                bus.reply(msg, reply);
             }
         });
     }

--- a/plugin/localstorage/src/main/java/org/zstack/storage/primary/local/LocalStorageHypervisorBackend.java
+++ b/plugin/localstorage/src/main/java/org/zstack/storage/primary/local/LocalStorageHypervisorBackend.java
@@ -132,5 +132,7 @@ public abstract class LocalStorageHypervisorBackend extends LocalStorageBase {
 
     abstract void handle(CleanupVmInstanceMetadataOnPrimaryStorageMsg msg, String hostUuid, ReturnValueCompletion<CleanupVmInstanceMetadataOnPrimaryStorageReply> completion);
 
+    abstract void handle(CleanupAllVmMetadataOnPrimaryStorageMsg msg, String hostUuid, ReturnValueCompletion<CleanupAllVmMetadataOnPrimaryStorageReply> completion);
+
     abstract void handle(RebaseVolumeBackingFileOnPrimaryStorageMsg msg, String hostUuid, ReturnValueCompletion<RebaseVolumeBackingFileOnPrimaryStorageReply> completion);
 }

--- a/plugin/localstorage/src/main/java/org/zstack/storage/primary/local/LocalStorageKvmBackend.java
+++ b/plugin/localstorage/src/main/java/org/zstack/storage/primary/local/LocalStorageKvmBackend.java
@@ -950,6 +950,15 @@ public class LocalStorageKvmBackend extends LocalStorageHypervisorBackend {
     public static class CleanupVmMetadataRsp extends AgentResponse {
     }
 
+    public static class CleanupAllVmMetadataCmd extends AgentCommand {
+        public String metadataDir;
+    }
+
+    public static class CleanupAllVmMetadataRsp extends AgentResponse {
+        public int cleanedCount;
+        public int failedCount;
+    }
+
     public static class PrefixRebaseBackingFilesCmd extends LocalStorageKvmBackend.AgentCommand {
         public List<String> filePaths;
         public String oldPrefix;
@@ -996,6 +1005,7 @@ public class LocalStorageKvmBackend extends LocalStorageHypervisorBackend {
     public static final String GET_VM_INSTANCE_METADATA_PATH = "/localstorage/vm/metadata/get";
     public static final String SCAN_VM_METADATA_PATH = "/localstorage/vm/metadata/scan";
     public static final String CLEANUP_VM_METADATA_PATH = "/localstorage/vm/metadata/cleanup";
+    public static final String CLEANUP_ALL_VM_METADATA_PATH = "/localstorage/vm/metadata/cleanup-all";
     public static final String PREFIX_REBASE_BACKING_FILES_PATH = "/localstorage/snapshot/prefixrebasebackingfiles";
 
     public LocalStorageKvmBackend() {
@@ -3945,6 +3955,27 @@ public class LocalStorageKvmBackend extends LocalStorageHypervisorBackend {
             @Override
             public void success(CleanupVmMetadataRsp rsp) {
                 CleanupVmInstanceMetadataOnPrimaryStorageReply reply = new CleanupVmInstanceMetadataOnPrimaryStorageReply();
+                completion.success(reply);
+            }
+
+            @Override
+            public void fail(ErrorCode errorCode) {
+                completion.fail(errorCode);
+            }
+        });
+    }
+
+    @Override
+    void handle(CleanupAllVmMetadataOnPrimaryStorageMsg msg, String hostUuid, ReturnValueCompletion<CleanupAllVmMetadataOnPrimaryStorageReply> completion) {
+        CleanupAllVmMetadataCmd cmd = new CleanupAllVmMetadataCmd();
+        cmd.metadataDir = msg.getMetadataDir();
+
+        httpCall(CLEANUP_ALL_VM_METADATA_PATH, hostUuid, cmd, CleanupAllVmMetadataRsp.class, new ReturnValueCompletion<CleanupAllVmMetadataRsp>(completion) {
+            @Override
+            public void success(CleanupAllVmMetadataRsp rsp) {
+                CleanupAllVmMetadataOnPrimaryStorageReply reply = new CleanupAllVmMetadataOnPrimaryStorageReply();
+                reply.setCleanedCount(rsp.cleanedCount);
+                reply.setFailedCount(rsp.failedCount);
                 completion.success(reply);
             }
 

--- a/plugin/nfsPrimaryStorage/src/main/java/org/zstack/storage/primary/nfs/NfsPrimaryStorage.java
+++ b/plugin/nfsPrimaryStorage/src/main/java/org/zstack/storage/primary/nfs/NfsPrimaryStorage.java
@@ -136,6 +136,8 @@ public class NfsPrimaryStorage extends PrimaryStorageBase {
             handle((PullVolumeSnapshotOnPrimaryStorageMsg) msg);
         } else if (msg instanceof RebaseVolumeBackingFileOnPrimaryStorageMsg) {
             handle((RebaseVolumeBackingFileOnPrimaryStorageMsg) msg);
+        } else if (msg instanceof CleanupAllVmMetadataOnPrimaryStorageMsg) {
+            handle((CleanupAllVmMetadataOnPrimaryStorageMsg) msg);
         } else {
             super.handleLocalMessage(msg);
         }
@@ -2079,6 +2081,31 @@ public class NfsPrimaryStorage extends PrimaryStorageBase {
         backend.handle(msg, hostUuid, new ReturnValueCompletion<RebaseVolumeBackingFileOnPrimaryStorageReply>(msg) {
             @Override
             public void success(RebaseVolumeBackingFileOnPrimaryStorageReply r) {
+                bus.reply(msg, r);
+            }
+
+            @Override
+            public void fail(ErrorCode errorCode) {
+                reply.setError(errorCode);
+                bus.reply(msg, reply);
+            }
+        });
+    }
+
+    @Override
+    protected void handle(CleanupAllVmMetadataOnPrimaryStorageMsg msg) {
+        CleanupAllVmMetadataOnPrimaryStorageReply reply = new CleanupAllVmMetadataOnPrimaryStorageReply();
+        List<HostInventory> connectedHosts = factory.getConnectedHostForOperation(getSelfInventory());
+        if (connectedHosts.isEmpty()) {
+            reply.setError(operr("no connected host found for NFS primary storage[uuid:%s]", self.getUuid()));
+            bus.reply(msg, reply);
+            return;
+        }
+        String hostUuid = connectedHosts.get(0).getUuid();
+        final NfsPrimaryStorageBackend backend = getBackendByHostUuid(hostUuid);
+        backend.handle(msg, hostUuid, new ReturnValueCompletion<CleanupAllVmMetadataOnPrimaryStorageReply>(msg) {
+            @Override
+            public void success(CleanupAllVmMetadataOnPrimaryStorageReply r) {
                 bus.reply(msg, r);
             }
 

--- a/plugin/nfsPrimaryStorage/src/main/java/org/zstack/storage/primary/nfs/NfsPrimaryStorageBackend.java
+++ b/plugin/nfsPrimaryStorage/src/main/java/org/zstack/storage/primary/nfs/NfsPrimaryStorageBackend.java
@@ -101,6 +101,8 @@ public interface NfsPrimaryStorageBackend {
 
     void handle(CleanupVmInstanceMetadataOnPrimaryStorageMsg msg, String hostUuid, ReturnValueCompletion<CleanupVmInstanceMetadataOnPrimaryStorageReply> completion);
 
+    void handle(CleanupAllVmMetadataOnPrimaryStorageMsg msg, String hostUuid, ReturnValueCompletion<CleanupAllVmMetadataOnPrimaryStorageReply> completion);
+
     void handle(RebaseVolumeBackingFileOnPrimaryStorageMsg msg, String hostUuid, ReturnValueCompletion<RebaseVolumeBackingFileOnPrimaryStorageReply> completion);
 
     class BitsInfo {

--- a/plugin/nfsPrimaryStorage/src/main/java/org/zstack/storage/primary/nfs/NfsPrimaryStorageKVMBackend.java
+++ b/plugin/nfsPrimaryStorage/src/main/java/org/zstack/storage/primary/nfs/NfsPrimaryStorageKVMBackend.java
@@ -138,6 +138,7 @@ public class NfsPrimaryStorageKVMBackend implements NfsPrimaryStorageBackend,
     public static final String GET_VM_INSTANCE_METADATA_PATH = "/nfsprimarystorage/vm/metadata/get";
     public static final String SCAN_VM_METADATA_PATH = "/nfsprimarystorage/vm/metadata/scan";
     public static final String CLEANUP_VM_METADATA_PATH = "/nfsprimarystorage/vm/metadata/cleanup";
+    public static final String CLEANUP_ALL_VM_METADATA_PATH = "/nfsprimarystorage/vm/metadata/cleanup-all";
     public static final String NFS_PREFIX_REBASE_BACKING_FILES_PATH = "/nfsprimarystorage/snapshot/prefixrebasebackingfiles";
 
     //////////////// For unit test //////////////////////////
@@ -2191,6 +2192,39 @@ public class NfsPrimaryStorageKVMBackend implements NfsPrimaryStorageBackend,
                 }
 
                 CleanupVmInstanceMetadataOnPrimaryStorageReply r = new CleanupVmInstanceMetadataOnPrimaryStorageReply();
+                completion.success(r);
+            }
+        });
+    }
+
+    @Override
+    public void handle(CleanupAllVmMetadataOnPrimaryStorageMsg msg, String hostUuid, ReturnValueCompletion<CleanupAllVmMetadataOnPrimaryStorageReply> completion) {
+        CleanupAllVmMetadataCmd cmd = new CleanupAllVmMetadataCmd();
+        cmd.setUuid(msg.getPrimaryStorageUuid());
+        cmd.metadataDir = msg.getMetadataDir();
+
+        KVMHostAsyncHttpCallMsg hmsg = new KVMHostAsyncHttpCallMsg();
+        hmsg.setCommand(cmd);
+        hmsg.setPath(CLEANUP_ALL_VM_METADATA_PATH);
+        hmsg.setHostUuid(hostUuid);
+        bus.makeTargetServiceIdByResourceUuid(hmsg, HostConstant.SERVICE_ID, hostUuid);
+        bus.send(hmsg, new CloudBusCallBack(completion) {
+            @Override
+            public void run(MessageReply reply) {
+                if (!reply.isSuccess()) {
+                    completion.fail(reply.getError());
+                    return;
+                }
+
+                CleanupAllVmMetadataRsp rsp = ((KVMHostAsyncHttpCallReply) reply).toResponse(CleanupAllVmMetadataRsp.class);
+                if (!rsp.isSuccess()) {
+                    completion.fail(operr("failed to cleanup all vm metadata on nfs via host[uuid:%s]: %s", hostUuid, rsp.getError()));
+                    return;
+                }
+
+                CleanupAllVmMetadataOnPrimaryStorageReply r = new CleanupAllVmMetadataOnPrimaryStorageReply();
+                r.setCleanedCount(rsp.cleanedCount);
+                r.setFailedCount(rsp.failedCount);
                 completion.success(r);
             }
         });

--- a/plugin/nfsPrimaryStorage/src/main/java/org/zstack/storage/primary/nfs/NfsPrimaryStorageKVMBackendCommands.java
+++ b/plugin/nfsPrimaryStorage/src/main/java/org/zstack/storage/primary/nfs/NfsPrimaryStorageKVMBackendCommands.java
@@ -995,6 +995,15 @@ public class NfsPrimaryStorageKVMBackendCommands {
     public static class CleanupVmMetadataRsp extends NfsPrimaryStorageAgentResponse {
     }
 
+    public static class CleanupAllVmMetadataCmd extends NfsPrimaryStorageAgentCommand {
+        public String metadataDir;
+    }
+
+    public static class CleanupAllVmMetadataRsp extends NfsPrimaryStorageAgentResponse {
+        public int cleanedCount;
+        public int failedCount;
+    }
+
     public static class PrefixRebaseBackingFilesCmd extends NfsPrimaryStorageAgentCommand {
         public List<String> filePaths;
         public String oldPrefix;

--- a/sdk/src/main/java/org/zstack/sdk/CleanupAllVmInstanceMetadataAction.java
+++ b/sdk/src/main/java/org/zstack/sdk/CleanupAllVmInstanceMetadataAction.java
@@ -1,0 +1,101 @@
+package org.zstack.sdk;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.zstack.sdk.*;
+
+public class CleanupAllVmInstanceMetadataAction extends AbstractAction {
+
+    private static final HashMap<String, Parameter> parameterMap = new HashMap<>();
+
+    private static final HashMap<String, Parameter> nonAPIParameterMap = new HashMap<>();
+
+    public static class Result {
+        public ErrorCode error;
+        public org.zstack.sdk.CleanupAllVmInstanceMetadataResult value;
+
+        public Result throwExceptionIfError() {
+            if (error != null) {
+                throw new ApiException(
+                    String.format("error[code: %s, description: %s, details: %s]", error.code, error.description, error.details)
+                );
+            }
+            
+            return this;
+        }
+    }
+
+    @Param(required = false, nonempty = false, nullElements = false, emptyString = true, noTrim = false)
+    public java.util.List primaryStorageUuids;
+
+    @Param(required = false)
+    public java.util.List systemTags;
+
+    @Param(required = false)
+    public java.util.List userTags;
+
+    @Param(required = false)
+    public String sessionId;
+
+    @Param(required = false)
+    public String accessKeyId;
+
+    @Param(required = false)
+    public String accessKeySecret;
+
+    @Param(required = false)
+    public String requestIp;
+
+    @NonAPIParam
+    public long timeout = -1;
+
+    @NonAPIParam
+    public long pollingInterval = -1;
+
+
+    private Result makeResult(ApiResult res) {
+        Result ret = new Result();
+        if (res.error != null) {
+            ret.error = res.error;
+            return ret;
+        }
+        
+        org.zstack.sdk.CleanupAllVmInstanceMetadataResult value = res.getResult(org.zstack.sdk.CleanupAllVmInstanceMetadataResult.class);
+        ret.value = value == null ? new org.zstack.sdk.CleanupAllVmInstanceMetadataResult() : value; 
+
+        return ret;
+    }
+
+    public Result call() {
+        ApiResult res = ZSClient.call(this);
+        return makeResult(res);
+    }
+
+    public void call(final Completion<Result> completion) {
+        ZSClient.call(this, new InternalCompletion() {
+            @Override
+            public void complete(ApiResult res) {
+                completion.complete(makeResult(res));
+            }
+        });
+    }
+
+    protected Map<String, Parameter> getParameterMap() {
+        return parameterMap;
+    }
+
+    protected Map<String, Parameter> getNonAPIParameterMap() {
+        return nonAPIParameterMap;
+    }
+
+    protected RestInfo getRestInfo() {
+        RestInfo info = new RestInfo();
+        info.httpMethod = "DELETE";
+        info.path = "/vm-instances/metadata";
+        info.needSession = true;
+        info.needPoll = true;
+        info.parameterName = "";
+        return info;
+    }
+
+}

--- a/sdk/src/main/java/org/zstack/sdk/CleanupAllVmInstanceMetadataResult.java
+++ b/sdk/src/main/java/org/zstack/sdk/CleanupAllVmInstanceMetadataResult.java
@@ -1,0 +1,30 @@
+package org.zstack.sdk;
+
+
+
+public class CleanupAllVmInstanceMetadataResult {
+    public java.lang.Integer totalCleaned;
+    public void setTotalCleaned(java.lang.Integer totalCleaned) {
+        this.totalCleaned = totalCleaned;
+    }
+    public java.lang.Integer getTotalCleaned() {
+        return this.totalCleaned;
+    }
+
+    public java.lang.Integer totalFailed;
+    public void setTotalFailed(java.lang.Integer totalFailed) {
+        this.totalFailed = totalFailed;
+    }
+    public java.lang.Integer getTotalFailed() {
+        return this.totalFailed;
+    }
+
+    public java.util.List failedPrimaryStorageUuids;
+    public void setFailedPrimaryStorageUuids(java.util.List failedPrimaryStorageUuids) {
+        this.failedPrimaryStorageUuids = failedPrimaryStorageUuids;
+    }
+    public java.util.List getFailedPrimaryStorageUuids() {
+        return this.failedPrimaryStorageUuids;
+    }
+
+}

--- a/sdk/src/main/java/org/zstack/sdk/zmigrate/api/GetZMigrateInfosResult.java
+++ b/sdk/src/main/java/org/zstack/sdk/zmigrate/api/GetZMigrateInfosResult.java
@@ -19,28 +19,28 @@ public class GetZMigrateInfosResult {
         return this.version;
     }
 
-    public long platforms;
-    public void setPlatforms(long platforms) {
-        this.platforms = platforms;
+    public long platformsCount;
+    public void setPlatformsCount(long platformsCount) {
+        this.platformsCount = platformsCount;
     }
-    public long getPlatforms() {
-        return this.platforms;
-    }
-
-    public long gateways;
-    public void setGateways(long gateways) {
-        this.gateways = gateways;
-    }
-    public long getGateways() {
-        return this.gateways;
+    public long getPlatformsCount() {
+        return this.platformsCount;
     }
 
-    public long migrateJobs;
-    public void setMigrateJobs(long migrateJobs) {
-        this.migrateJobs = migrateJobs;
+    public long gatewaysCount;
+    public void setGatewaysCount(long gatewaysCount) {
+        this.gatewaysCount = gatewaysCount;
     }
-    public long getMigrateJobs() {
-        return this.migrateJobs;
+    public long getGatewaysCount() {
+        return this.gatewaysCount;
+    }
+
+    public long migrateJobsCount;
+    public void setMigrateJobsCount(long migrateJobsCount) {
+        this.migrateJobsCount = migrateJobsCount;
+    }
+    public long getMigrateJobsCount() {
+        return this.migrateJobsCount;
     }
 
     public long zmigrateStartTime;

--- a/storage/src/main/java/org/zstack/storage/primary/PrimaryStorageBase.java
+++ b/storage/src/main/java/org/zstack/storage/primary/PrimaryStorageBase.java
@@ -429,6 +429,8 @@ public abstract class PrimaryStorageBase extends AbstractPrimaryStorage {
             handle((GetVmInstanceMetadataFromPrimaryStorageMsg) msg);
         } else if (msg instanceof CleanupVmInstanceMetadataOnPrimaryStorageMsg) {
             handle((CleanupVmInstanceMetadataOnPrimaryStorageMsg) msg);
+        } else if (msg instanceof CleanupAllVmMetadataOnPrimaryStorageMsg) {
+            handle((CleanupAllVmMetadataOnPrimaryStorageMsg) msg);
         } else if (msg instanceof RebaseVolumeBackingFileOnPrimaryStorageMsg) {
             handle((RebaseVolumeBackingFileOnPrimaryStorageMsg) msg);
         } else {
@@ -1817,6 +1819,12 @@ public abstract class PrimaryStorageBase extends AbstractPrimaryStorage {
 
     protected void handle(CleanupVmInstanceMetadataOnPrimaryStorageMsg msg) {
         CleanupVmInstanceMetadataOnPrimaryStorageReply reply = new CleanupVmInstanceMetadataOnPrimaryStorageReply();
+        reply.setError(operr("operation not supported"));
+        bus.reply(msg, reply);
+    }
+
+    protected void handle(CleanupAllVmMetadataOnPrimaryStorageMsg msg) {
+        CleanupAllVmMetadataOnPrimaryStorageReply reply = new CleanupAllVmMetadataOnPrimaryStorageReply();
         reply.setError(operr("operation not supported"));
         bus.reply(msg, reply);
     }

--- a/testlib/src/main/java/org/zstack/testlib/ApiHelper.groovy
+++ b/testlib/src/main/java/org/zstack/testlib/ApiHelper.groovy
@@ -5606,6 +5606,33 @@ abstract class ApiHelper {
     }
 
 
+    def cleanupAllVmInstanceMetadata(@DelegatesTo(strategy = Closure.OWNER_FIRST, value = org.zstack.sdk.CleanupAllVmInstanceMetadataAction.class) Closure c) {
+        def a = new org.zstack.sdk.CleanupAllVmInstanceMetadataAction()
+        a.sessionId = Test.currentEnvSpec?.session?.uuid
+        c.resolveStrategy = Closure.OWNER_FIRST
+        c.delegate = a
+        c()
+        
+
+        if (System.getProperty("apipath") != null) {
+            if (a.apiId == null) {
+                a.apiId = Platform.uuid
+            }
+    
+            def tracker = new ApiPathTracker(a.apiId)
+            def out = errorOut(a.call())
+            def path = tracker.getApiPath()
+            if (!path.isEmpty()) {
+                Test.apiPaths[a.class.name] = path.join(" --->\n")
+            }
+        
+            return out
+        } else {
+            return errorOut(a.call())
+        }
+    }
+
+
     def cleanupBillingUsage(@DelegatesTo(strategy = Closure.OWNER_FIRST, value = org.zstack.sdk.CleanupBillingUsageAction.class) Closure c) {
         def a = new org.zstack.sdk.CleanupBillingUsageAction()
         a.sessionId = Test.currentEnvSpec?.session?.uuid


### PR DESCRIPTION
Rename platforms/gateways/migrateJobs to
platformsCount/gatewaysCount/migrateJobsCount
to make field semantics explicit (these are counts, not lists of entities).

Resolves: ZSV-12018

Change-Id: I66667361746274616d6879666a6479796f797174

sync from gitlab !9760