### PR TITLE
<refactor>[sdnController]: normalize controller status lifecycle

### DIFF
--- a/conf/serviceConfig/sdnController.xml
+++ b/conf/serviceConfig/sdnController.xml
@@ -41,6 +41,11 @@
     </message>
 
     <message>
+        <name>org.zstack.network.zns.APIQueryZnsTenantRouterMsg</name>
+        <serviceId>query</serviceId>
+    </message>
+
+    <message>
         <name>org.zstack.sdnController.header.APIPullSdnControllerTenantMsg</name>
         <serviceId>query</serviceId>
     </message>

--- a/header/src/main/java/org/zstack/header/network/sdncontroller/SdnControllerStatus.java
+++ b/header/src/main/java/org/zstack/header/network/sdncontroller/SdnControllerStatus.java
@@ -3,9 +3,5 @@ package org.zstack.header.network.sdncontroller;
 public enum SdnControllerStatus {
     Connecting,
     Connected,
-    Disconnected,
-    /** ZNS-specific: wizard-init-sync is in progress */
-    Syncing,
-    /** ZNS-specific: wizard-init-sync completed successfully */
-    Ready
+    Disconnected
 }

--- a/plugin/sdnController/src/main/java/org/zstack/sdnController/SdnControllerFactory.java
+++ b/plugin/sdnController/src/main/java/org/zstack/sdnController/SdnControllerFactory.java
@@ -18,7 +18,7 @@ public interface SdnControllerFactory {
             case RECONNECT_SUCCESS:   return SdnControllerStatus.Connected;
             case RECONNECT_FAILED:    return SdnControllerStatus.Disconnected;
             case PING_FAILED:         return SdnControllerStatus.Disconnected;
-            case INIT_SYNC_STARTED:   return SdnControllerStatus.Syncing;
+            case INIT_SYNC_STARTED:   return SdnControllerStatus.Connecting;
             case INIT_SYNC_SUCCESS:   return SdnControllerStatus.Connected;
             case INIT_SYNC_FAILED:    return SdnControllerStatus.Disconnected;
             default:                  return vo.getStatus();

--- a/plugin/sdnController/src/main/java/org/zstack/sdnController/SdnControllerPingTracker.java
+++ b/plugin/sdnController/src/main/java/org/zstack/sdnController/SdnControllerPingTracker.java
@@ -63,13 +63,6 @@ public class SdnControllerPingTracker extends PingTracker implements
             return null;
         }
 
-        // ZNS controllers are externally-managed (state machine driven by ZNS push notifications).
-        // Syncing and Ready are ZNS-specific states; Cloud must NOT ping them autonomously.
-        if (vo.getStatus() == SdnControllerStatus.Syncing
-                || vo.getStatus() == SdnControllerStatus.Ready) {
-            return null;
-        }
-
         SdnControllerPingMsg msg = new SdnControllerPingMsg();
         msg.setSdnControllerUuid(resUuid);
         bus.makeTargetServiceIdByResourceUuid(msg, SdnControllerConstant.SERVICE_ID, resUuid);
@@ -91,12 +84,6 @@ public class SdnControllerPingTracker extends PingTracker implements
         SdnControllerVO vo = dbf.findByUuid(resourceUuid, SdnControllerVO.class);
         if (vo == null) {
             logger.warn(String.format("SDN controller[uuid:%s] has been deleted, skip ping handling", resourceUuid));
-            return;
-        }
-
-        // ZNS controllers (Syncing/Ready) are externally-managed; skip autonomous status changes.
-        if (vo.getStatus() == SdnControllerStatus.Syncing
-                || vo.getStatus() == SdnControllerStatus.Ready) {
             return;
         }
 

--- a/sdk/src/main/java/org/zstack/sdk/SdnControllerStatus.java
+++ b/sdk/src/main/java/org/zstack/sdk/SdnControllerStatus.java
@@ -4,6 +4,4 @@ public enum SdnControllerStatus {
 	Connecting,
 	Connected,
 	Disconnected,
-	Syncing,
-	Ready,
 }


### PR DESCRIPTION
Use the shared SDN controller lifecycle states for ZNS.

This keeps Cloud and SDK status values aligned.

Test: ./runMavenProfile premium

Change-Id: I8b735d6f6e14f5a0b0c0f247f1a8f8c6d6f4c001

sync from gitlab !9788