### PR TITLE
<fix>[vm]: publish HA start state change

### DIFF
--- a/compute/src/main/java/org/zstack/compute/vm/VmInstanceBase.java
+++ b/compute/src/main/java/org/zstack/compute/vm/VmInstanceBase.java
@@ -326,6 +326,10 @@ public class VmInstanceBase extends AbstractVmInstance {
     }
 
     protected VmInstanceVO changeVmStateInDb(VmInstanceStateEvent stateEvent, Runnable runnable) {
+        return changeVmStateInDb(stateEvent, runnable, null);
+    }
+
+    protected VmInstanceVO changeVmStateInDb(VmInstanceStateEvent stateEvent, Runnable runnable, String stateChangeSource) {
         VmInstanceState bs = self.getState();
         final VmInstanceState state = self.getState().nextState(stateEvent);
 
@@ -374,6 +378,7 @@ public class VmInstanceBase extends AbstractVmInstance {
             data.setVmUuid(self.getUuid());
             data.setOldState(bs.toString());
             data.setNewState(state.toString());
+            data.setStateChangeSource(stateChangeSource);
             data.setInventory(getSelfInventory());
             evtf.fire(VmCanonicalEvents.VM_FULL_STATE_CHANGED_PATH, data);
 
@@ -1004,16 +1009,7 @@ public class VmInstanceBase extends AbstractVmInstance {
 
                         logger.debug(String.format("HaStartVmJudger[%s] says the VM[uuid:%s, name:%s] is qualified for HA start, now we are starting it",
                                 judger.getClass(), self.getUuid(), self.getName()));
-                        UpdateQuery sql = SQL.New(VmInstanceVO.class)
-                                .eq(VmInstanceVO_.uuid, self.getUuid())
-                                .set(VmInstanceVO_.state, VmInstanceState.Stopped)
-                                .set(VmInstanceVO_.hostUuid, null);
-
-                        if (self.getHostUuid() != null) {
-                            sql.set(VmInstanceVO_.lastHostUuid, self.getHostUuid());
-                        }
-
-                        sql.update();
+                        changeVmStateInDb(VmInstanceStateEvent.stopped, null, HaStartVmInstanceMsg.class.getName());
 
                         startVm(msg, new Completion(msg, chain) {
                             @Override
@@ -8984,4 +8980,3 @@ public class VmInstanceBase extends AbstractVmInstance {
         });
     }
 }
-

--- a/header/src/main/java/org/zstack/header/vm/VmCanonicalEvents.java
+++ b/header/src/main/java/org/zstack/header/vm/VmCanonicalEvents.java
@@ -155,6 +155,7 @@ public class VmCanonicalEvents {
         private String vmUuid;
         private String oldState;
         private String newState;
+        private String stateChangeSource;
         private VmInstanceInventory inventory;
         private Date date = new Date();
 
@@ -196,6 +197,14 @@ public class VmCanonicalEvents {
 
         public void setNewState(String newState) {
             this.newState = newState;
+        }
+
+        public String getStateChangeSource() {
+            return stateChangeSource;
+        }
+
+        public void setStateChangeSource(String stateChangeSource) {
+            this.stateChangeSource = stateChangeSource;
         }
     }
 


### PR DESCRIPTION
## Root Cause

`VmInstanceBase.handle(HaStartVmInstanceMsg)` directly updated `VmInstanceVO.state` to `Stopped` through SQL before HA start. This bypassed `changeVmStateInDb()`, so the VM state transition log, `/vm/state/change` canonical event, and `VmStateChangedExtensionPoint` callback were not emitted for the HA internal `Unknown -> Stopped` transition.

## Resolve

- Add optional `stateChangeSource` to `VmCanonicalEvents.VmStateChangedData`; existing events keep the default `null` value.
- Route HA start's internal state reset through `changeVmStateInDb(VmInstanceStateEvent.stopped, ..., HaStartVmInstanceMsg.class.getName())` instead of direct SQL update.
- The matching premium MR uses this source to skip HA's own state-change event and avoid recursive NeverStop HA start.

## Verification

Remote environment: `root@172.20.18.132`

- `/home/zstack/header`: `/usr/local/maven/bin/mvn clean install -Dmaven.test.skip=true` -> BUILD SUCCESS
- `/home/zstack/compute`: `/usr/local/maven/bin/mvn clean install -Dmaven.test.skip=true` -> BUILD SUCCESS
- `/home/zstack/premium/mevoco`: `/usr/local/maven/bin/mvn clean install -Dmaven.test.skip=true` -> BUILD SUCCESS
- `/home/zstack/premium/test-premium`: `/usr/local/maven/bin/mvn test -T 1C -Dtest=VmHaStartStateChangeEventCase` -> Tests run: 1, Failures: 0, Errors: 0

Jira: ZSTAC-84266

sync from gitlab !9794