### PR TITLE
<feature>[zns]: ZCF-2747 add VmNicLifecycle framework for VM migration double chassis

### DIFF
--- a/compute/src/main/java/org/zstack/compute/vm/VmNicLifecycleGlobalConfig.java
+++ b/compute/src/main/java/org/zstack/compute/vm/VmNicLifecycleGlobalConfig.java
@@ -1,0 +1,14 @@
+package org.zstack.compute.vm;
+
+import org.zstack.core.config.GlobalConfig;
+import org.zstack.core.config.GlobalConfigDefinition;
+import org.zstack.core.config.GlobalConfigValidation;
+
+@GlobalConfigDefinition
+public class VmNicLifecycleGlobalConfig {
+    public static final String CATEGORY = "vmNicLifecycle";
+
+    @GlobalConfigValidation(numberGreaterThan = 0)
+    public static GlobalConfig RECONCILE_TIMEOUT =
+            new GlobalConfig(CATEGORY, "reconcileOnHost.timeout");
+}

--- a/compute/src/main/java/org/zstack/compute/vm/VmNicLifecycleManager.java
+++ b/compute/src/main/java/org/zstack/compute/vm/VmNicLifecycleManager.java
@@ -1,0 +1,460 @@
+package org.zstack.compute.vm;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.zstack.core.Platform;
+import org.zstack.core.componentloader.PluginRegistry;
+import org.zstack.core.workflow.FlowChainBuilder;
+import org.zstack.header.core.Completion;
+import org.zstack.header.core.NoErrorCompletion;
+import org.zstack.header.core.workflow.*;
+import org.zstack.header.errorcode.ErrorCode;
+import org.zstack.header.errorcode.SysErrors;
+import org.zstack.header.network.l3.L3NetworkInventory;
+import org.zstack.header.vm.*;
+import org.zstack.utils.Utils;
+import org.zstack.utils.logging.CLogger;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+public class VmNicLifecycleManager implements
+        PreVmInstantiateResourceExtensionPoint,
+        VmReleaseResourceExtensionPoint,
+        VmInstanceMigrateExtensionPoint,
+        InstantiateResourceOnAttachingNicExtensionPoint,
+        ReleaseNetworkServiceOnDetachingNicExtensionPoint {
+
+    private static final CLogger logger = Utils.getLogger(VmNicLifecycleManager.class);
+
+    @Autowired
+    private PluginRegistry pluginRgty;
+
+    private List<VmNicLifecycleExtensionPoint> getExtensions() {
+        return pluginRgty.getExtensionList(VmNicLifecycleExtensionPoint.class);
+    }
+
+    // ===================== NIC filtering =====================
+
+    private List<VmNicInventory> filterNics(VmNicLifecycleExtensionPoint ext,
+                                            List<VmNicInventory> allNics) {
+        List<VmNicInventory> matched = new ArrayList<>();
+        for (VmNicInventory nic : allNics) {
+            try {
+                if (ext.isApplicable(nic)) {
+                    matched.add(nic);
+                }
+            } catch (Exception e) {
+                logger.error(String.format("[VmNicLifecycle] %s.isApplicable(nic=%s) threw exception",
+                        ext.getClass().getSimpleName(), nic.getUuid()), e);
+                throw new RuntimeException(String.format("%s.isApplicable failed for nic[uuid:%s]",
+                        ext.getClass().getSimpleName(), nic.getUuid()), e);
+            }
+        }
+        return matched;
+    }
+
+    // ===================== fail-fast serial runner (setup / preMigrate) =====================
+
+    private void runSetup(Iterator<VmNicLifecycleExtensionPoint> it,
+                          String hostUuid, List<VmNicInventory> allNics,
+                          Completion completion) {
+        if (!it.hasNext()) {
+            completion.success();
+            return;
+        }
+
+        VmNicLifecycleExtensionPoint ext = it.next();
+        List<VmNicInventory> nics;
+        try {
+            nics = filterNics(ext, allNics);
+        } catch (RuntimeException e) {
+            completion.fail(Platform.err(SysErrors.OPERATION_ERROR.toString(), SysErrors.OPERATION_ERROR, "%s", e.getMessage()));
+            return;
+        }
+        if (nics.isEmpty()) {
+            runSetup(it, hostUuid, allNics, completion);
+            return;
+        }
+
+        long start = System.currentTimeMillis();
+        ext.setupOnHost(hostUuid, nics, new Completion(completion) {
+            @Override
+            public void success() {
+                logger.debug(String.format("[VmNicLifecycle] %s.setupOnHost(host=%s, nics=%d) " +
+                                "completed in %dms", ext.getClass().getSimpleName(), hostUuid,
+                        nics.size(), System.currentTimeMillis() - start));
+                runSetup(it, hostUuid, allNics, completion);
+            }
+
+            @Override
+            public void fail(ErrorCode errorCode) {
+                logger.warn(String.format("[VmNicLifecycle] %s.setupOnHost(host=%s) failed: %s",
+                        ext.getClass().getSimpleName(), hostUuid, errorCode));
+                completion.fail(errorCode);
+            }
+        });
+    }
+
+    private void runPreMigrate(Iterator<VmNicLifecycleExtensionPoint> it,
+                               String srcHostUuid, String destHostUuid,
+                               List<VmNicInventory> allNics, Completion completion) {
+        if (!it.hasNext()) {
+            completion.success();
+            return;
+        }
+
+        VmNicLifecycleExtensionPoint ext = it.next();
+        List<VmNicInventory> nics;
+        try {
+            nics = filterNics(ext, allNics);
+        } catch (RuntimeException e) {
+            completion.fail(Platform.err(SysErrors.OPERATION_ERROR.toString(), SysErrors.OPERATION_ERROR, "%s", e.getMessage()));
+            return;
+        }
+        if (nics.isEmpty()) {
+            runPreMigrate(it, srcHostUuid, destHostUuid, allNics, completion);
+            return;
+        }
+
+        long start = System.currentTimeMillis();
+        ext.preMigrate(srcHostUuid, destHostUuid, nics, new Completion(completion) {
+            @Override
+            public void success() {
+                logger.debug(String.format("[VmNicLifecycle] %s.preMigrate(src=%s, dest=%s, nics=%d) " +
+                                "completed in %dms", ext.getClass().getSimpleName(),
+                        srcHostUuid, destHostUuid, nics.size(), System.currentTimeMillis() - start));
+                runPreMigrate(it, srcHostUuid, destHostUuid, allNics, completion);
+            }
+
+            @Override
+            public void fail(ErrorCode errorCode) {
+                logger.warn(String.format("[VmNicLifecycle] %s.preMigrate(src=%s, dest=%s) failed: %s",
+                        ext.getClass().getSimpleName(), srcHostUuid, destHostUuid, errorCode));
+                completion.fail(errorCode);
+            }
+        });
+    }
+
+    // ===================== fail-logged serial runner (cleanup / postMigrate / failedMigrate) =====================
+
+    @FunctionalInterface
+    private interface CleanupAction {
+        void execute(VmNicLifecycleExtensionPoint ext, List<VmNicInventory> nics,
+                     NoErrorCompletion completion);
+    }
+
+    private void runFailLogged(Iterator<VmNicLifecycleExtensionPoint> it,
+                               List<VmNicInventory> allNics,
+                               String methodName, CleanupAction action,
+                               NoErrorCompletion completion) {
+        if (!it.hasNext()) {
+            completion.done();
+            return;
+        }
+
+        VmNicLifecycleExtensionPoint ext = it.next();
+        List<VmNicInventory> nics;
+        try {
+            nics = filterNics(ext, allNics);
+        } catch (RuntimeException e) {
+            logger.warn(String.format("[VmNicLifecycle] %s.isApplicable threw exception during %s",
+                    ext.getClass().getSimpleName(), methodName), e);
+            runFailLogged(it, allNics, methodName, action, completion);
+            return;
+        }
+        if (nics.isEmpty()) {
+            runFailLogged(it, allNics, methodName, action, completion);
+            return;
+        }
+
+        try {
+            action.execute(ext, nics, new NoErrorCompletion() {
+                @Override
+                public void done() {
+                    runFailLogged(it, allNics, methodName, action, completion);
+                }
+            });
+        } catch (Throwable t) {
+            logger.warn(String.format("[VmNicLifecycle] %s.%s threw exception",
+                    ext.getClass().getSimpleName(), methodName), t);
+            runFailLogged(it, allNics, methodName, action, completion);
+        }
+    }
+
+    private void runCleanup(Iterator<VmNicLifecycleExtensionPoint> it,
+                            String hostUuid, List<VmNicInventory> allNics,
+                            NoErrorCompletion completion) {
+        runFailLogged(it, allNics, "cleanupFromHost",
+                (ext, nics, done) -> ext.cleanupFromHost(hostUuid, nics, done), completion);
+    }
+
+    private void runCleanupStale(Iterator<VmNicLifecycleExtensionPoint> it,
+                                 String lastHostUuid, List<VmNicInventory> allNics,
+                                 NoErrorCompletion completion) {
+        runFailLogged(it, allNics, "cleanupStaleResource",
+                (ext, nics, done) -> ext.cleanupStaleResource(lastHostUuid, nics, done), completion);
+    }
+
+    private void runPostMigrate(Iterator<VmNicLifecycleExtensionPoint> it,
+                                String srcHostUuid, String destHostUuid,
+                                List<VmNicInventory> allNics, NoErrorCompletion completion) {
+        runFailLogged(it, allNics, "postMigrate",
+                (ext, nics, done) -> ext.postMigrate(srcHostUuid, destHostUuid, nics, done),
+                completion);
+    }
+
+    private void runFailedMigrate(Iterator<VmNicLifecycleExtensionPoint> it,
+                                  String srcHostUuid, String destHostUuid,
+                                  List<VmNicInventory> allNics, NoErrorCompletion completion) {
+        runFailLogged(it, allNics, "failedMigrate",
+                (ext, nics, done) -> ext.failedMigrate(srcHostUuid, destHostUuid, nics, done),
+                completion);
+    }
+
+    // ===================== PreVmInstantiateResourceExtensionPoint =====================
+
+    @Override
+    public void preBeforeInstantiateVmResource(VmInstanceSpec spec)
+            throws VmInstantiateResourceException {
+        // sync hook — no resource operations
+    }
+
+    @Override
+    public void preInstantiateVmResource(VmInstanceSpec spec, Completion completion) {
+        List<VmNicInventory> allNics = spec.getDestNics();
+        if (allNics == null || allNics.isEmpty() || getExtensions().isEmpty()) {
+            completion.success();
+            return;
+        }
+
+        if (spec.getDestHost() == null) {
+            completion.success();
+            return;
+        }
+        String destHostUuid = spec.getDestHost().getUuid();
+        String lastHostUuid = spec.getVmInventory().getLastHostUuid();
+        VmInstanceConstant.VmOperation op = spec.getCurrentVmOperation();
+
+        FlowChain chain = FlowChainBuilder.newSimpleFlowChain();
+        chain.setName("vmnic-lifecycle-pre-instantiate-" + spec.getVmInventory().getUuid());
+
+        if (lastHostUuid != null && !lastHostUuid.equals(destHostUuid)
+                && op == VmInstanceConstant.VmOperation.Start) {
+            chain.then(new NoRollbackFlow() {
+                String __name__ = "cleanup-stale-resource-from-last-host";
+
+                @Override
+                public void run(FlowTrigger trigger, Map data) {
+                    runCleanupStale(getExtensions().iterator(), lastHostUuid, allNics,
+                            new NoErrorCompletion() {
+                                @Override
+                                public void done() {
+                                    trigger.next();
+                                }
+                            });
+                }
+            });
+        }
+
+        chain.then(new NoRollbackFlow() {
+            String __name__ = "setup-on-dest-host";
+
+            @Override
+            public void run(FlowTrigger trigger, Map data) {
+                runSetup(getExtensions().iterator(), destHostUuid, allNics, new Completion(trigger) {
+                    @Override
+                    public void success() {
+                        trigger.next();
+                    }
+
+                    @Override
+                    public void fail(ErrorCode errorCode) {
+                        trigger.fail(errorCode);
+                    }
+                });
+            }
+        });
+
+        chain.done(new FlowDoneHandler(completion) {
+            @Override
+            public void handle(Map data) {
+                completion.success();
+            }
+        }).error(new FlowErrorHandler(completion) {
+            @Override
+            public void handle(ErrorCode errCode, Map data) {
+                completion.fail(errCode);
+            }
+        }).start();
+    }
+
+    @Override
+    public void preReleaseVmResource(VmInstanceSpec spec, Completion completion) {
+        doCleanup(spec, new NoErrorCompletion(completion) {
+            @Override
+            public void done() {
+                completion.success();
+            }
+        });
+    }
+
+    // ===================== VmReleaseResourceExtensionPoint =====================
+
+    @Override
+    public void releaseVmResource(VmInstanceSpec spec, Completion completion) {
+        if (spec.getCurrentVmOperation() == VmInstanceConstant.VmOperation.Reboot) {
+            completion.success();
+            return;
+        }
+        doCleanup(spec, new NoErrorCompletion(completion) {
+            @Override
+            public void done() {
+                completion.success();
+            }
+        });
+    }
+
+    private void doCleanup(VmInstanceSpec spec, NoErrorCompletion completion) {
+        List<VmNicInventory> allNics = spec.getDestNics();
+        if (allNics == null || allNics.isEmpty() || getExtensions().isEmpty()) {
+            completion.done();
+            return;
+        }
+        if (spec.getDestHost() == null) {
+            completion.done();
+            return;
+        }
+        String hostUuid = spec.getDestHost().getUuid();
+        runCleanup(getExtensions().iterator(), hostUuid, allNics, completion);
+    }
+
+    // ===================== VmInstanceMigrateExtensionPoint =====================
+
+    @Override
+    public void beforeMigrateVm(VmInstanceInventory inv, String destHostUuid) {
+        // no-op — sync validation hook
+    }
+
+    @Override
+    public void preMigrateVm(VmInstanceInventory inv, String destHostUuid,
+                              Completion completion) {
+        if (getExtensions().isEmpty()) {
+            completion.success();
+            return;
+        }
+        String srcHostUuid = inv.getHostUuid();
+        List<VmNicInventory> allNics = inv.getVmNics();
+        if (allNics == null || allNics.isEmpty()) {
+            completion.success();
+            return;
+        }
+        runPreMigrate(getExtensions().iterator(), srcHostUuid, destHostUuid, allNics, completion);
+    }
+
+    @Override
+    public void postMigrateVm(VmInstanceInventory inv, String destHostUuid,
+                               Completion completion) {
+        if (getExtensions().isEmpty()) {
+            completion.success();
+            return;
+        }
+        String srcHostUuid = inv.getHostUuid();
+        List<VmNicInventory> allNics = inv.getVmNics();
+        if (allNics == null || allNics.isEmpty()) {
+            completion.success();
+            return;
+        }
+        runPostMigrate(getExtensions().iterator(), srcHostUuid, destHostUuid, allNics,
+                new NoErrorCompletion(completion) {
+                    @Override
+                    public void done() {
+                        completion.success();
+                    }
+                });
+    }
+
+    @Override
+    public void afterMigrateVm(VmInstanceInventory inv, String srcHostUuid,
+                                NoErrorCompletion completion) {
+        completion.done();
+    }
+
+    @Override
+    public void failedToMigrateVm(VmInstanceInventory inv, String destHostUuid,
+                                   ErrorCode reason, NoErrorCompletion completion) {
+        if (getExtensions().isEmpty()) {
+            completion.done();
+            return;
+        }
+        String srcHostUuid = inv.getHostUuid();
+        List<VmNicInventory> allNics = inv.getVmNics();
+        if (allNics == null || allNics.isEmpty()) {
+            completion.done();
+            return;
+        }
+        runFailedMigrate(getExtensions().iterator(), srcHostUuid, destHostUuid, allNics, completion);
+    }
+
+    // ===================== InstantiateResourceOnAttachingNicExtensionPoint =====================
+
+    @Override
+    public void instantiateResourceOnAttachingNic(VmInstanceSpec spec,
+                                                   L3NetworkInventory l3, Completion completion) {
+        VmInstanceInventory vm = spec.getVmInventory();
+        if (!VmInstanceState.Running.toString().equals(vm.getState()) || getExtensions().isEmpty()) {
+            completion.success();
+            return;
+        }
+
+        List<VmNicInventory> newNics = spec.getDestNics().stream()
+                .filter(nic -> nic.getL3NetworkUuid().equals(l3.getUuid()))
+                .collect(Collectors.toList());
+        if (newNics.isEmpty()) {
+            completion.success();
+            return;
+        }
+
+        String hostUuid = vm.getHostUuid();
+        runSetup(getExtensions().iterator(), hostUuid, newNics, completion);
+    }
+
+    @Override
+    public void releaseResourceOnAttachingNic(VmInstanceSpec spec,
+                                               L3NetworkInventory l3, NoErrorCompletion completion) {
+        doCleanupForNic(spec, l3, completion);
+    }
+
+    private void doCleanupForNic(VmInstanceSpec spec, L3NetworkInventory l3,
+                                  NoErrorCompletion completion) {
+        if (getExtensions().isEmpty()) {
+            completion.done();
+            return;
+        }
+        String hostUuid = spec.getVmInventory().getHostUuid();
+        if (hostUuid == null) {
+            completion.done();
+            return;
+        }
+        List<VmNicInventory> nics = spec.getDestNics().stream()
+                .filter(nic -> nic.getL3NetworkUuid().equals(l3.getUuid()))
+                .collect(Collectors.toList());
+        runCleanup(getExtensions().iterator(), hostUuid, nics, completion);
+    }
+
+    // ===================== ReleaseNetworkServiceOnDetachingNicExtensionPoint =====================
+
+    @Override
+    public void releaseResourceOnDetachingNic(VmInstanceSpec spec,
+                                               VmNicInventory nic, NoErrorCompletion completion) {
+        if (getExtensions().isEmpty()) {
+            completion.done();
+            return;
+        }
+        String hostUuid = spec.getVmInventory().getHostUuid();
+        if (hostUuid == null) {
+            completion.done();
+            return;
+        }
+        runCleanup(getExtensions().iterator(), hostUuid, Collections.singletonList(nic), completion);
+    }
+}

--- a/conf/globalConfig/vmNicLifecycle.xml
+++ b/conf/globalConfig/vmNicLifecycle.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<globalConfig xmlns="http://zstack.org/schema/zstack">
+    <config>
+        <name>reconcileOnHost.timeout</name>
+        <description>Timeout in seconds for each VmNicLifecycleExtensionPoint implementation's reconcileOnHost call during host heartbeat reconciliation</description>
+        <category>vmNicLifecycle</category>
+        <defaultValue>30</defaultValue>
+        <type>java.lang.Long</type>
+    </config>
+</globalConfig>

--- a/conf/springConfigXml/Kvm.xml
+++ b/conf/springConfigXml/Kvm.xml
@@ -96,6 +96,12 @@
         </zstack:plugin>
     </bean>
 
+    <bean id="VmNicLifecycleKvmBridge" class="org.zstack.kvm.VmNicLifecycleKvmBridge">
+        <zstack:plugin>
+            <zstack:extension interface="org.zstack.kvm.KVMPingAgentNoFailureExtensionPoint" />
+        </zstack:plugin>
+    </bean>
+
     <bean id="KVMSecurityGroupBackend" class="org.zstack.kvm.KVMSecurityGroupBackend">
         <zstack:plugin>
             <zstack:extension interface="org.zstack.network.securitygroup.SecurityGroupHypervisorBackend" />

--- a/conf/springConfigXml/VmInstanceManager.xml
+++ b/conf/springConfigXml/VmInstanceManager.xml
@@ -261,4 +261,14 @@
         </zstack:plugin>
     </bean>
 
+    <bean id="VmNicLifecycleManager" class="org.zstack.compute.vm.VmNicLifecycleManager">
+        <zstack:plugin>
+            <zstack:extension interface="org.zstack.header.vm.PreVmInstantiateResourceExtensionPoint" />
+            <zstack:extension interface="org.zstack.header.vm.VmReleaseResourceExtensionPoint" />
+            <zstack:extension interface="org.zstack.header.vm.VmInstanceMigrateExtensionPoint" />
+            <zstack:extension interface="org.zstack.header.vm.InstantiateResourceOnAttachingNicExtensionPoint" />
+            <zstack:extension interface="org.zstack.header.vm.ReleaseNetworkServiceOnDetachingNicExtensionPoint" />
+        </zstack:plugin>
+    </bean>
+
 </beans>

--- a/header/src/main/java/org/zstack/header/vm/VmNicLifecycleExtensionPoint.java
+++ b/header/src/main/java/org/zstack/header/vm/VmNicLifecycleExtensionPoint.java
@@ -1,0 +1,116 @@
+package org.zstack.header.vm;
+
+import org.zstack.header.core.Completion;
+import org.zstack.header.core.NoErrorCompletion;
+
+import java.util.List;
+
+/**
+ * Extension point for managing the lifecycle of VM NICs on hosts.
+ * Implementations are invoked during VM start, stop, migration, NIC attach/detach,
+ * and periodic reconciliation driven by KVM heartbeat.
+ *
+ * <p>All async methods must invoke their completion callback exactly once,
+ * even on error paths. {@link Completion}-based methods may fail the operation;
+ * {@link NoErrorCompletion}-based methods must always succeed (log and absorb errors).
+ */
+public interface VmNicLifecycleExtensionPoint {
+
+    /**
+     * Returns true if this extension should manage the given NIC.
+     * Called synchronously; must not block or throw checked exceptions.
+     *
+     * @param nic the NIC to evaluate
+     * @return true if this extension handles the NIC
+     */
+    boolean isApplicable(VmNicInventory nic);
+
+    /**
+     * Called when a VM starts or a NIC is attached to a running VM.
+     * Failure aborts the VM start / NIC attach operation.
+     *
+     * @param hostUuid   UUID of the host where the VM is starting
+     * @param nics       NICs filtered by {@link #isApplicable}
+     * @param completion call {@code success()} or {@code fail()} exactly once
+     */
+    void setupOnHost(String hostUuid, List<VmNicInventory> nics, Completion completion);
+
+    /**
+     * Called when a VM stops or a NIC is detached. Errors are logged but do not
+     * block the operation.
+     *
+     * @param hostUuid   UUID of the host the VM is leaving
+     * @param nics       NICs filtered by {@link #isApplicable}
+     * @param completion call {@code done()} exactly once
+     */
+    void cleanupFromHost(String hostUuid, List<VmNicInventory> nics, NoErrorCompletion completion);
+
+    /**
+     * Called before live migration starts. Default: setup on destination host.
+     * Failure aborts the migration.
+     * Execution order: preMigrate → (live migration) → postMigrate or failedMigrate.
+     *
+     * @param srcHostUuid  UUID of the source host
+     * @param destHostUuid UUID of the destination host
+     * @param nics         NICs filtered by {@link #isApplicable}
+     * @param completion   call {@code success()} or {@code fail()} exactly once
+     */
+    default void preMigrate(String srcHostUuid, String destHostUuid,
+                            List<VmNicInventory> nics, Completion completion) {
+        setupOnHost(destHostUuid, nics, completion);
+    }
+
+    /**
+     * Called after live migration succeeds. Errors are logged but do not block.
+     *
+     * @param srcHostUuid  UUID of the source host
+     * @param destHostUuid UUID of the destination host
+     * @param nics         NICs filtered by {@link #isApplicable}
+     * @param completion   call {@code done()} exactly once
+     */
+    default void postMigrate(String srcHostUuid, String destHostUuid,
+                             List<VmNicInventory> nics, NoErrorCompletion completion) {
+        cleanupFromHost(srcHostUuid, nics, completion);
+    }
+
+    /**
+     * Called when live migration fails. Errors are logged but do not block.
+     *
+     * @param srcHostUuid  UUID of the source host
+     * @param destHostUuid UUID of the destination host (where partial setup may exist)
+     * @param nics         NICs filtered by {@link #isApplicable}
+     * @param completion   call {@code done()} exactly once
+     */
+    default void failedMigrate(String srcHostUuid, String destHostUuid,
+                               List<VmNicInventory> nics, NoErrorCompletion completion) {
+        cleanupFromHost(destHostUuid, nics, completion);
+    }
+
+    /**
+     * Called on VM start when the VM's last known host differs from the destination host.
+     * Used to clean up state left on the previous host after an ungraceful shutdown.
+     * Errors are logged but do not block.
+     *
+     * @param lastHostUuid UUID of the host where the VM last ran
+     * @param nics         NICs filtered by {@link #isApplicable}
+     * @param completion   call {@code done()} exactly once
+     */
+    default void cleanupStaleResource(String lastHostUuid, List<VmNicInventory> nics,
+                                      NoErrorCompletion completion) {
+        cleanupFromHost(lastHostUuid, nics, completion);
+    }
+
+    /**
+     * Called periodically on each successful KVM heartbeat to reconcile NIC state.
+     * Implementations should ensure remote systems match the expected state in {@code expectedNics}.
+     * Errors are logged but do not block the heartbeat.
+     *
+     * @param hostUuid      UUID of the host being reconciled
+     * @param expectedNics  all Running-VM NICs on this host, filtered by {@link #isApplicable}
+     * @param completion    call {@code done()} exactly once
+     */
+    default void reconcileOnHost(String hostUuid, List<VmNicInventory> expectedNics,
+                                 NoErrorCompletion completion) {
+        completion.done();
+    }
+}

--- a/plugin/kvm/src/main/java/org/zstack/kvm/VmNicLifecycleKvmBridge.java
+++ b/plugin/kvm/src/main/java/org/zstack/kvm/VmNicLifecycleKvmBridge.java
@@ -1,0 +1,115 @@
+package org.zstack.kvm;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.zstack.compute.vm.VmNicLifecycleGlobalConfig;
+import org.zstack.core.asyncbatch.While;
+import org.zstack.core.componentloader.PluginRegistry;
+import org.zstack.core.db.Q;
+import org.zstack.core.thread.ThreadFacade;
+import org.zstack.core.thread.ThreadFacadeImpl;
+import org.zstack.header.core.NoErrorCompletion;
+import org.zstack.header.core.WhileDoneCompletion;
+import org.zstack.header.errorcode.ErrorCodeList;
+import org.zstack.header.vm.*;
+import org.zstack.header.vm.VmNicLifecycleExtensionPoint;
+import org.zstack.utils.Utils;
+import org.zstack.utils.logging.CLogger;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
+
+public class VmNicLifecycleKvmBridge implements KVMPingAgentNoFailureExtensionPoint {
+
+    private static final CLogger logger = Utils.getLogger(VmNicLifecycleKvmBridge.class);
+
+    @Autowired
+    private PluginRegistry pluginRgty;
+    @Autowired
+    private ThreadFacade thdf;
+
+    private List<VmNicLifecycleExtensionPoint> extensions;
+
+    void init() {
+        extensions = pluginRgty.getExtensionList(VmNicLifecycleExtensionPoint.class);
+    }
+
+    @Override
+    public void kvmPingAgentNoFailure(KVMHostInventory host, NoErrorCompletion completion) {
+        if (extensions.isEmpty()) {
+            completion.done();
+            return;
+        }
+
+        String hostUuid = host.getUuid();
+
+        List<VmNicInventory> allExpectedNics;
+        try {
+            List<VmInstanceVO> runningVms = Q.New(VmInstanceVO.class)
+                    .eq(VmInstanceVO_.hostUuid, hostUuid)
+                    .eq(VmInstanceVO_.state, VmInstanceState.Running)
+                    .list();
+            allExpectedNics = runningVms.stream()
+                    .flatMap(vm -> VmNicInventory.valueOf(vm.getVmNics()).stream())
+                    .collect(Collectors.toList());
+        } catch (Exception e) {
+            logger.warn(String.format("[VmNicLifecycle] failed to query Running VMs " +
+                    "on host[uuid:%s] for reconciliation, skip this round", hostUuid), e);
+            completion.done();
+            return;
+        }
+
+        long timeoutSeconds = VmNicLifecycleGlobalConfig.RECONCILE_TIMEOUT.value(Long.class);
+
+        new While<>(extensions).step((ext, whileCompletion) -> {
+            List<VmNicInventory> matchedNics;
+            try {
+                matchedNics = allExpectedNics.stream()
+                        .filter(ext::isApplicable)
+                        .collect(Collectors.toList());
+            } catch (Exception e) {
+                logger.warn(String.format("[VmNicLifecycle] %s.isApplicable threw exception " +
+                                "during reconciliation on host[uuid:%s]",
+                        ext.getClass().getSimpleName(), hostUuid), e);
+                whileCompletion.done();
+                return;
+            }
+
+            AtomicBoolean completed = new AtomicBoolean(false);
+
+            ThreadFacadeImpl.TimeoutTaskReceipt receipt = thdf.submitTimeoutTask(() -> {
+                if (completed.compareAndSet(false, true)) {
+                    logger.warn(String.format("[VmNicLifecycle] %s.reconcileOnHost timed out " +
+                                    "after %ds on host[uuid:%s]",
+                            ext.getClass().getSimpleName(), timeoutSeconds, hostUuid));
+                    whileCompletion.done();
+                }
+            }, TimeUnit.SECONDS, timeoutSeconds);
+
+            try {
+                ext.reconcileOnHost(hostUuid, matchedNics, new NoErrorCompletion() {
+                    @Override
+                    public void done() {
+                        if (completed.compareAndSet(false, true)) {
+                            receipt.cancel();
+                            whileCompletion.done();
+                        }
+                    }
+                });
+            } catch (Throwable t) {
+                if (completed.compareAndSet(false, true)) {
+                    receipt.cancel();
+                    logger.warn(String.format("[VmNicLifecycle] %s.reconcileOnHost(host=%s) " +
+                            "threw exception", ext.getClass().getSimpleName(), hostUuid), t);
+                    whileCompletion.done();
+                }
+            }
+        }, extensions.size()).run(new WhileDoneCompletion(completion) {
+            @Override
+            public void done(ErrorCodeList errorCodeList) {
+                completion.done();
+            }
+        });
+    }
+}


### PR DESCRIPTION
## Summary

Implements ZCF-2747: VM NIC lifecycle abstraction framework to support double chassis OVN port setup during live migration on ZNS networks.

## Changes

```
compute/src/main/java/org/zstack/compute/vm/VmNicLifecycleGlobalConfig.java |  14 ++
compute/src/main/java/org/zstack/compute/vm/VmNicLifecycleManager.java      | 489 ++++++++++++++++++++++++
conf/globalConfig/vmNicLifecycle.xml                                        |  10 +
conf/springConfigXml/Kvm.xml                                                |   6 +
conf/springConfigXml/VmInstanceManager.xml                                  |  10 +
header/src/main/java/org/zstack/header/vm/VmNicLifecycleExtensionPoint.java |  40 +++
plugin/kvm/src/main/java/org/zstack/kvm/VmNicLifecycleKvmBridge.java        | 115 +++++++++
7 files changed, 684 insertions(+)
```

## Key Design

- `VmNicLifecycleExtensionPoint` — 8-method interface (setupOnHost, cleanupFromHost, preMigrate, postMigrate, failedMigrate, reconcileOnHost, cleanupStaleResource, isApplicable)
- `VmNicLifecycleManager` — dispatches to all registered extensions at VM start/stop/migrate lifecycle events
- `VmNicLifecycleKvmBridge` — reconcile bridge triggered on KVM heartbeat ping
- Also removes `nodeUuid` from `SdnControllerHostRefVO` (ZNS-specific field moved to premium)

## Testing
- [ ] CI pipeline
- [ ] Manual test with ZNS migration

Resolves: ZCF-2747

sync from gitlab !9806