### PR TITLE
<fix>[conf]: recover stale mariadb socket

### DIFF
--- a/conf/install/zstack-server
+++ b/conf/install/zstack-server
@@ -17,6 +17,9 @@
 pidfile='/var/run/zstack/zstack-server.pid'
 TOMCAT_PATH="/usr/local/zstack/root/apache-tomcat"
 zstack_app=${ZSTACK_HOME-"$TOMCAT_PATH/webapps/zstack"}
+MARIADB_SERVICE=${ZSTACK_MARIADB_SERVICE:-mariadb}
+MARIADB_SOCKET=${ZSTACK_MARIADB_SOCKET:-/var/lib/mysql/mysql.sock}
+ZSTACK_SERVER_LOG_DIR=${ZSTACK_SERVER_LOG_DIR:-/var/log/zstack}
 
 which zstack-ctl &>/dev/null
 if [ $? -ne 0 ]; then
@@ -32,7 +35,92 @@ stop_zstack(){
     ZSTACK_HOME=$zstack_app HOME=`echo ~root` zstack-ctl stop
 }
 
+log_zstack_server() {
+    mkdir -p "$ZSTACK_SERVER_LOG_DIR" 2>/dev/null
+    if [ -d "$ZSTACK_SERVER_LOG_DIR" ]; then
+        echo "$@" >> "$ZSTACK_SERVER_LOG_DIR/zstack-server.log"
+    else
+        echo "$@"
+    fi
+}
+
+mariadb_service_exists() {
+    if command -v systemctl >/dev/null 2>&1; then
+        systemctl list-unit-files "$MARIADB_SERVICE.service" 2>/dev/null | grep -q "$MARIADB_SERVICE.service" && return 0
+    fi
+
+    if command -v service >/dev/null 2>&1; then
+        service "$MARIADB_SERVICE" status >/dev/null 2>&1 && return 0
+    fi
+
+    [ -x "/etc/init.d/$MARIADB_SERVICE" ] && return 0
+
+    return 1
+}
+
+mariadb_is_active() {
+    if command -v systemctl >/dev/null 2>&1; then
+        systemctl is-active --quiet "$MARIADB_SERVICE" >/dev/null 2>&1 && return 0
+    fi
+
+    if command -v service >/dev/null 2>&1; then
+        service "$MARIADB_SERVICE" status >/dev/null 2>&1 && return 0
+    fi
+
+    if [ -x "/etc/init.d/$MARIADB_SERVICE" ]; then
+        "/etc/init.d/$MARIADB_SERVICE" status >/dev/null 2>&1 && return 0
+    fi
+
+    return 1
+}
+
+socket_is_used() {
+    has_probe=false
+
+    if command -v lsof >/dev/null 2>&1; then
+        has_probe=true
+        lsof -t -- "$MARIADB_SOCKET" >/dev/null 2>&1 && return 0
+    fi
+
+    if command -v fuser >/dev/null 2>&1; then
+        has_probe=true
+        fuser "$MARIADB_SOCKET" >/dev/null 2>&1 && return 0
+    fi
+
+    [ "$has_probe" = "true" ] || return 2
+
+    return 1
+}
+
+start_mariadb_service() {
+    if command -v systemctl >/dev/null 2>&1; then
+        systemctl reset-failed "$MARIADB_SERVICE" >/dev/null 2>&1
+        systemctl start "$MARIADB_SERVICE"
+        return $?
+    fi
+
+    service "$MARIADB_SERVICE" start
+}
+
+recover_mariadb_stale_socket() {
+    [ "$ZSTACK_RECOVER_MARIADB_SOCKET" = "false" ] && return 0
+    [ -e "$MARIADB_SOCKET" ] || return 0
+    mariadb_service_exists || return 0
+    mariadb_is_active && return 0
+    socket_is_used
+    socket_status=$?
+    [ "$socket_status" -eq 0 ] && return 0
+    [ "$socket_status" -eq 2 ] && return 0
+
+    log_zstack_server "removing stale MariaDB socket $MARIADB_SOCKET before zstack start"
+    rm -f "$MARIADB_SOCKET" || return 1
+
+    log_zstack_server "starting $MARIADB_SERVICE service before zstack start"
+    start_mariadb_service
+}
+
 start_zstack(){
+    recover_mariadb_stale_socket || return $?
     ZSTACK_HOME=$zstack_app HOME=`echo ~root` zstack-ctl start
 }
 

--- a/test/src/test/bash/test_zstack_server_mariadb_recovery.sh
+++ b/test/src/test/bash/test_zstack_server_mariadb_recovery.sh
@@ -1,0 +1,173 @@
+#!/bin/sh
+
+set -eu
+
+script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+repo_dir=$(CDPATH= cd -- "$script_dir/../../../.." && pwd)
+script="$repo_dir/conf/install/zstack-server"
+tmp_dir=$(mktemp -d)
+
+cleanup() {
+    rm -rf "$tmp_dir"
+}
+
+trap cleanup EXIT
+
+bin_dir="$tmp_dir/bin"
+mkdir -p "$bin_dir"
+
+cat > "$bin_dir/zstack-ctl" <<'EOF'
+#!/bin/sh
+echo "zstack-ctl $*" >> "$ZSTUB_CALLS"
+exit 0
+EOF
+
+cat > "$bin_dir/systemctl" <<'EOF'
+#!/bin/sh
+case "$1 $2" in
+    "list-unit-files mariadb.service")
+        echo "mariadb.service enabled"
+        exit 0
+        ;;
+    "is-active --quiet")
+        [ "${ZSTUB_MARIADB_ACTIVE:-false}" = "true" ] && exit 0
+        exit 3
+        ;;
+    "reset-failed mariadb")
+        echo "systemctl reset-failed mariadb" >> "$ZSTUB_CALLS"
+        exit 0
+        ;;
+    "start mariadb")
+        echo "systemctl start mariadb" >> "$ZSTUB_CALLS"
+        exit 0
+        ;;
+esac
+exit 1
+EOF
+
+cat > "$bin_dir/lsof" <<'EOF'
+#!/bin/sh
+exit 1
+EOF
+
+cat > "$bin_dir/fuser" <<'EOF'
+#!/bin/sh
+exit 1
+EOF
+
+chmod +x "$bin_dir/zstack-ctl" "$bin_dir/systemctl" "$bin_dir/lsof" "$bin_dir/fuser"
+
+assert_contains() {
+    grep -F "$1" "$2" >/dev/null || {
+        echo "expected '$1' in $2" >&2
+        exit 1
+    }
+}
+
+calls="$tmp_dir/calls"
+socket="$tmp_dir/mysql.sock"
+log_dir="$tmp_dir/log"
+touch "$socket"
+
+PATH="$bin_dir:$PATH" \
+ZSTUB_CALLS="$calls" \
+ZSTACK_MARIADB_SOCKET="$socket" \
+ZSTACK_SERVER_LOG_DIR="$log_dir" \
+sh "$script" start >/dev/null
+
+[ ! -e "$socket" ] || {
+    echo "expected stale socket to be removed" >&2
+    exit 1
+}
+assert_contains "systemctl reset-failed mariadb" "$calls"
+assert_contains "systemctl start mariadb" "$calls"
+assert_contains "zstack-ctl start" "$calls"
+
+sysv_bin_dir="$tmp_dir/sysv-bin"
+mkdir -p "$sysv_bin_dir"
+cp "$bin_dir/zstack-ctl" "$bin_dir/lsof" "$bin_dir/fuser" "$sysv_bin_dir/"
+ln -s /usr/bin/grep "$sysv_bin_dir/grep"
+cat > "$sysv_bin_dir/which" <<'EOF'
+#!/bin/sh
+command -v "$1"
+EOF
+cat > "$sysv_bin_dir/service" <<'EOF'
+#!/bin/sh
+if [ "$1 $2" = "mariadb status" ]; then
+    echo "mariadb is running"
+    exit 0
+fi
+exit 1
+EOF
+chmod +x "$sysv_bin_dir/which" "$sysv_bin_dir/service"
+
+calls="$tmp_dir/calls-sysv-active"
+socket="$tmp_dir/mysql-sysv-active.sock"
+touch "$socket"
+
+PATH="$sysv_bin_dir" \
+ZSTUB_CALLS="$calls" \
+ZSTACK_MARIADB_SOCKET="$socket" \
+ZSTACK_SERVER_LOG_DIR="$log_dir" \
+/bin/sh "$script" start >/dev/null
+
+[ -e "$socket" ] || {
+    echo "expected active SysV MariaDB socket to be kept" >&2
+    exit 1
+}
+if grep -F "systemctl start mariadb" "$calls" >/dev/null 2>&1; then
+    echo "unexpected call: systemctl start mariadb" >&2
+    exit 1
+fi
+assert_contains "zstack-ctl start" "$calls"
+
+no_probe_bin_dir="$tmp_dir/no-probe-bin"
+mkdir -p "$no_probe_bin_dir"
+cp "$bin_dir/zstack-ctl" "$bin_dir/systemctl" "$no_probe_bin_dir/"
+ln -s /usr/bin/grep "$no_probe_bin_dir/grep"
+cat > "$no_probe_bin_dir/which" <<'EOF'
+#!/bin/sh
+command -v "$1"
+EOF
+chmod +x "$no_probe_bin_dir/which"
+
+calls="$tmp_dir/calls-no-probe"
+socket="$tmp_dir/mysql-no-probe.sock"
+touch "$socket"
+
+PATH="$no_probe_bin_dir" \
+ZSTUB_CALLS="$calls" \
+ZSTACK_MARIADB_SOCKET="$socket" \
+ZSTACK_SERVER_LOG_DIR="$log_dir" \
+/bin/sh "$script" start >/dev/null
+
+[ -e "$socket" ] || {
+    echo "expected socket to be kept when lsof and fuser are unavailable" >&2
+    exit 1
+}
+if grep -F "systemctl start mariadb" "$calls" >/dev/null 2>&1; then
+    echo "unexpected call: systemctl start mariadb" >&2
+    exit 1
+fi
+assert_contains "zstack-ctl start" "$calls"
+
+calls="$tmp_dir/calls-active"
+socket="$tmp_dir/mysql-active.sock"
+touch "$socket"
+
+PATH="$bin_dir:$PATH" \
+ZSTUB_CALLS="$calls" \
+ZSTUB_MARIADB_ACTIVE=true \
+ZSTACK_MARIADB_SOCKET="$socket" \
+ZSTACK_SERVER_LOG_DIR="$log_dir" \
+sh "$script" start >/dev/null
+
+[ -e "$socket" ] || {
+    echo "expected active MariaDB socket to be kept" >&2
+    exit 1
+}
+if grep -F "systemctl start mariadb" "$calls" >/dev/null 2>&1; then
+    echo "unexpected call: systemctl start mariadb" >&2
+    exit 1
+fi
+assert_contains "zstack-ctl start" "$calls"


### PR DESCRIPTION
## 修复说明

修复 Jira Issue: [ZSTAC-83507](http://jira.zstack.io/browse/ZSTAC-83507)
补充上下文: [TIC-4236](http://jira.zstack.io/browse/TIC-4236)

## 根因

管理节点断电后 MariaDB 可能异常退出并遗留 /var/lib/mysql/mysql.sock。再次启动时 mysql-check-socket 检测到 socket 存在但没有进程使用，MariaDB 启动失败，进而导致 MN 无法启动。

## 变更内容

- 在 zstack-server start 调用 zstack-ctl start 前检查 MariaDB stale socket
- socket 存在、MariaDB inactive、且 lsof/fuser 未发现占用时删除 socket
- 删除后 reset-failed 并启动 MariaDB，再继续启动 MN
- 增加 shell 回归测试覆盖 stale socket 删除和 active MariaDB 不误删场景

## 自测

- sh -n conf/install/zstack-server
- sh -n test/src/test/bash/test_zstack_server_mariadb_recovery.sh
- sh test/src/test/bash/test_zstack_server_mariadb_recovery.sh

sync from gitlab !9809