### PR TITLE
<fix>[ssh]: support legacy host keys

### DIFF
--- a/plugin/virtualRouterProvider/src/main/java/org/zstack/network/service/virtualrouter/vyos/VyosConfigSshFlow.java
+++ b/plugin/virtualRouterProvider/src/main/java/org/zstack/network/service/virtualrouter/vyos/VyosConfigSshFlow.java
@@ -119,13 +119,13 @@ public class VyosConfigSshFlow extends NoRollbackFlow {
                 script = String.format("echo \"%s\" > .ssh/authorized_keys\n %s", asf.getPublicKey(), script);
 
                 try {
-                    new Ssh().shell(script
+                    new Ssh().allowLegacyHostKeyAlgorithms().shell(script
                     ).setTimeout(300).setPrivateKey(asf.getPrivateKey()).setUsername("vyos").setHostname(mgmtNicIp).setPort(sshPort).runErrorByExceptionAndClose();
                 } catch (SshException e ) {
                      /*
                     ZSTAC-18352, try again with password when key fail
                      */
-                    new Ssh().shell(script
+                    new Ssh().allowLegacyHostKeyAlgorithms().shell(script
                     ).setTimeout(300).setPassword(password).setUsername("vyos").setHostname(mgmtNicIp).setPort(sshPort).runErrorByExceptionAndClose();
                 }
 

--- a/plugin/virtualRouterProvider/src/main/java/org/zstack/network/service/virtualrouter/vyos/VyosConnectFlow.java
+++ b/plugin/virtualRouterProvider/src/main/java/org/zstack/network/service/virtualrouter/vyos/VyosConnectFlow.java
@@ -71,7 +71,7 @@ public class VyosConnectFlow extends NoRollbackFlow {
                     sshPort, vrMgtIp));
             return;
         }
-        Ssh ssh1 = new Ssh();
+        Ssh ssh1 = new Ssh().allowLegacyHostKeyAlgorithms();
         ssh1.setUsername("vyos").setPrivateKey(asf.getPrivateKey()).setPort(sshPort)
                 .setHostname(vrMgtIp).setTimeout(timeout);
         SshResult ret1 = ssh1.command("sudo tail -n 300 /home/vyos/zvr/zvrboot.log").runAndClose();
@@ -81,7 +81,7 @@ public class VyosConnectFlow extends NoRollbackFlow {
             logger.debug(String.format("get vyos bootup log failed: %s", ret1.getStderr()));
         }
 
-        Ssh ssh2 = new Ssh();
+        Ssh ssh2 = new Ssh().allowLegacyHostKeyAlgorithms();
         ssh2.setUsername("vyos").setPrivateKey(asf.getPrivateKey()).setPort(sshPort)
                 .setHostname(vrMgtIp).setTimeout(timeout);
         SshResult ret2 = ssh2.command("sudo tail -n 300 /home/vyos/zvr/zvrstartup.log").runAndClose();
@@ -91,7 +91,7 @@ public class VyosConnectFlow extends NoRollbackFlow {
             logger.debug(String.format("get zvr startup log failed: %s", ret2.getStderr()));
         }
 
-        Ssh ssh3 = new Ssh();
+        Ssh ssh3 = new Ssh().allowLegacyHostKeyAlgorithms();
         ssh3.setUsername("vyos").setPrivateKey(asf.getPrivateKey()).setPort(sshPort)
                 .setHostname(vrMgtIp).setTimeout(timeout);
         SshResult ret3 = ssh3.command("sudo tail -n 300 /home/vyos/zvr/zvr.log").runAndClose();
@@ -101,7 +101,7 @@ public class VyosConnectFlow extends NoRollbackFlow {
             logger.debug(String.format("get zvr log failed: %s", ret3.getStderr()));
         }
 
-        Ssh ssh4 = new Ssh();
+        Ssh ssh4 = new Ssh().allowLegacyHostKeyAlgorithms();
         ssh4.setUsername("vyos").setPrivateKey(asf.getPrivateKey()).setPort(sshPort)
                 .setHostname(vrMgtIp).setTimeout(timeout);
         SshResult ret4 = ssh4.command("ps aux | grep zvr").runAndClose();

--- a/plugin/virtualRouterProvider/src/main/java/org/zstack/network/service/virtualrouter/vyos/VyosDeployAgentFlow.java
+++ b/plugin/virtualRouterProvider/src/main/java/org/zstack/network/service/virtualrouter/vyos/VyosDeployAgentFlow.java
@@ -126,7 +126,7 @@ public class VyosDeployAgentFlow extends NoRollbackFlow {
 
             private void deployAgent(int port) {
                 try {
-                    new Ssh().setTimeout(300).scpUpload(
+                    new Ssh().allowLegacyHostKeyAlgorithms().setTimeout(300).scpUpload(
                             PathUtil.findFileOnClassPath("ansible/zvr/zvr.bin", true).getAbsolutePath(),
                             "/home/vyos/zvr.bin"
                     ).scpUpload(
@@ -142,7 +142,7 @@ public class VyosDeployAgentFlow extends NoRollbackFlow {
                     ZSTAC-18352, try again with password when key fail
                      */
                     String password = VirtualRouterGlobalConfig.VYOS_PASSWORD.value();
-                    new Ssh().setTimeout(300).scpUpload(
+                    new Ssh().allowLegacyHostKeyAlgorithms().setTimeout(300).scpUpload(
                             PathUtil.findFileOnClassPath("ansible/zvr/zvr.bin", true).getAbsolutePath(),
                             "/home/vyos/zvr.bin"
                     ).scpUpload(
@@ -161,14 +161,14 @@ public class VyosDeployAgentFlow extends NoRollbackFlow {
                         "sudo bash /home/vyos/zvr/ssh/zvr-reboot.sh %s\n", forceReboot);
 
                 try {
-                    new Ssh().shell(script
+                    new Ssh().allowLegacyHostKeyAlgorithms().shell(script
                     ).setTimeout(300).setPrivateKey(asf.getPrivateKey()).setUsername("vyos").setHostname(mgmtNicIp).setPort(port).runErrorByExceptionAndClose();
                 } catch (SshException  e ) {
                     /*
                     ZSTAC-18352, try again with password when key fail
                      */
                     String password = VirtualRouterGlobalConfig.VYOS_PASSWORD.value();
-                    new Ssh().shell(script
+                    new Ssh().allowLegacyHostKeyAlgorithms().shell(script
                     ).setTimeout(300).setPassword(password).setUsername("vyos").setHostname(mgmtNicIp).setPort(port).runErrorByExceptionAndClose();
                 }
             }
@@ -193,7 +193,7 @@ public class VyosDeployAgentFlow extends NoRollbackFlow {
 
     private boolean isZvrMd5Changed(String ip, int port){
         int interval = 30 ;
-        Ssh ssh = new Ssh();
+        Ssh ssh = new Ssh().allowLegacyHostKeyAlgorithms();
         ssh.setUsername("vyos")
                 .setPrivateKey(asf.getPrivateKey())
                 .setPort(port)
@@ -288,7 +288,7 @@ public class VyosDeployAgentFlow extends NoRollbackFlow {
                     sshPort, vrMgtIp));
             return;
         }
-        Ssh ssh1 = new Ssh();
+        Ssh ssh1 = new Ssh().allowLegacyHostKeyAlgorithms();
         ssh1.setUsername("vyos").setPrivateKey(asf.getPrivateKey()).setPort(sshPort)
                 .setHostname(vrMgtIp).setTimeout(timeout);
         SshResult ret1 = ssh1.command("sudo tail -n 300 /home/vyos/zvr/zvrReboot.log").runAndClose();
@@ -298,7 +298,7 @@ public class VyosDeployAgentFlow extends NoRollbackFlow {
             logger.debug(String.format("get vyos reboot log failed: %s", ret1.getStderr()));
         }
 
-        Ssh ssh2 = new Ssh();
+        Ssh ssh2 = new Ssh().allowLegacyHostKeyAlgorithms();
         ssh2.setUsername("vyos").setPrivateKey(asf.getPrivateKey()).setPort(sshPort)
                 .setHostname(vrMgtIp).setTimeout(timeout);
         SshResult ret2 = ssh2.command("sudo tail -n 300 /tmp/agentRestart.log").runAndClose();

--- a/utils/src/main/java/org/zstack/utils/ssh/Ssh.java
+++ b/utils/src/main/java/org/zstack/utils/ssh/Ssh.java
@@ -53,8 +53,35 @@ public class Ssh {
     private boolean suppressException = false;
     private ScriptRunner script;
     private String language = "LANG=\"en_US.UTF-8\"; ";
+    private boolean legacyHostKeyAlgorithmsAllowed = false;
 
     private boolean init = false;
+
+    static String appendSshAlgorithms(String configuredAlgorithms, String... algorithms) {
+        Set<String> configured = new LinkedHashSet<String>();
+        if (StringUtils.isNotBlank(configuredAlgorithms)) {
+            for (String algorithm : configuredAlgorithms.split(",")) {
+                if (StringUtils.isNotBlank(algorithm)) {
+                    configured.add(algorithm.trim());
+                }
+            }
+        }
+
+        configured.addAll(Arrays.asList(algorithms));
+        return StringUtils.join(configured, ",");
+    }
+
+    private void enableLegacyHostKeyAlgorithms() {
+        session.setConfig("server_host_key",
+                appendSshAlgorithms(session.getConfig("server_host_key"), "ssh-rsa", "ssh-dss"));
+        session.setConfig("PubkeyAcceptedKeyTypes",
+                appendSshAlgorithms(session.getConfig("PubkeyAcceptedKeyTypes"), "ssh-rsa", "ssh-dss"));
+    }
+
+    public Ssh allowLegacyHostKeyAlgorithms() {
+        legacyHostKeyAlgorithmsAllowed = true;
+        return this;
+    }
 
     private interface SshRunner {
         SshResult run();
@@ -404,6 +431,9 @@ public class Ssh {
 
             session = jSch.getSession(username, hostname, port);
             session.setConfig("StrictHostKeyChecking", "no");
+            if (legacyHostKeyAlgorithmsAllowed) {
+                enableLegacyHostKeyAlgorithms();
+            }
             session.setPassword(password);
             if (privateKey == null) {
                 session.setConfig("PreferredAuthentications", "password");

--- a/utils/src/test/java/org/zstack/utils/ssh/SshTest.java
+++ b/utils/src/test/java/org/zstack/utils/ssh/SshTest.java
@@ -1,0 +1,24 @@
+package org.zstack.utils.ssh;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class SshTest {
+    @Test
+    public void addLegacyHostKeyAlgorithmsForOldVyosSshd() {
+        Assert.assertEquals("ssh-ed25519,rsa-sha2-512,ssh-rsa,ssh-dss",
+                Ssh.appendSshAlgorithms("ssh-ed25519,rsa-sha2-512", "ssh-rsa", "ssh-dss"));
+    }
+
+    @Test
+    public void doNotDuplicateLegacyHostKeyAlgorithms() {
+        Assert.assertEquals("ssh-ed25519,ssh-rsa,ssh-dss",
+                Ssh.appendSshAlgorithms("ssh-ed25519,ssh-rsa", "ssh-rsa", "ssh-dss"));
+    }
+
+    @Test
+    public void useLegacyHostKeyAlgorithmsWhenConfigIsEmpty() {
+        Assert.assertEquals("ssh-rsa,ssh-dss",
+                Ssh.appendSshAlgorithms(null, "ssh-rsa", "ssh-dss"));
+    }
+}


### PR DESCRIPTION
## 修复说明

修复 Jira: http://jira.zstack.io/browse/ZSTAC-85141

## 根因

JSch 0.2.9 默认 server_host_key proposal 不包含 ssh-rsa/ssh-dss，老 VyOS sshd 只提供这两个 host key 算法，导致云路由部署阶段 SSH 协商失败。

## 变更

- 为 JSch server_host_key 追加 ssh-rsa 和 ssh-dss
- 同步追加 PubkeyAcceptedKeyTypes
- 新增单测覆盖追加、去重和空配置场景

## 测试

- mvn -pl utils -Dtest=org.zstack.utils.ssh.SshTest test

sync from gitlab !9812