### PR TITLE
fix(ZCF-3472): show geneve network vni

### DIFF
--- a/sdk/src/main/java/org/zstack/sdk/network/zns/L2GeneveNetworkInventory.java
+++ b/sdk/src/main/java/org/zstack/sdk/network/zns/L2GeneveNetworkInventory.java
@@ -12,4 +12,12 @@ public class L2GeneveNetworkInventory extends org.zstack.sdk.L2NetworkInventory 
         return this.geneveId;
     }
 
+    public java.lang.Integer vni;
+    public void setVni(java.lang.Integer vni) {
+        this.vni = vni;
+    }
+    public java.lang.Integer getVni() {
+        return this.vni;
+    }
+
 }

--- a/search/src/main/java/org/zstack/zql/ast/ZQLMetadata.java
+++ b/search/src/main/java/org/zstack/zql/ast/ZQLMetadata.java
@@ -110,7 +110,7 @@ public class ZQLMetadata {
 
         public void errorIfNoField(String fname) {
             if (!hasInventoryField(fname)) {
-                throw new CloudRuntimeException(String.format("inventory[${selfInventoryClass}] has no field[%s]", fname));
+                throw new CloudRuntimeException(String.format("inventory[%s] has no field[%s]", simpleInventoryName(), fname));
             }
         }
 


### PR DESCRIPTION
Root cause: L2GeneveNetworkInventory did not expose a vni field, so Cloud GraphQL returned null for L2GeneveNetwork VNI.\n\nSolution: map Geneve virtualNetworkId/geneveId to vni and add regression assertions.\n\nSelf-test:\n- mvn -pl sdk -DskipTests install -q\n- mvn -pl plugin-premium/zns,test-premium -DskipTests install -q

sync from gitlab !9817