### PR TITLE
[ZCF-3527] Move ZNS API registration out of base sdnController config

### DIFF
--- a/conf/serviceConfig/sdnController.xml
+++ b/conf/serviceConfig/sdnController.xml
@@ -41,11 +41,6 @@
     </message>
 
     <message>
-        <name>org.zstack.network.zns.APIQueryZnsTenantRouterMsg</name>
-        <serviceId>query</serviceId>
-    </message>
-
-    <message>
         <name>org.zstack.sdnController.header.APIPullSdnControllerTenantMsg</name>
         <serviceId>query</serviceId>
     </message>


### PR DESCRIPTION
Root cause: base sdnController serviceConfig registered premium-only org.zstack.network.zns.APIQueryZnsTenantRouterMsg, causing root unit tests to fail Management Node startup with ClassNotFoundException when premium zns is not on classpath.

Fix: remove the premium ZNS tenant-router query API from base conf/serviceConfig/sdnController.xml.

Related premium MR moves the registration into premium/conf/serviceConfig/zns.xml.

sync from gitlab !9826