### PR TITLE
<fix>[query]: ZSTAC-80742 limit API query concurrency

### DIFF
--- a/search/src/main/java/org/zstack/query/QueryFacadeImpl.java
+++ b/search/src/main/java/org/zstack/query/QueryFacadeImpl.java
@@ -349,7 +349,7 @@ public class QueryFacadeImpl extends AbstractService implements QueryFacade, Glo
         }
     }
 
-    private void handle(APIQueryMessage msg) {
+    private APIQueryReply doQuery(APIQueryMessage msg) {
         AutoQuery at = autoQueryMap.get(msg.getClass());
         if (at == null) {
             at = msg.getClass().getAnnotation(AutoQuery.class);
@@ -374,12 +374,45 @@ public class QueryFacadeImpl extends AbstractService implements QueryFacade, Glo
             if (result.inventories != null) {
                 replySetter.invoke(reply, result.inventories);
             }
-            bus.reply(msg, reply);
+            return reply;
         } catch (OperationFailureException of) {
             throw of;
         } catch (Exception e) {
             throw new OperationFailureException(inerr("failed to query: %s", e.getMessage()));
         }
+    }
+
+    private void handle(APIQueryMessage msg) {
+        thdf.syncSubmit(new SyncTask<Void>() {
+            @Override
+            public Void call() {
+                APIQueryReply reply;
+                try {
+                    reply = doQuery(msg);
+                } catch (OperationFailureException of) {
+                    reply = new APIQueryReply();
+                    reply.setError(of.getErrorCode());
+                }
+
+                bus.reply(msg, reply);
+                return null;
+            }
+
+            @Override
+            public String getName() {
+                return getSyncSignature();
+            }
+
+            @Override
+            public String getSyncSignature() {
+                return "api-query";
+            }
+
+            @Override
+            public int getSyncLevel() {
+                return getQuerySyncLevel();
+            }
+        });
     }
 
     private String toZQLConditionString(QueryCondition c) {


### PR DESCRIPTION
## Summary
Limit backend AutoQuery concurrency to prevent bursty GraphQL VM list refreshes from overwhelming the management node.

## Root Cause
Refreshing the VM list can fan out into many GraphQL-backed `APIQueryMessage` requests such as `GuestToolsState` and `ModelServiceInstance` queries. ZQL and BatchQuery were already routed through the query sync queue, but ordinary AutoQuery handling executed directly, allowing large bursts to run concurrently and overload the management node.

## Changes
- Route `APIQueryMessage` handling through the existing query sync queue.
- Reuse the same query sync level as ZQL/BatchQuery.
- Preserve existing AutoQuery response construction and error propagation.

## Testing
- [x] `JAVA_HOME=$(/usr/libexec/java_home -v 1.8) mvn -pl search -am -DskipTests compile`
- [ ] CI pipeline
- [ ] Manual reproduction with 100 VM batch migration and VM list refresh

Resolves: ZSTAC-80742

sync from gitlab !9866