### PR TITLE
<fix>[dgpu]: clarify missing dGPU quota error

### DIFF
--- a/conf/i18n/globalErrorCodeMapping/global-error-en_US.json
+++ b/conf/i18n/globalErrorCodeMapping/global-error-en_US.json
@@ -4722,6 +4722,7 @@
   "ORG_ZSTACK_DGPU_10010": "Available License not found, please apply addon license for product dGPU.",
   "ORG_ZSTACK_DGPU_10011": "Addon license for product dGPU has expired, please renew it.",
   "ORG_ZSTACK_DGPU_10012": "Insufficient dGPU GPU number licensed. Your license permits %d GPU, there are %d GPU used, shared: %d, need: %d.",
+  "ORG_ZSTACK_DGPU_10013": "dGPU AddOn License is available, but no GPU number quota is granted. Please update the dGPU AddOn License, or request dGPU GPU number capacity from License Server for the current node.",
   "ORG_ZSTACK_AI_10159": "Model service instance[UUID: %s] failed to start within %s seconds. Reason: %s",
   "ORG_ZSTACK_AI_10138": "Requested CPU count[%s] exceeds the CPU limit[%s]",
   "ORG_ZSTACK_AI_10139": "Requested memory size[%s] exceeds the memory limit[%s]",

--- a/conf/i18n/globalErrorCodeMapping/global-error-zh_CN.json
+++ b/conf/i18n/globalErrorCodeMapping/global-error-zh_CN.json
@@ -4722,6 +4722,7 @@
   "ORG_ZSTACK_DGPU_10010": "未找到可用的 dGPU AddOn License，请为 dGPU 产品申请并上传对应授权。",
   "ORG_ZSTACK_DGPU_10011": "dGPU 产品的 AddOn License 已过期，请及时续期。",
   "ORG_ZSTACK_DGPU_10012": "dGPU 授权 GPU 数量不足。License 允许 %d 个 GPU，当前已使用 %d 个，其他节点共享使用 %d 个，本次还需要 %d 个。",
+  "ORG_ZSTACK_DGPU_10013": "dGPU AddOn License 已存在，但未授予 GPU 数量授权。请更新 dGPU AddOn License，或从 License Server 为当前节点申请 dGPU GPU 数量授权。",
   "ORG_ZSTACK_AI_10138": "请求 CPU 数量[%s]超过 CPU 上限[%s]",
   "ORG_ZSTACK_AI_10139": "请求内存大小[%s]超过内存上限[%s]",
   "ORG_ZSTACK_AI_10140": "请求 CPU 数量[%s] 不能低于最小保证值，配置最小值: %s，实际最小值: %s（max(cpuNum × 20%%, 配置最小值)）",

--- a/utils/src/main/java/org/zstack/utils/clouderrorcode/CloudOperationsErrorCode.java
+++ b/utils/src/main/java/org/zstack/utils/clouderrorcode/CloudOperationsErrorCode.java
@@ -16049,4 +16049,6 @@ public class CloudOperationsErrorCode {
     public static final String ORG_ZSTACK_DGPU_10011 = "ORG_ZSTACK_DGPU_10011";
 
     public static final String ORG_ZSTACK_DGPU_10012 = "ORG_ZSTACK_DGPU_10012";
+
+    public static final String ORG_ZSTACK_DGPU_10013 = "ORG_ZSTACK_DGPU_10013";
 }


### PR DESCRIPTION
## Summary
- Add ORG_ZSTACK_DGPU_10013 for dGPU AddOn licenses that exist without GPU number quota.
- Add zh_CN/en_US global error mappings for the clearer message.

## Verification
- jq empty conf/i18n/globalErrorCodeMapping/global-error-en_US.json conf/i18n/globalErrorCodeMapping/global-error-zh_CN.json
- git diff --check
- JAVA_HOME=$(/usr/libexec/java_home -v 1.8) mvn -pl utils -DskipTests package

## Notes
- Targeted TestDGpuLicenseCase could not run locally because required org.zstack:*:5.5.0 Maven artifacts were absent and blocked by maven-default-http-blocker.

sync from gitlab !9875