### PR TITLE
<fix>[ai]: expose CDN template framework

### DIFF
--- a/conf/db/upgrade/V5.5.22__schema.sql
+++ b/conf/db/upgrade/V5.5.22__schema.sql
@@ -39,6 +39,7 @@ CREATE TABLE IF NOT EXISTS `zstack`.`CdnModelServiceTemplateVO` (
     `name` varchar(255) NOT NULL,
     `version` varchar(255) DEFAULT NULL,
     `platform` varchar(255) DEFAULT NULL,
+    `framework` varchar(255) DEFAULT NULL,
     `size` bigint DEFAULT NULL,
     `projectId` varchar(255) DEFAULT NULL,
     `projectName` varchar(255) DEFAULT NULL,
@@ -54,6 +55,7 @@ CREATE TABLE IF NOT EXISTS `zstack`.`CdnModelServiceTemplateVO` (
     CONSTRAINT `fkCdnModelServiceTemplateVOModelServiceVO` FOREIGN KEY (`modelServiceUuid`)
         REFERENCES `zstack`.`ModelServiceVO` (`uuid`) ON DELETE SET NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+CALL ADD_COLUMN('CdnModelServiceTemplateVO', 'framework', 'varchar(255)', 1, NULL);
 
 -- dGPU billing support tables
 

--- a/sdk/src/main/java/org/zstack/sdk/CdnModelServiceTemplateInventory.java
+++ b/sdk/src/main/java/org/zstack/sdk/CdnModelServiceTemplateInventory.java
@@ -36,6 +36,14 @@ public class CdnModelServiceTemplateInventory  {
         return this.platform;
     }
 
+    public java.lang.String framework;
+    public void setFramework(java.lang.String framework) {
+        this.framework = framework;
+    }
+    public java.lang.String getFramework() {
+        return this.framework;
+    }
+
     public java.lang.Long size;
     public void setSize(java.lang.Long size) {
         this.size = size;


### PR DESCRIPTION
## Summary
- Add `framework` column for `CdnModelServiceTemplateVO` in V5.5.22 schema upgrade.
- Add `framework` to Java SDK `CdnModelServiceTemplateInventory` so UI/SDK consumers can read the API field.

## Verification
- PR Docker `registry.docker.zstack.io:80/pr-build-bin:2.41test-4`
- `./runMavenProfile premium` passed
- `mvn install -DskipTests -pl sdk` passed
- `cd /zstack/premium/test-premium && mvn test -Dtest=ImportModelServiceTemplateCase -Dsurefire.useFile=false` passed

sync from gitlab !9879