### PR TITLE
<fix>[zns]: ZCF-3603 centralize zns nic mode tag

### DIFF
--- a/compute/src/main/java/org/zstack/compute/vm/VmInstanceBase.java
+++ b/compute/src/main/java/org/zstack/compute/vm/VmInstanceBase.java
@@ -2303,6 +2303,7 @@ public class VmInstanceBase extends AbstractVmInstance {
         Defer.guard(setCustomMacSystemTag::rollback);
 
         final VmInstanceSpec spec = buildSpecFromInventory(getSelfInventory(), VmOperation.AttachNic);
+        spec.setMessage(msg);
         final VmInstanceInventory vm = spec.getVmInventory();
         List<L3NetworkInventory> l3s = new ArrayList<>();
         for (String l3Uuid : l3Uuids) {

--- a/compute/src/main/java/org/zstack/compute/vm/VmNicManagerImpl.java
+++ b/compute/src/main/java/org/zstack/compute/vm/VmNicManagerImpl.java
@@ -293,30 +293,28 @@ public class VmNicManagerImpl implements VmNicManager, VmNicExtensionPoint, Prep
         VSwitchType vSwitchType = VSwitchType.valueOf(l2nw.getvSwitchType());
 
         if (L2NetworkConstant.VSWITCH_TYPE_ZNS.equals(l2nw.getvSwitchType())) {
-            List<String> znsNicModeTags = new ArrayList<>();
+            List<String> znsNicModes = new ArrayList<>();
             if (vmSystemTags != null) {
-                znsNicModeTags.addAll(vmSystemTags.stream()
+                znsNicModes.addAll(vmSystemTags.stream()
                         .filter(Objects::nonNull)
                         .map(String::trim)
-                        .filter(tag -> tag.startsWith(L2NetworkConstant.ZNS_NIC_MODE_TAG_PREFIX))
+                        .filter(VmSystemTags.ZNS_NIC_MODE::isMatch)
+                        .map(tag -> VmSystemTags.ZNS_NIC_MODE.getTokenByTag(tag, VmSystemTags.ZNS_NIC_MODE_TOKEN))
                         .collect(Collectors.toList()));
             }
-            znsNicModeTags.addAll(Q.New(SystemTagVO.class)
-                    .select(SystemTagVO_.tag)
-                    .eq(SystemTagVO_.resourceType, VmInstanceVO.class.getSimpleName())
-                    .eq(SystemTagVO_.resourceUuid, vmUuid)
-                    .like(SystemTagVO_.tag, L2NetworkConstant.ZNS_NIC_MODE_TAG_PREFIX + "%")
-                    .listValues());
+            znsNicModes.addAll(VmSystemTags.ZNS_NIC_MODE.getTags(vmUuid).stream()
+                    .map(tag -> VmSystemTags.ZNS_NIC_MODE.getTokenByTag(tag, VmSystemTags.ZNS_NIC_MODE_TOKEN))
+                    .collect(Collectors.toList()));
 
-            for (String tag : znsNicModeTags) {
-                if (!L2NetworkConstant.ZNS_NIC_MODE_DPDK_TAG.equals(tag) && !L2NetworkConstant.ZNS_NIC_MODE_KERNEL_TAG.equals(tag)) {
+            for (String mode : znsNicModes) {
+                if (!VmInstanceConstant.ZNS_NIC_MODE_DPDK.equals(mode) && !VmInstanceConstant.ZNS_NIC_MODE_KERNEL.equals(mode)) {
                     throw new OperationFailureException(argerr(ORG_ZSTACK_COMPUTE_VM_10257,
-                            "invalid znsNicMode system tag[%s], valid values are [%s, %s]",
-                            tag, L2NetworkConstant.ZNS_NIC_MODE_DPDK_TAG, L2NetworkConstant.ZNS_NIC_MODE_KERNEL_TAG));
+                            "invalid znsNicMode[%s], valid values are [%s, %s]",
+                            mode, VmInstanceConstant.ZNS_NIC_MODE_DPDK, VmInstanceConstant.ZNS_NIC_MODE_KERNEL));
                 }
             }
 
-            boolean enableZnsDpdk = znsNicModeTags.contains(L2NetworkConstant.ZNS_NIC_MODE_DPDK_TAG);
+            boolean enableZnsDpdk = znsNicModes.contains(VmInstanceConstant.ZNS_NIC_MODE_DPDK);
             logger.debug(String.format("create %s on zns l3 network[uuid:%s] inside VmAllocateNicFlow",
                     enableZnsDpdk ? "dpdk vhostuser nic" : "vnic", l3nw.getUuid()));
             return vSwitchType.getVmNicType(enableZnsDpdk ? VmNicType.VmNicSubType.VHOSTUSER : VmNicType.VmNicSubType.NONE);

--- a/compute/src/main/java/org/zstack/compute/vm/VmSystemTags.java
+++ b/compute/src/main/java/org/zstack/compute/vm/VmSystemTags.java
@@ -321,6 +321,10 @@ public class VmSystemTags {
 
     public static PatternedSystemTag VM_MEMORY_ACCESS_MODE_SHARED = new PatternedSystemTag(("vmMemoryAccessModeShared"), VmInstanceVO.class);
 
+    public static String ZNS_NIC_MODE_TOKEN = "znsNicMode";
+    public static PatternedSystemTag ZNS_NIC_MODE = new PatternedSystemTag(
+            String.format("%s::{%s}", ZNS_NIC_MODE_TOKEN, ZNS_NIC_MODE_TOKEN), VmInstanceVO.class);
+
     public static String IFACE_ID_TOKEN = "ifaceId";
     public static PatternedSystemTag IFACE_ID = new PatternedSystemTag(
             String.format("ifaceId::{%s}", IFACE_ID_TOKEN), VmNicVO.class);

--- a/header/src/main/java/org/zstack/header/network/l2/L2NetworkConstant.java
+++ b/header/src/main/java/org/zstack/header/network/l2/L2NetworkConstant.java
@@ -44,11 +44,6 @@ public interface L2NetworkConstant {
     public static final String OVN_DPDK_VNIC_SRC_PATH = "/var/run/openvswitch/";
     public static final String ACCEL_TYPE_VDPA = "vDPA";
     public static final String ACCEL_TYPE_VHOST_USER_SPACE = "dpdkvhostuserclient";
-    public static final String ZNS_NIC_MODE_TAG_PREFIX = "znsNicMode::";
-    public static final String ZNS_NIC_MODE_DPDK = "dpdk";
-    public static final String ZNS_NIC_MODE_KERNEL = "kernel";
-    public static final String ZNS_NIC_MODE_DPDK_TAG = ZNS_NIC_MODE_TAG_PREFIX + ZNS_NIC_MODE_DPDK;
-    public static final String ZNS_NIC_MODE_KERNEL_TAG = ZNS_NIC_MODE_TAG_PREFIX + ZNS_NIC_MODE_KERNEL;
 
     public static final String DETACH_L2NETWORK_CODE = "l2Network.detach";
 

--- a/header/src/main/java/org/zstack/header/vm/VmInstanceConstant.java
+++ b/header/src/main/java/org/zstack/header/vm/VmInstanceConstant.java
@@ -18,6 +18,8 @@ public interface VmInstanceConstant {
     String KVM_HYPERVISOR_TYPE = "KVM";
 
     String VIRTUAL_NIC_TYPE = "VNIC";
+    String ZNS_NIC_MODE_DPDK = "dpdk";
+    String ZNS_NIC_MODE_KERNEL = "kernel";
 
     String VM_SYNC_SIGNATURE_PREFIX = "Vm-";
 

--- a/header/src/main/java/org/zstack/header/vm/VmNicInventory.java
+++ b/header/src/main/java/org/zstack/header/vm/VmNicInventory.java
@@ -40,6 +40,8 @@ public class VmNicInventory implements Serializable {
     @Deprecated
     private Integer ipVersion;
     private String driverType;
+    @APINoSee
+    private String interfaceId;
     private List<UsedIpInventory> usedIps;
     private String internalName;
     private Integer deviceId;
@@ -221,6 +223,14 @@ public class VmNicInventory implements Serializable {
 
     public void setDriverType(String driverType) {
         this.driverType = driverType;
+    }
+
+    public String getInterfaceId() {
+        return interfaceId;
+    }
+
+    public void setInterfaceId(String interfaceId) {
+        this.interfaceId = interfaceId;
     }
 
     public String getType() {


### PR DESCRIPTION
## Summary
Move the VM-level znsNicMode system tag definition into VmSystemTags and keep the ZCF-3603 cross-repo branch suffix at @@2.

## Changes
- Define ZNS_NIC_MODE in VmSystemTags.
- Move ZNS NIC mode values to VmInstanceConstant.
- Resolve ZNS NIC mode through PatternedSystemTag token parsing in VmNicManagerImpl.
- Remove duplicate znsNicMode constants from L2NetworkConstant.

## Testing
- Not rerun after branch rename/rebase.
- Previous compile-only check: mvn -pl header,compute -DskipTests install

Resolves: ZCF-3603

sync from gitlab !9881