### PR TITLE
<fix>[ha]: stabilize suspect host pre-fence flow

### DIFF
--- a/compute/src/main/java/org/zstack/compute/vm/VmInstanceBase.java
+++ b/compute/src/main/java/org/zstack/compute/vm/VmInstanceBase.java
@@ -9272,4 +9272,3 @@ public class VmInstanceBase extends AbstractVmInstance {
         });
     }
 }
-

--- a/compute/src/main/java/org/zstack/compute/vm/VmStartOnHypervisorFlow.java
+++ b/compute/src/main/java/org/zstack/compute/vm/VmStartOnHypervisorFlow.java
@@ -5,17 +5,26 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Configurable;
 import org.zstack.core.cloudbus.CloudBus;
 import org.zstack.core.cloudbus.CloudBusCallBack;
+import org.zstack.core.asyncbatch.While;
 import org.zstack.core.componentloader.PluginRegistry;
+import org.zstack.core.workflow.FlowChainBuilder;
+import org.zstack.header.core.Completion;
+import org.zstack.header.core.WhileDoneCompletion;
 import org.zstack.header.core.workflow.Flow;
+import org.zstack.header.core.workflow.FlowChain;
+import org.zstack.header.core.workflow.FlowDoneHandler;
+import org.zstack.header.core.workflow.FlowErrorHandler;
 import org.zstack.header.core.workflow.FlowRollback;
 import org.zstack.header.core.workflow.FlowTrigger;
+import org.zstack.header.core.workflow.NoRollbackFlow;
+import org.zstack.header.errorcode.ErrorCode;
+import org.zstack.header.errorcode.ErrorCodeList;
 import org.zstack.header.host.HostConstant;
 import org.zstack.header.message.MessageReply;
 import org.zstack.header.vm.*;
 import org.zstack.utils.Utils;
 import org.zstack.utils.logging.CLogger;
 
-import java.util.List;
 import java.util.Map;
 @Configurable(preConstruction = true, autowire = Autowire.BY_TYPE)
 public class VmStartOnHypervisorFlow implements Flow {
@@ -26,34 +35,68 @@ public class VmStartOnHypervisorFlow implements Flow {
     @Autowired
     private PluginRegistry pluginRgty;
 
-    private final List<VmBeforeStartOnHypervisorExtensionPoint> exts = pluginRgty.getExtensionList(VmBeforeStartOnHypervisorExtensionPoint.class);;
-
-    private void fireExtensions(VmInstanceSpec spec) {
-        for (VmBeforeStartOnHypervisorExtensionPoint ext : exts) {
-            ext.beforeStartVmOnHypervisor(spec);
-        }
-    }
-
     @Override
     public void run(final FlowTrigger chain, final Map data) {
         final VmInstanceSpec spec = (VmInstanceSpec) data.get(VmInstanceConstant.Params.VmInstanceSpec.toString());
-
-        fireExtensions(spec);
-
-        StartVmOnHypervisorMsg msg = new StartVmOnHypervisorMsg();
-        msg.setVmSpec(spec);
-        bus.makeTargetServiceIdByResourceUuid(msg, HostConstant.SERVICE_ID, spec.getDestHost().getUuid());
-        bus.send(msg, new CloudBusCallBack(chain) {
+        FlowChain fchain = FlowChainBuilder.newSimpleFlowChain();
+        fchain.setName(String.format("vm-start-on-hypervisor-vm-%s", spec.getVmInventory().getUuid()));
+        fchain.then(new NoRollbackFlow() {
             @Override
-            public void run(MessageReply reply) {
-                if (reply.isSuccess()) {
-                    data.put(VmStartOnHypervisorFlow.class.getName(), true);
-                    chain.next();
-                } else {
-                    chain.fail(reply.getError());
-                }
+            public void run(FlowTrigger trigger, Map d) {
+                new While<>(pluginRgty.getExtensionList(VmBeforeStartOnHypervisorExtensionPoint.class))
+                        .each((ext, comp) -> ext.beforeStartVmOnHypervisor(spec, new Completion(comp) {
+                            @Override
+                            public void success() {
+                                comp.done();
+                            }
+
+                            @Override
+                            public void fail(ErrorCode errorCode) {
+                                comp.addError(errorCode);
+                                comp.done();
+                            }
+                        })).run(new WhileDoneCompletion(trigger) {
+                            @Override
+                            public void done(ErrorCodeList errorCodeList) {
+                                if (errorCodeList.getCauses().size() > 0) {
+                                    trigger.fail(errorCodeList.getCauses().get(0));
+                                } else {
+                                    trigger.next();
+                                }
+                            }
+                        });
             }
         });
+        fchain.then(new NoRollbackFlow() {
+            @Override
+            public void run(FlowTrigger trigger, Map d) {
+                StartVmOnHypervisorMsg msg = new StartVmOnHypervisorMsg();
+                msg.setVmSpec(spec);
+                bus.makeTargetServiceIdByResourceUuid(msg, HostConstant.SERVICE_ID, spec.getDestHost().getUuid());
+                bus.send(msg, new CloudBusCallBack(trigger) {
+                    @Override
+                    public void run(MessageReply reply) {
+                        if (reply.isSuccess()) {
+                            data.put(VmStartOnHypervisorFlow.class.getName(), true);
+                            trigger.next();
+                        } else {
+                            trigger.fail(reply.getError());
+                        }
+                    }
+                });
+            }
+        });
+        fchain.done(new FlowDoneHandler(chain) {
+            @Override
+            public void handle(Map d) {
+                chain.next();
+            }
+        }).error(new FlowErrorHandler(chain) {
+            @Override
+            public void handle(ErrorCode errCode, Map d) {
+                chain.fail(errCode);
+            }
+        }).start();
     }
 
     @Override

--- a/header/src/main/java/org/zstack/header/vm/HaStartVmInstanceMsg.java
+++ b/header/src/main/java/org/zstack/header/vm/HaStartVmInstanceMsg.java
@@ -12,6 +12,7 @@ public class HaStartVmInstanceMsg extends NeedReplyMessage implements VmInstance
     private String vmInstanceUuid;
     private String judgerClassName;
     private List<String> softAvoidHostUuids;
+    private String accessiblePeerHostUuid;
     private String haReason;
 
     public String getJudgerClassName() {
@@ -28,6 +29,14 @@ public class HaStartVmInstanceMsg extends NeedReplyMessage implements VmInstance
 
     public void setSoftAvoidHostUuids(List<String> softAvoidHostUuids) {
         this.softAvoidHostUuids = softAvoidHostUuids;
+    }
+
+    public String getAccessiblePeerHostUuid() {
+        return accessiblePeerHostUuid;
+    }
+
+    public void setAccessiblePeerHostUuid(String accessiblePeerHostUuid) {
+        this.accessiblePeerHostUuid = accessiblePeerHostUuid;
     }
 
     @Override

--- a/header/src/main/java/org/zstack/header/vm/VmBeforeStartOnHypervisorExtensionPoint.java
+++ b/header/src/main/java/org/zstack/header/vm/VmBeforeStartOnHypervisorExtensionPoint.java
@@ -1,7 +1,14 @@
 package org.zstack.header.vm;
 
+import org.zstack.header.core.Completion;
+
 /**
  */
 public interface VmBeforeStartOnHypervisorExtensionPoint {
-    void beforeStartVmOnHypervisor(VmInstanceSpec spec);
+    default void beforeStartVmOnHypervisor(VmInstanceSpec spec) {}
+
+    default void beforeStartVmOnHypervisor(VmInstanceSpec spec, Completion completion) {
+        beforeStartVmOnHypervisor(spec);
+        completion.success();
+    }
 }


### PR DESCRIPTION
Pre-fence leftover QEMU processes through a reachable sibling host
and pass that sibling through HA VM start. Use the agent success
flag as the pre-fence verdict and drop redundant response fields.

Test: mvn -pl plugin/kvm,simulator/simulatorImpl,testlib -am -DskipTests compile

Resolves: ZSTAC-83890

Change-Id: I168adf82338f9df9e76287619b7f76a8e5be695f
(cherry picked from commit 847cc3b1e5fda4c1e7c1466c0ffedb5de3e23098)

sync from gitlab !9885