### PR TITLE
<fix>[vm]: ZSTAC-84158 handle StopVmGC host mismatch

### DIFF
--- a/compute/src/main/java/org/zstack/compute/vm/StopVmGC.java
+++ b/compute/src/main/java/org/zstack/compute/vm/StopVmGC.java
@@ -51,6 +51,7 @@ public class StopVmGC extends EventBasedGarbageCollector {
             public void run(FlowTrigger trigger, Map data) {
                 StopVmOnHypervisorMsg msg = new StopVmOnHypervisorMsg();
                 msg.setVmInventory(inventory);
+                msg.setIgnoreNotFoundError(true);
                 bus.makeTargetServiceIdByResourceUuid(msg, HostConstant.SERVICE_ID, hostUuid);
                 bus.send(msg, new CloudBusCallBack(trigger) {
                     @Override
@@ -66,6 +67,16 @@ public class StopVmGC extends EventBasedGarbageCollector {
         }).then(new NoRollbackFlow() {
             @Override
             public void run(FlowTrigger trigger, Map data) {
+                String vmHostUuid = Q.New(VmInstanceVO.class).select(VmInstanceVO_.hostUuid)
+                        .eq(VmInstanceVO_.uuid, inventory.getUuid()).findValue();
+                if (!hostUuid.equals(vmHostUuid)) {
+                    logger.debug(String.format("skip changing vm[uuid:%s] state to stopped after StopVmGC, " +
+                            "current host[uuid:%s] is not gc host[uuid:%s]", inventory.getUuid(),
+                            vmHostUuid, hostUuid));
+                    trigger.next();
+                    return;
+                }
+
                 ChangeVmStateMsg cmsg = new ChangeVmStateMsg();
                 cmsg.setVmInstanceUuid(inventory.getUuid());
                 cmsg.setStateEvent(VmInstanceStateEvent.stopped.toString());

--- a/header/src/main/java/org/zstack/header/vm/StopVmOnHypervisorMsg.java
+++ b/header/src/main/java/org/zstack/header/vm/StopVmOnHypervisorMsg.java
@@ -7,7 +7,7 @@ public class StopVmOnHypervisorMsg extends NeedReplyMessage implements HostMessa
     private VmInstanceInventory vmInventory;
     private String type;
     private boolean debug;
-    private boolean ignoreNotFoundError;
+    private Boolean ignoreNotFoundError;
 
     public VmInstanceInventory getVmInventory() {
         return vmInventory;
@@ -38,11 +38,11 @@ public class StopVmOnHypervisorMsg extends NeedReplyMessage implements HostMessa
         this.debug = debug;
     }
 
-    public boolean isIgnoreNotFoundError() {
+    public Boolean isIgnoreNotFoundError() {
         return ignoreNotFoundError;
     }
 
-    public void setIgnoreNotFoundError(boolean ignoreNotFoundError) {
+    public void setIgnoreNotFoundError(Boolean ignoreNotFoundError) {
         this.ignoreNotFoundError = ignoreNotFoundError;
     }
 }

--- a/header/src/main/java/org/zstack/header/vm/StopVmOnHypervisorMsg.java
+++ b/header/src/main/java/org/zstack/header/vm/StopVmOnHypervisorMsg.java
@@ -7,6 +7,7 @@ public class StopVmOnHypervisorMsg extends NeedReplyMessage implements HostMessa
     private VmInstanceInventory vmInventory;
     private String type;
     private boolean debug;
+    private boolean ignoreNotFoundError;
 
     public VmInstanceInventory getVmInventory() {
         return vmInventory;
@@ -35,5 +36,13 @@ public class StopVmOnHypervisorMsg extends NeedReplyMessage implements HostMessa
 
     public void setDebug(boolean debug) {
         this.debug = debug;
+    }
+
+    public boolean isIgnoreNotFoundError() {
+        return ignoreNotFoundError;
+    }
+
+    public void setIgnoreNotFoundError(boolean ignoreNotFoundError) {
+        this.ignoreNotFoundError = ignoreNotFoundError;
     }
 }

--- a/plugin/kvm/src/main/java/org/zstack/kvm/KVMAgentCommands.java
+++ b/plugin/kvm/src/main/java/org/zstack/kvm/KVMAgentCommands.java
@@ -3328,6 +3328,8 @@ public class KVMAgentCommands {
         private String type;
         @GrayVersion(value = "5.0.0")
         private long timeout;
+        @GrayVersion(value = "5.5.22")
+        private boolean ignoreNotFoundError;
         private List<VmNicInventory> vmNics;
 
         public String getUuid() {
@@ -3352,6 +3354,14 @@ public class KVMAgentCommands {
 
         public void setType(String type) {
             this.type = type;
+        }
+
+        public boolean isIgnoreNotFoundError() {
+            return ignoreNotFoundError;
+        }
+
+        public void setIgnoreNotFoundError(boolean ignoreNotFoundError) {
+            this.ignoreNotFoundError = ignoreNotFoundError;
         }
 
         public List<VmNicInventory> getVmNics() {

--- a/plugin/kvm/src/main/java/org/zstack/kvm/KVMAgentCommands.java
+++ b/plugin/kvm/src/main/java/org/zstack/kvm/KVMAgentCommands.java
@@ -3329,7 +3329,7 @@ public class KVMAgentCommands {
         @GrayVersion(value = "5.0.0")
         private long timeout;
         @GrayVersion(value = "5.5.22")
-        private boolean ignoreNotFoundError;
+        private Boolean ignoreNotFoundError;
         private List<VmNicInventory> vmNics;
 
         public String getUuid() {
@@ -3356,11 +3356,11 @@ public class KVMAgentCommands {
             this.type = type;
         }
 
-        public boolean isIgnoreNotFoundError() {
+        public Boolean isIgnoreNotFoundError() {
             return ignoreNotFoundError;
         }
 
-        public void setIgnoreNotFoundError(boolean ignoreNotFoundError) {
+        public void setIgnoreNotFoundError(Boolean ignoreNotFoundError) {
             this.ignoreNotFoundError = ignoreNotFoundError;
         }
 

--- a/plugin/kvm/src/main/java/org/zstack/kvm/KVMHost.java
+++ b/plugin/kvm/src/main/java/org/zstack/kvm/KVMHost.java
@@ -3872,6 +3872,7 @@ public class KVMHost extends HostBase implements Host {
         cmd.setUuid(vminv.getUuid());
         cmd.setType(msg.getType());
         cmd.setTimeout(120);
+        cmd.setIgnoreNotFoundError(msg.isIgnoreNotFoundError());
         cmd.setVmNics(vminv.getVmNics());
 
         try {


### PR DESCRIPTION
- StopVmGC 下发 stop 时设置 ignoreNotFound。
- stop 返回后只在 VM 仍属于 GC host 时改为 Stopped。
- StopVmOnHypervisorMsg/StopVmCmd 透传 ignoreNotFound。

sync from gitlab !9888