### PR TITLE
<feature>[sdk]: Add GetLicenseUsages API for multi-dimension usage

### DIFF
--- a/conf/roleDefinitions/roleDefinition.json
+++ b/conf/roleDefinitions/roleDefinition.json
@@ -78,6 +78,7 @@
           "org.zstack.license.APIGetLicenseRecordsMsg",
           "org.zstack.license.APIGetLicenseInfoMsg",
           "org.zstack.license.APIGetLicenseCapabilitiesMsg",
+          "org.zstack.license.api.usage.APIGetLicenseUsagesMsg",
           "org.zstack.ldap.**",
           "org.zstack.header.storageDevice.**",
           "org.zstack.header.aliyun.oss.**",

--- a/sdk/src/main/java/SourceClassMap.java
+++ b/sdk/src/main/java/SourceClassMap.java
@@ -365,6 +365,7 @@ public class SourceClassMap {
 			put("org.zstack.license.UKeyInventory", "org.zstack.sdk.UKeyInventory");
 			put("org.zstack.license.UKeyStatus", "org.zstack.sdk.UKeyStatus");
 			put("org.zstack.license.entity.LicenseHistoryInventory", "org.zstack.sdk.license.entity.LicenseHistoryInventory");
+			put("org.zstack.license.entity.LicenseUsageResult", "org.zstack.sdk.license.entity.LicenseUsageResult");
 			put("org.zstack.license.entity.LicenseUsageView", "org.zstack.sdk.license.entity.LicenseUsageView");
 			put("org.zstack.license.entity.UpdateLicenseView", "org.zstack.sdk.license.entity.UpdateLicenseView");
 			put("org.zstack.loginControl.entity.AccessControlRuleInventory", "org.zstack.sdk.AccessControlRuleInventory");
@@ -1267,6 +1268,7 @@ public class SourceClassMap {
 			put("org.zstack.sdk.keyprovider.api.RekeyProviderResult", "org.zstack.crypto.keyprovider.api.RekeyProviderResult");
 			put("org.zstack.sdk.keyprovider.api.RekeySkippedResource", "org.zstack.crypto.keyprovider.api.RekeySkippedResource");
 			put("org.zstack.sdk.license.entity.LicenseHistoryInventory", "org.zstack.license.entity.LicenseHistoryInventory");
+			put("org.zstack.sdk.license.entity.LicenseUsageResult", "org.zstack.license.entity.LicenseUsageResult");
 			put("org.zstack.sdk.license.entity.LicenseUsageView", "org.zstack.license.entity.LicenseUsageView");
 			put("org.zstack.sdk.license.entity.UpdateLicenseView", "org.zstack.license.entity.UpdateLicenseView");
 			put("org.zstack.sdk.managements.common.ManagementNodeStatusView", "org.zstack.managements.entity.common.ManagementNodeStatusView");

--- a/sdk/src/main/java/org/zstack/sdk/license/api/usage/GetLicenseUsagesAction.java
+++ b/sdk/src/main/java/org/zstack/sdk/license/api/usage/GetLicenseUsagesAction.java
@@ -1,0 +1,95 @@
+package org.zstack.sdk.license.api.usage;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.zstack.sdk.*;
+
+public class GetLicenseUsagesAction extends AbstractAction {
+
+    private static final HashMap<String, Parameter> parameterMap = new HashMap<>();
+
+    private static final HashMap<String, Parameter> nonAPIParameterMap = new HashMap<>();
+
+    public static class Result {
+        public ErrorCode error;
+        public org.zstack.sdk.license.api.usage.GetLicenseUsagesResult value;
+
+        public Result throwExceptionIfError() {
+            if (error != null) {
+                throw new ApiException(
+                    String.format("error[code: %s, description: %s, details: %s]", error.code, error.description, error.details)
+                );
+            }
+            
+            return this;
+        }
+    }
+
+    @Param(required = false, nonempty = false, nullElements = false, emptyString = true, noTrim = false)
+    public java.util.List licenseTypes;
+
+    @Param(required = false)
+    public java.util.List systemTags;
+
+    @Param(required = false)
+    public java.util.List userTags;
+
+    @Param(required = false)
+    public String sessionId;
+
+    @Param(required = false)
+    public String accessKeyId;
+
+    @Param(required = false)
+    public String accessKeySecret;
+
+    @Param(required = false)
+    public String requestIp;
+
+
+    private Result makeResult(ApiResult res) {
+        Result ret = new Result();
+        if (res.error != null) {
+            ret.error = res.error;
+            return ret;
+        }
+        
+        org.zstack.sdk.license.api.usage.GetLicenseUsagesResult value = res.getResult(org.zstack.sdk.license.api.usage.GetLicenseUsagesResult.class);
+        ret.value = value == null ? new org.zstack.sdk.license.api.usage.GetLicenseUsagesResult() : value; 
+
+        return ret;
+    }
+
+    public Result call() {
+        ApiResult res = ZSClient.call(this);
+        return makeResult(res);
+    }
+
+    public void call(final Completion<Result> completion) {
+        ZSClient.call(this, new InternalCompletion() {
+            @Override
+            public void complete(ApiResult res) {
+                completion.complete(makeResult(res));
+            }
+        });
+    }
+
+    protected Map<String, Parameter> getParameterMap() {
+        return parameterMap;
+    }
+
+    protected Map<String, Parameter> getNonAPIParameterMap() {
+        return nonAPIParameterMap;
+    }
+
+    protected RestInfo getRestInfo() {
+        RestInfo info = new RestInfo();
+        info.httpMethod = "GET";
+        info.path = "/licenses/usages";
+        info.needSession = true;
+        info.needPoll = false;
+        info.parameterName = "";
+        return info;
+    }
+
+}

--- a/sdk/src/main/java/org/zstack/sdk/license/api/usage/GetLicenseUsagesResult.java
+++ b/sdk/src/main/java/org/zstack/sdk/license/api/usage/GetLicenseUsagesResult.java
@@ -1,0 +1,14 @@
+package org.zstack.sdk.license.api.usage;
+
+
+
+public class GetLicenseUsagesResult {
+    public java.util.List results;
+    public void setResults(java.util.List results) {
+        this.results = results;
+    }
+    public java.util.List getResults() {
+        return this.results;
+    }
+
+}

--- a/sdk/src/main/java/org/zstack/sdk/license/entity/LicenseUsageResult.java
+++ b/sdk/src/main/java/org/zstack/sdk/license/entity/LicenseUsageResult.java
@@ -1,0 +1,31 @@
+package org.zstack.sdk.license.entity;
+
+
+
+public class LicenseUsageResult  {
+
+    public java.lang.String module;
+    public void setModule(java.lang.String module) {
+        this.module = module;
+    }
+    public java.lang.String getModule() {
+        return this.module;
+    }
+
+    public java.lang.String primaryQuotaType;
+    public void setPrimaryQuotaType(java.lang.String primaryQuotaType) {
+        this.primaryQuotaType = primaryQuotaType;
+    }
+    public java.lang.String getPrimaryQuotaType() {
+        return this.primaryQuotaType;
+    }
+
+    public java.util.List usages;
+    public void setUsages(java.util.List usages) {
+        this.usages = usages;
+    }
+    public java.util.List getUsages() {
+        return this.usages;
+    }
+
+}

--- a/testlib/src/main/java/org/zstack/testlib/ApiHelper.groovy
+++ b/testlib/src/main/java/org/zstack/testlib/ApiHelper.groovy
@@ -37233,6 +37233,33 @@ abstract class ApiHelper {
     }
 
 
+    def getLicenseUsages(@DelegatesTo(strategy = Closure.OWNER_FIRST, value = org.zstack.sdk.license.api.usage.GetLicenseUsagesAction.class) Closure c) {
+        def a = new org.zstack.sdk.license.api.usage.GetLicenseUsagesAction()
+        a.sessionId = Test.currentEnvSpec?.session?.uuid
+        c.resolveStrategy = Closure.OWNER_FIRST
+        c.delegate = a
+        c()
+        
+
+        if (System.getProperty("apipath") != null) {
+            if (a.apiId == null) {
+                a.apiId = Platform.uuid
+            }
+    
+            def tracker = new ApiPathTracker(a.apiId)
+            def out = errorOut(a.call())
+            def path = tracker.getApiPath()
+            if (!path.isEmpty()) {
+                Test.apiPaths[a.class.name] = path.join(" --->\n")
+            }
+        
+            return out
+        } else {
+            return errorOut(a.call())
+        }
+    }
+
+
     def getManagementNodesStatus(@DelegatesTo(strategy = Closure.OWNER_FIRST, value = org.zstack.sdk.managements.common.GetManagementNodesStatusAction.class) Closure c) {
         def a = new org.zstack.sdk.managements.common.GetManagementNodesStatusAction()
         a.sessionId = Test.currentEnvSpec?.session?.uuid


### PR DESCRIPTION
Introduce APIGetLicenseUsagesMsg / APIGetLicenseUsagesReply
so callers can query platform and addon license usage
across CPUSocket, CPUCore, Host (and VM where applicable) in one request.

Resolves: ZSV-12284
Related: ZSV-12274

Change-Id: I786a656d6b656c76776f78746e617a646e707a6c

sync from gitlab !9926