### PR TITLE
fix[workflow]: propagate doneHandler exception to errorHandler in SimpleFlowChain

### DIFF
--- a/core/src/main/java/org/zstack/core/workflow/SimpleFlowChain.java
+++ b/core/src/main/java/org/zstack/core/workflow/SimpleFlowChain.java
@@ -760,6 +760,8 @@ public class SimpleFlowChain implements FlowTrigger, FlowRollback, FlowChain, Fl
                 if (errorHandler != null) {
                     errorHandler.handle(err, this.data);
                 }
+                callFinallyHandler();
+                return;
             }
         }
 

--- a/core/src/main/java/org/zstack/core/workflow/SimpleFlowChain.java
+++ b/core/src/main/java/org/zstack/core/workflow/SimpleFlowChain.java
@@ -756,7 +756,7 @@ public class SimpleFlowChain implements FlowTrigger, FlowRollback, FlowChain, Fl
                 doneHandler.handle(this.data);
             } catch (Throwable t) {
                 logger.warn(String.format("unhandled exception when calling %s", doneHandler.getClass()), t);
-                ErrorCode err = inerr(t.getMessage());
+                ErrorCode err = inerr(ORG_ZSTACK_CORE_WORKFLOW_10001, t.getMessage());
                 if (errorHandler != null) {
                     errorHandler.handle(err, this.data);
                 }

--- a/core/src/main/java/org/zstack/core/workflow/SimpleFlowChain.java
+++ b/core/src/main/java/org/zstack/core/workflow/SimpleFlowChain.java
@@ -757,10 +757,8 @@ public class SimpleFlowChain implements FlowTrigger, FlowRollback, FlowChain, Fl
             } catch (Throwable t) {
                 logger.warn(String.format("unhandled exception when calling %s", doneHandler.getClass()), t);
                 ErrorCode err = inerr(ORG_ZSTACK_CORE_WORKFLOW_10001, t.getMessage());
-                if (errorHandler != null) {
-                    errorHandler.handle(err, this.data);
-                }
-                callFinallyHandler();
+                setErrorCode(err);
+                callErrorHandler(false);
                 return;
             }
         }

--- a/core/src/main/java/org/zstack/core/workflow/SimpleFlowChain.java
+++ b/core/src/main/java/org/zstack/core/workflow/SimpleFlowChain.java
@@ -756,6 +756,10 @@ public class SimpleFlowChain implements FlowTrigger, FlowRollback, FlowChain, Fl
                 doneHandler.handle(this.data);
             } catch (Throwable t) {
                 logger.warn(String.format("unhandled exception when calling %s", doneHandler.getClass()), t);
+                ErrorCode err = inerr(t.getMessage());
+                if (errorHandler != null) {
+                    errorHandler.handle(err, this.data);
+                }
             }
         }
 


### PR DESCRIPTION
## Root Cause
SimpleFlowChain.callDoneHandler() caught Throwable in a try-catch but only logged a warning. The exception was silently swallowed, meaning complete.fail() was never called. This caused the FlowChain queue slot to be permanently occupied (ZSTAC-84185).

## Fix
- When doneHandler.handle() throws, wrap the exception in an ErrorCode
- Propagate to errorHandler.handle() so it can trigger the error handling chain
- Uses existing ORG_ZSTACK_CORE_WORKFLOW_10001 error code (consistent with other error paths in the same file)

## Risk
Low. Change is only in the exception catch block. Normal (non-exception) flow is unchanged.

Resolves: ZSTAC-84185

sync from gitlab !9943