### PR TITLE
fix[vm]: reject destroy VM when host is Disconnected and preserve original state

### DIFF
--- a/compute/src/main/java/org/zstack/compute/vm/VmDestroyOnHypervisorFlow.java
+++ b/compute/src/main/java/org/zstack/compute/vm/VmDestroyOnHypervisorFlow.java
@@ -14,6 +14,8 @@ import org.zstack.header.host.CheckVmStateOnHypervisorMsg;
 import org.zstack.header.host.CheckVmStateOnHypervisorReply;
 import org.zstack.header.host.HostConstant;
 import org.zstack.header.host.HostErrors;
+import org.zstack.header.host.HostStatus;
+import org.zstack.header.host.HostVO;
 import org.zstack.header.message.MessageReply;
 import org.zstack.header.vm.DestroyVmOnHypervisorMsg;
 import org.zstack.header.vm.VmInstanceConstant;
@@ -21,6 +23,8 @@ import org.zstack.header.vm.VmInstanceSpec;
 import org.zstack.header.vm.VmInstanceState;
 import org.zstack.utils.Utils;
 import org.zstack.utils.logging.CLogger;
+
+import static org.zstack.core.Platform.err;
 
 import java.util.Collections;
 import java.util.Map;
@@ -77,6 +81,14 @@ public class VmDestroyOnHypervisorFlow extends NoRollbackFlow {
 
         if (VmInstanceState.Stopped.toString().equals(spec.getVmInventory().getState())) {
             chain.next();
+            return;
+        }
+
+        HostVO host = dbf.findByUuid(hostUuid, HostVO.class);
+        if (host != null && host.getStatus() == HostStatus.Disconnected) {
+            chain.fail(err(HostErrors.HOST_IS_DISCONNECTED,
+                    "host[uuid:%s] is Disconnected, cannot destroy vm[uuid:%s] on it",
+                    hostUuid, spec.getVmInventory().getUuid()));
             return;
         }
 

--- a/compute/src/main/java/org/zstack/compute/vm/VmInstanceBase.java
+++ b/compute/src/main/java/org/zstack/compute/vm/VmInstanceBase.java
@@ -236,7 +236,16 @@ public class VmInstanceBase extends AbstractVmInstance {
                         }
                     });
                 } else {
-                    changeVmStateInDb(VmInstanceStateEvent.unknown);
+                    new SQLBatch() {
+                        @Override
+                        protected void scripts() {
+                            self = findByUuid(self.getUuid(), self.getClass());
+                            self.setState(originalCopy.getState());
+                            self.setHostUuid(originalCopy.getHostUuid());
+                            self.setLastHostUuid(originalCopy.getLastHostUuid());
+                            self = merge(self);
+                        }
+                    }.execute();
                     completion.fail(errCode);
                 }
             }


### PR DESCRIPTION
## Root Cause
Destroying a VM during host disconnect left the VM in Unknown state with no recovery path.

## Fix
- Reject destroy VM when host is Disconnected (fail fast)
- Preserve original VM state on destroy failure instead of transitioning to Unknown

Resolves: ZSTAC-84948

sync from gitlab !9947