### PR TITLE
<fix>[xinfini]: surface deactivate failures to prevent split-brain

### DIFF
--- a/plugin/xinfini/src/main/java/org/zstack/xinfini/XInfiniApiHelper.java
+++ b/plugin/xinfini/src/main/java/org/zstack/xinfini/XInfiniApiHelper.java
@@ -523,6 +523,14 @@ public class XInfiniApiHelper {
         } else {
             retryUtilResourceDeleted(gReq, GetBdcBdevResponse.class);
         }
+
+        // the polling above intentionally swallows timeout, so verify the bdev is really gone:
+        // a bdev that is still attached means the old client keeps holding the volume
+        if (!call(gReq, GetBdcBdevResponse.class).resourceIsDeleted()) {
+            throw new OperationFailureException(operr(ORG_ZSTACK_XINFINI_10004,
+                    "bdev[id:%s] still exists after deletion polling on bdc[id:%s], " +
+                            "the old storage client may still hold the volume", bdevId, bdcId));
+        }
     }
 
     public VolumeModule rollbackSnapshot(int volId, int snapId) {

--- a/plugin/xinfini/src/main/java/org/zstack/xinfini/XInfiniStorageController.java
+++ b/plugin/xinfini/src/main/java/org/zstack/xinfini/XInfiniStorageController.java
@@ -206,18 +206,25 @@ public class XInfiniStorageController implements PrimaryStorageControllerSvc, Pr
     public void deactivate(String installPath, String protocol, HostInventory h, Completion comp) {
         logger.debug(String.format("deactivating volume[path: %s, protocol:%s] on host[uuid:%s, ip:%s]",
                 installPath, protocol, h.getUuid(), h.getManagementIp()));
-        if (VolumeProtocol.Vhost.toString().equals(protocol)) {
-            deactivateVhost(installPath, h);
-            comp.success();
-            return;
-        } else if (VolumeProtocol.iSCSI.toString().equals(protocol)) {
-            // iscsi target is shared by all hosts, we cannot control one volume on one host for now.
-            deactivateIscsi(installPath, h);
-            comp.success();
+        // a deactivate failure must be reported through comp.fail() rather than swallowed,
+        // otherwise the caller cannot tell the old storage client is still holding the volume
+        try {
+            if (VolumeProtocol.Vhost.toString().equals(protocol)) {
+                deactivateVhost(installPath, h);
+            } else if (VolumeProtocol.iSCSI.toString().equals(protocol)) {
+                // iscsi target is shared by all hosts, we cannot control one volume on one host for now.
+                deactivateIscsi(installPath, h);
+            } else {
+                comp.fail(operr(ORG_ZSTACK_XINFINI_10013, "not supported protocol[%s] for deactivate", protocol));
+                return;
+            }
+        } catch (Exception e) {
+            comp.fail(operr("failed to deactivate volume[path:%s, protocol:%s] on host[uuid:%s, ip:%s]: %s",
+                    installPath, protocol, h.getUuid(), h.getManagementIp(), e.getMessage()));
             return;
         }
 
-        comp.fail(operr(ORG_ZSTACK_XINFINI_10013, "not supported protocol[%s] for deactivate", protocol));
+        comp.success();
     }
 
     private void deactivateIscsi(String installPath, HostInventory h) {
@@ -259,7 +266,8 @@ public class XInfiniStorageController implements PrimaryStorageControllerSvc, Pr
             return;
         }
 
-        retry(() -> apiHelper.deleteBdcBdev(bdev.getSpec().getId(), bdc.getSpec().getId()));
+        // use the rethrowing retry: a bdev that cannot be removed must surface as a failure
+        retryOrThrow(() -> apiHelper.deleteBdcBdev(bdev.getSpec().getId(), bdc.getSpec().getId()));
     }
 
     @Override
@@ -1098,18 +1106,35 @@ public class XInfiniStorageController implements PrimaryStorageControllerSvc, Pr
         retry(r, 3);
     }
 
-
     private void retry(Runnable r, int retry) {
-        while (retry-- > 0) {
+        // retry is the swallowing variant of retryOrThrow: give up silently after the last attempt
+        try {
+            retryOrThrow(r, retry);
+        } catch (RuntimeException ignored) {
+        }
+    }
+
+    private void retryOrThrow(Runnable r) {
+        retryOrThrow(r, 3);
+    }
+
+    private void retryOrThrow(Runnable r, int retry) {
+        RuntimeException lastError = null;
+        for (int i = 0; i < retry; i++) {
             try {
                 r.run();
                 return;
-            } catch (Exception e) {
+            } catch (RuntimeException e) {
+                lastError = e;
                 logger.warn("runnable failed, try ", e);
                 try {
                     TimeUnit.SECONDS.sleep(3);
                 } catch (InterruptedException ignore) {}
             }
+        }
+
+        if (lastError != null) {
+            throw lastError;
         }
     }
 }

--- a/test/src/test/groovy/org/zstack/test/integration/storage/primary/addon/xinfini/XinfiniPrimaryStorageCase.groovy
+++ b/test/src/test/groovy/org/zstack/test/integration/storage/primary/addon/xinfini/XinfiniPrimaryStorageCase.groovy
@@ -12,7 +12,12 @@ import org.zstack.xinfini.XInfiniApiHelper
 import org.zstack.xinfini.XInfiniPathHelper
 import org.zstack.xinfini.sdk.vhost.BdcModule
 import org.zstack.xinfini.sdk.vhost.BdcBdevModule
+import org.zstack.header.core.Completion
+import org.zstack.header.errorcode.ErrorCode
+import org.zstack.header.errorcode.OperationFailureException
 import org.zstack.header.host.HostConstant
+import org.zstack.header.host.HostVO
+import org.zstack.header.host.HostVO_
 import org.zstack.header.host.PingHostMsg
 import org.zstack.header.message.MessageReply
 import org.zstack.header.storage.backup.DownloadImageFromRemoteTargetMsg
@@ -44,6 +49,8 @@ import org.zstack.storage.backup.BackupStorageSystemTags
 import org.zstack.tag.SystemTagCreator
 import org.zstack.test.integration.storage.StorageTest
 import org.zstack.testlib.EnvSpec
+import org.zstack.testlib.ExternalPrimaryStorageSpec
+import org.zstack.testlib.HttpError
 import org.zstack.testlib.SubCase
 import org.zstack.utils.data.SizeUnit
 import org.zstack.utils.gson.JSONObjectUtil
@@ -181,6 +188,7 @@ class XinfiniPrimaryStorageCase extends SubCase {
             simulatorEnv()
             testCreateXinfiniStorage()
             testCreateVm()
+            testPreventSplitBrainOnDeactivateFailure()
             testHandleInactiveVolume()
             testCreateVolumeRollback()
             testAttachIso()
@@ -341,6 +349,86 @@ class XinfiniPrimaryStorageCase extends SubCase {
         } as VmInstanceInventory
 
         deleteVm(vm2.uuid)
+    }
+
+    // when the old host's storage client cannot be isolated, deactivate must report
+    // a failure instead of silently succeeding, otherwise the VM gets started on a
+    // new host while the old QEMU still holds the volume (split-brain).
+    void testPreventSplitBrainOnDeactivateFailure() {
+        def rootVolPath = Q.New(VolumeVO.class)
+                .eq(VolumeVO_.uuid, vm.rootVolumeUuid)
+                .select(VolumeVO_.installPath).findValue() as String
+        int volId = XInfiniPathHelper.getVolIdFromPath(rootVolPath)
+        BdcModule bdc = controller.apiHelper.queryBdcByIp(host1.managementIp)
+        BdcBdevModule bdev = controller.apiHelper.queryBdcBdevByVolumeIdAndBdcId(volId, bdc.spec.id)
+        assert bdev != null
+
+        // simMode: 0 = default, 1 = delete request fails, 2 = delete accepted but bdev never disappears
+        int[] simMode = [0]
+        boolean[] bdcInactive = [false]
+
+        env.simulator("/afa/v1/bdcs/\\d+") { HttpServletRequest req, HttpEntity<String> e, EnvSpec spec ->
+            return [
+                metadata: [id: 1, name: "bdc-1", state: [state: "active"]],
+                spec    : [id: 1, name: "bdc-1", ip: "127.0.0.1", port: 9500],
+                status  : [id: 1, run_state: bdcInactive[0] ? "Offline" : "Active",
+                           installed: true, hostname: "localhost", version: "1.0.0"]
+            ]
+        }
+
+        env.simulator("/afa/v1/bdc-bdevs/\\d+") { HttpServletRequest req, HttpEntity<String> e, EnvSpec spec ->
+            def matcher = (req.getRequestURI() =~ /\/(\d+)$/)
+            int bdevId = matcher.find() ? Integer.parseInt(matcher.group(1)) : -1
+            def store = ExternalPrimaryStorageSpec.XinfiniSimulators.bdcBdevs
+            if (req.getMethod() == "DELETE") {
+                if (simMode[0] == 1) {
+                    return [message: "delete bdev failed on purpose"]
+                }
+                if (simMode[0] != 2) {
+                    store.remove(bdevId)
+                }
+                return [:]
+            }
+
+            def stored = store.get(bdevId)
+            if (stored == null) {
+                throw new HttpError(404, "not found")
+            }
+            return [metadata: [id: stored.spec?.id, name: stored.spec?.name, state: [state: "active"]],
+                    spec: stored.spec, status: stored.status]
+        }
+
+        def hostVO = Q.New(HostVO.class).eq(HostVO_.uuid, host1.uuid).find()
+        def headerHost = org.zstack.header.host.HostInventory.valueOf(hostVO)
+
+        // scenario 1: the delete bdev request fails -> deactivate must report failure
+        simMode[0] = 1
+        boolean[] result = [false, false]   // [success, fail]
+        controller.deactivate(rootVolPath, "Vhost", headerHost, new Completion(null) {
+            @Override
+            void success() { result[0] = true }
+
+            @Override
+            void fail(ErrorCode errorCode) { result[1] = true }
+        })
+        assert result[1]: "deactivate must fail when the bdev cannot be deleted"
+        assert !result[0]: "deactivate must not report success when the bdev cannot be deleted"
+
+        // scenario 2: the delete request is accepted but the bdev stays attached ->
+        // deleteBdcBdev must error out instead of silently treating it as deleted
+        simMode[0] = 2
+        bdcInactive[0] = true
+        boolean errored = false
+        try {
+            controller.apiHelper.deleteBdcBdev(bdev.spec.id, bdc.spec.id)
+        } catch (OperationFailureException ignored) {
+            errored = true
+        }
+        assert errored: "deleteBdcBdev must error out when the bdev is still attached"
+
+        // restore default simulator behaviour for the rest of the suite
+        simMode[0] = 0
+        bdcInactive[0] = false
     }
 
     void testHandleInactiveVolume() {


### PR DESCRIPTION
## ZSTAC-85124

### Root Cause
When a VM is started on a new host, the old host's storage client must be isolated first. The xinfini `deactivate` path swallowed every failure in three places: the bdev delete polling timeout was ignored, the retry wrapper never rethrew, and `deactivate()` reported success unconditionally. As a result, the control plane wrongly believed the old client was gone — the blacklist fallback in `beforeStartVmOnKvm` was never reached, the VM was started on a new host while the old QEMU still held the volume, causing split-brain on the volume.

### Changes
| Module | Change |
|--------|--------|
| `plugin/xinfini` (`XInfiniStorageController`) | `deleteBdcBdev()` verifies the bdev is really gone after delete polling and errors out if it still exists; `deactivateVhost()` uses a rethrowing retry so an undeletable bdev surfaces as a failure; `deactivate()` reports failures through `comp.fail()` instead of swallowing them, so `beforeStartVmOnKvm` can fall back to blacklist and abort the VM start. |
| `plugin/xinfini` (`XInfiniApiHelper`) | Add a rethrowing retry helper. |
| `test` (`XinfiniPrimaryStorageCase`) | Cover the delete-failure and undeletable-bdev scenarios. |

### Test
- `XinfiniPrimaryStorageCase`: passed

Related: ZSTAC-85124

sync from gitlab !9967