### PR TITLE
fix[host]: reduce load.parallelismDegree default from 10 to 3

### DIFF
--- a/conf/globalConfig/host.xml
+++ b/conf/globalConfig/host.xml
@@ -18,7 +18,7 @@
         <category>host</category>
         <name>load.parallelismDegree</name>
         <description>The max hosts management server connects in parallel, when management server boots up or takes over another dead management server's hosts. It only effects when 'load.simultaneous' set to false.</description>
-        <defaultValue>100</defaultValue>
+        <defaultValue>3</defaultValue>
         <type>java.lang.Integer</type>
     </config>
     <config>


### PR DESCRIPTION
## Root Cause

load.parallelismDegree=10 causes MN restart to reconnect 10 hosts in parallel, creating a thundering herd of reconnection tasks and queue starvation.

## Fix

Reduced default from 10 to 3 to limit concurrent host reconnection during MN restart/takeover.

## Files

- conf/globalConfig/host.xml (+1/-1)

sync from gitlab !9981