### PR TITLE
fix[ceph]: clean up PrimaryStorageHostRefVO on Ceph PS detach

### DIFF
--- a/plugin/ceph/src/main/java/org/zstack/storage/ceph/primary/CephPrimaryStorageFactory.java
+++ b/plugin/ceph/src/main/java/org/zstack/storage/ceph/primary/CephPrimaryStorageFactory.java
@@ -1305,18 +1305,23 @@ public class CephPrimaryStorageFactory implements PrimaryStorageFactory, CephCap
             return;
         }
 
-        List<String> huuids = Q.New(HostVO.class).select(HostVO_.uuid)
-                .eq(HostVO_.clusterUuid, clusterUuid)
-                .listValues();
+        new SQLBatch() {
+            @Override
+            protected void scripts() {
+                List<String> huuids = Q.New(HostVO.class).select(HostVO_.uuid)
+                        .eq(HostVO_.clusterUuid, clusterUuid)
+                        .listValues();
+                if (huuids.isEmpty()) {
+                    return;
+                }
 
-        if (huuids == null || huuids.isEmpty()) {
-            return;
-        }
-
-        SQL.New(PrimaryStorageHostRefVO.class)
-                .eq(PrimaryStorageHostRefVO_.primaryStorageUuid, inventory.getUuid())
-                .in(PrimaryStorageHostRefVO_.hostUuid, huuids)
-                .hardDelete();
+                SQL.New(PrimaryStorageHostRefVO.class)
+                        .eq(PrimaryStorageHostRefVO_.primaryStorageUuid, inventory.getUuid())
+                        .in(PrimaryStorageHostRefVO_.hostUuid, huuids)
+                        .hardDelete();
+            }
+        }.execute();
+        logger.debug("succeed delete PrimaryStorageHostRef record");
     }
 
     private String getPoolName(String customPoolName, String defaultPoolName, long volumeSize, String poolType, String psUuid) {

--- a/plugin/ceph/src/main/java/org/zstack/storage/ceph/primary/CephPrimaryStorageFactory.java
+++ b/plugin/ceph/src/main/java/org/zstack/storage/ceph/primary/CephPrimaryStorageFactory.java
@@ -22,6 +22,7 @@ import org.zstack.core.cloudbus.EventFacade;
 import org.zstack.core.componentloader.PluginRegistry;
 import org.zstack.core.db.DatabaseFacade;
 import org.zstack.core.db.Q;
+import org.zstack.core.db.SQL;
 import org.zstack.core.db.SQLBatch;
 import org.zstack.core.db.SimpleQuery;
 import org.zstack.core.db.SimpleQuery.Op;
@@ -89,7 +90,8 @@ public class CephPrimaryStorageFactory implements PrimaryStorageFactory, CephCap
         KvmSetupSelfFencerExtensionPoint, KVMPreAttachIsoExtensionPoint, Component, PostMarkRootVolumeAsSnapshotExtension,
         BeforeTakeLiveSnapshotsOnVolumes, VmInstanceCreateExtensionPoint, CreateDataVolumeExtensionPoint,
         InstanceOfferingUserConfigValidator, DiskOfferingUserConfigValidator, MarkRootVolumeAsSnapshotExtension,
-        VmCapabilitiesExtensionPoint, PreVmInstantiateResourceExtensionPoint, PSCapacityExtensionPoint, RecalculatePrimaryStorageCapacityExtensionPoint {
+        VmCapabilitiesExtensionPoint, PreVmInstantiateResourceExtensionPoint, PSCapacityExtensionPoint, RecalculatePrimaryStorageCapacityExtensionPoint,
+        PrimaryStorageDetachExtensionPoint {
     private static final CLogger logger = Utils.getLogger(CephPrimaryStorageFactory.class);
 
     public static final PrimaryStorageType type = new PrimaryStorageType(CephConstants.CEPH_PRIMARY_STORAGE_TYPE);
@@ -1283,6 +1285,38 @@ public class CephPrimaryStorageFactory implements PrimaryStorageFactory, CephCap
     @Override
     public void beforeRecalculatePrimaryStorageCapacity(RecalculatePrimaryStorageCapacityStruct struct) {
 
+    }
+
+    @Override
+    public void preDetachPrimaryStorage(PrimaryStorageInventory inventory, String clusterUuid) throws PrimaryStorageException {
+    }
+
+    @Override
+    public void beforeDetachPrimaryStorage(PrimaryStorageInventory inventory, String clusterUuid) {
+    }
+
+    @Override
+    public void failToDetachPrimaryStorage(PrimaryStorageInventory inventory, String clusterUuid) {
+    }
+
+    @Override
+    public void afterDetachPrimaryStorage(PrimaryStorageInventory inventory, String clusterUuid) {
+        if (!inventory.getType().equals(CephConstants.CEPH_PRIMARY_STORAGE_TYPE)) {
+            return;
+        }
+
+        List<String> huuids = Q.New(HostVO.class).select(HostVO_.uuid)
+                .eq(HostVO_.clusterUuid, clusterUuid)
+                .listValues();
+
+        if (huuids == null || huuids.isEmpty()) {
+            return;
+        }
+
+        SQL.New(PrimaryStorageHostRefVO.class)
+                .eq(PrimaryStorageHostRefVO_.primaryStorageUuid, inventory.getUuid())
+                .in(PrimaryStorageHostRefVO_.hostUuid, huuids)
+                .hardDelete();
     }
 
     private String getPoolName(String customPoolName, String defaultPoolName, long volumeSize, String poolType, String psUuid) {

--- a/test/src/test/groovy/org/zstack/test/integration/storage/primary/ceph/CephDetachHostRefCleanupCase.groovy
+++ b/test/src/test/groovy/org/zstack/test/integration/storage/primary/ceph/CephDetachHostRefCleanupCase.groovy
@@ -1,0 +1,61 @@
+package org.zstack.test.integration.storage.primary.ceph
+
+import org.zstack.core.db.Q
+import org.zstack.header.storage.primary.PrimaryStorageHostRefVO
+import org.zstack.header.storage.primary.PrimaryStorageHostRefVO_
+import org.zstack.sdk.ClusterInventory
+import org.zstack.sdk.HostInventory
+import org.zstack.sdk.PrimaryStorageInventory
+import org.zstack.test.integration.storage.CephEnv
+import org.zstack.test.integration.storage.StorageTest
+import org.zstack.testlib.EnvSpec
+import org.zstack.testlib.SubCase
+
+class CephDetachHostRefCleanupCase extends SubCase {
+    EnvSpec env
+
+    @Override
+    void clean() {
+        env.delete()
+    }
+
+    @Override
+    void setup() {
+        useSpring(StorageTest.springSpec)
+    }
+
+    @Override
+    void environment() {
+        env = CephEnv.CephStorageOneVmEnv()
+    }
+
+    @Override
+    void test() {
+        env.create {
+            testDetachCleansUpHostRefVO()
+        }
+    }
+
+    void testDetachCleansUpHostRefVO() {
+        PrimaryStorageInventory ps = env.inventoryByName("ceph-pri")
+        ClusterInventory cluster = env.inventoryByName("cluster")
+        HostInventory kvm = env.inventoryByName("kvm")
+
+        long before = Q.New(PrimaryStorageHostRefVO.class)
+                .eq(PrimaryStorageHostRefVO_.primaryStorageUuid, ps.uuid)
+                .eq(PrimaryStorageHostRefVO_.hostUuid, kvm.uuid)
+                .count()
+        assert before == 1
+
+        detachPrimaryStorageFromCluster {
+            primaryStorageUuid = ps.uuid
+            clusterUuid = cluster.uuid
+        }
+
+        long after = Q.New(PrimaryStorageHostRefVO.class)
+                .eq(PrimaryStorageHostRefVO_.primaryStorageUuid, ps.uuid)
+                .eq(PrimaryStorageHostRefVO_.hostUuid, kvm.uuid)
+                .count()
+        assert after == 0
+    }
+}


### PR DESCRIPTION
## Root Cause Analysis

When Ceph primary storage is detached from a cluster, the `PrimaryStorageHostRefVO` records for hosts in that cluster are not cleaned up. These orphan records cause periodic MN probes to keep checking host-to-PS connections that no longer exist, occupying queue slots. NFS primary storage already correctly cleans up these records via `hardDelete()` in `afterDetachPrimaryStorage()`. SMP and LocalStorage were fixed in !9986 and !9987. Ceph was missed because `CephPrimaryStorageFactory` did not implement `PrimaryStorageDetachExtensionPoint`.

## Fix

1. Added `PrimaryStorageDetachExtensionPoint` interface to `CephPrimaryStorageFactory`
2. Implemented `afterDetachPrimaryStorage()` to clean up `PrimaryStorageHostRefVO` records for the detached cluster
3. Added null/empty guard for host UUIDs before hardDelete

## Files Changed
- plugin/ceph/src/main/java/org/zstack/storage/ceph/primary/CephPrimaryStorageFactory.java

sync from gitlab !9989