### PR TITLE
fix[kvm]: libvirtd restart guard with VM threshold on reconnect

### DIFF
--- a/plugin/kvm/src/main/java/org/zstack/kvm/KVMGlobalConfig.java
+++ b/plugin/kvm/src/main/java/org/zstack/kvm/KVMGlobalConfig.java
@@ -139,6 +139,11 @@ public class KVMGlobalConfig {
     @BindResourceConfig({HostVO.class, ClusterVO.class})
     public static GlobalConfig RECONNECT_HOST_RESTART_LIBVIRTD_SERVICE = new GlobalConfig(CATEGORY, "reconnect.host.restart.libvirtd.service");
 
+    @GlobalConfigValidation(numberGreaterThan = -1)
+    @GlobalConfigDef(defaultValue = "100", type = Integer.class, description = "restart libvirtd on reconnect only when running vm count is at or below this threshold; 0 means only hosts with no running VMs")
+    @BindResourceConfig({HostVO.class, ClusterVO.class})
+    public static GlobalConfig RECONNECT_HOST_RESTART_LIBVIRTD_RUNNING_VM_THRESHOLD = new GlobalConfig(CATEGORY, "reconnect.host.restart.libvirtd.running.vm.threshold");
+
     @GlobalConfigValidation(validValues = {"true", "false"})
     @GlobalConfigDef(defaultValue = "true", type = Boolean.class, description = "enable TLS encryption for libvirt remote connections (migration)")
     public static GlobalConfig LIBVIRT_TLS_ENABLED = new GlobalConfig(CATEGORY, "libvirt.tls.enabled");
@@ -152,5 +157,4 @@ public class KVMGlobalConfig {
     @GlobalConfigDef(defaultValue = "0G", description = "minimum free memory size to start vm, size in GB")
     @BindResourceConfig({HostVO.class, ClusterVO.class})
     public static GlobalConfig MINIMUM_MEMORY_SIZE_BEFORE_START_VM = new GlobalConfig(CATEGORY, "min.free.memory.size");
-
 }

--- a/plugin/kvm/src/main/java/org/zstack/kvm/KVMHost.java
+++ b/plugin/kvm/src/main/java/org/zstack/kvm/KVMHost.java
@@ -6065,7 +6065,8 @@ public class KVMHost extends HostBase implements Host {
                                     // update host agent version when open grayScaleUpgrade
                                     upgradeChecker.updateAgentVersion(self.getUuid(), AnsibleConstant.KVM_AGENT_NAME, dbf.getDbVersion(), dbf.getDbVersion());
                                 }
-                                if (Boolean.TRUE.equals(data.get("LIBVIRT_TLS_REDEPLOY_WILL_RUN"))) {
+                                if (Boolean.TRUE.equals(data.get("LIBVIRT_TLS_REDEPLOY_WILL_RUN"))
+                                        && Boolean.TRUE.equals(deployed)) {
                                     clearLibvirtTlsRedeployPending();
                                 }
                                 trigger.next();

--- a/plugin/kvm/src/main/java/org/zstack/kvm/KVMHost.java
+++ b/plugin/kvm/src/main/java/org/zstack/kvm/KVMHost.java
@@ -127,8 +127,13 @@ import static org.zstack.utils.clouderrorcode.CloudOperationsErrorCode.*;
 public class KVMHost extends HostBase implements Host {
     private static final CLogger logger = Utils.getLogger(KVMHost.class);
     private static final ZTester tester = Utils.getTester();
+    private static final String LIBVIRT_TLS_REDEPLOY_PENDING_LABEL = "kvm::libvirtTlsRedeployPending::%s";
     protected static OperationChecker allowedOperations = new OperationChecker(true);
     protected static OperationChecker skipOperations = new OperationChecker(true);
+
+    public static String libvirtTlsRedeployPendingLabel(String hostUuid) {
+        return String.format(LIBVIRT_TLS_REDEPLOY_PENDING_LABEL, hostUuid);
+    }
 
     public static Set<String> parseSanIps(String sanOutput) {
         Set<String> sanIps = new HashSet<>();
@@ -142,6 +147,28 @@ public class KVMHost extends HostBase implements Host {
             }
         }
         return sanIps;
+    }
+
+    // Pending-label lifecycle (self-healing, no leak):
+    //   SET   — check-tls-certs-if-needed detects needDeploy (line ~5803)
+    //   CLEAR — check-tls-certs-if-needed detects certs already valid (line ~5805),
+    //            OR ansible success callback after redeploy actually ran (line ~6003)
+    //   SELF-HEAL — every reconnect re-runs check-tls-certs-if-needed, which re-evaluates
+    //            and either re-marks or clears. If ansible fails or MN crashes mid-deploy,
+    //            the label stays (correct: certs not deployed) and the next reconnect fixes it.
+    //   Migration gate — isLibvirtTlsRedeployPending(src|dst) prevents useTls=true
+    //            when either host may have stale TLS certs.
+    private void markLibvirtTlsRedeployPending() {
+        String key = libvirtTlsRedeployPendingLabel(self.getUuid());
+        new JsonLabel().createIfAbsent(key, true, self.getUuid());
+    }
+
+    private void clearLibvirtTlsRedeployPending() {
+        new JsonLabel().delete(libvirtTlsRedeployPendingLabel(self.getUuid()));
+    }
+
+    private boolean isLibvirtTlsRedeployPending(String hostUuid) {
+        return new JsonLabel().exists(libvirtTlsRedeployPendingLabel(hostUuid));
     }
 
     @Autowired
@@ -487,6 +514,8 @@ public class KVMHost extends HostBase implements Host {
         Class<T> responseClass;
         String commandStr;
         String commandName;
+        TimeUnit timeoutUnit;
+        Long timeout;
 
         public Http(String path, String cmd, String commandName, Class<T> rspClz) {
             this.path = path;
@@ -500,6 +529,12 @@ public class KVMHost extends HostBase implements Host {
             this.cmd = cmd;
             this.responseClass = rspClz;
             this.commandName = cmd.getClass().getName();
+        }
+
+        Http<T> setTimeout(TimeUnit unit, long timeout) {
+            this.timeoutUnit = unit;
+            this.timeout = timeout;
+            return this;
         }
 
         void call(ReturnValueCompletion<T> completion) {
@@ -536,9 +571,9 @@ public class KVMHost extends HostBase implements Host {
                     public Class<T> getReturnClass() {
                         return responseClass;
                     }
-                }, TimeUnit.MILLISECONDS, timeoutManager.getTimeout());
+                }, timeout == null ? TimeUnit.MILLISECONDS : timeoutUnit, timeout == null ? timeoutManager.getTimeout() : timeout);
             } else {
-                restf.asyncJsonPost(path, cmd, header, new JsonAsyncRESTCallback<T>(completion) {
+                JsonAsyncRESTCallback<T> callback = new JsonAsyncRESTCallback<T>(completion) {
                     @Override
                     public void fail(ErrorCode err) {
                         completion.fail(err);
@@ -557,7 +592,12 @@ public class KVMHost extends HostBase implements Host {
                     public Class<T> getReturnClass() {
                         return responseClass;
                     }
-                }); // DO NOT pass unit, timeout here, they are null
+                };
+                if (timeout == null) {
+                    restf.asyncJsonPost(path, cmd, header, callback);
+                } else {
+                    restf.asyncJsonPost(path, cmd, header, callback, timeoutUnit, timeout);
+                }
             }
         }
 
@@ -3214,8 +3254,11 @@ public class KVMHost extends HostBase implements Host {
                         cmd.setDownTime(s.downTime);
                         cmd.setBandwidth(s.bandwidth);
                         cmd.setNics(nicTos);
-                        cmd.setUseTls(KVMGlobalConfig.LIBVIRT_TLS_ENABLED.value(Boolean.class)
-                                && rcf.getResourceConfigValue(KVMGlobalConfig.RECONNECT_HOST_RESTART_LIBVIRTD_SERVICE, self.getUuid(), Boolean.class));
+                        boolean srcAllowRestartLibvirtd = rcf.getResourceConfigValue(KVMGlobalConfig.RECONNECT_HOST_RESTART_LIBVIRTD_SERVICE, srcHostUuid, Boolean.class);
+                        boolean dstAllowRestartLibvirtd = rcf.getResourceConfigValue(KVMGlobalConfig.RECONNECT_HOST_RESTART_LIBVIRTD_SERVICE, dstHostUuid, Boolean.class);
+                        boolean tlsRedeployPending = isLibvirtTlsRedeployPending(srcHostUuid) || isLibvirtTlsRedeployPending(dstHostUuid);
+                        cmd.setUseTls(KVMHostUtils.shouldUseTlsForMigration(KVMGlobalConfig.LIBVIRT_TLS_ENABLED.value(Boolean.class),
+                                srcAllowRestartLibvirtd, dstAllowRestartLibvirtd, tlsRedeployPending));
 
                         if (s.diskMigrationMap != null) {
                             Map<String, VolumeTO> diskMigrationMap = new HashMap<>();
@@ -5821,6 +5864,9 @@ public class KVMHost extends HostBase implements Host {
 
                             if (needDeploy) {
                                 data.put("NEED_DEPLOY_TLS_CERT", true);
+                                markLibvirtTlsRedeployPending();
+                            } else {
+                                clearLibvirtTlsRedeployPending();
                             }
                         } catch (Exception e) {
                             logger.warn(String.format(
@@ -5961,7 +6007,19 @@ public class KVMHost extends HostBase implements Host {
                             deployArguments.setBridgeDisableIptables("true");
                         }
 
-                        deployArguments.setRestartLibvirtd(rcf.getResourceConfigValue(KVMGlobalConfig.RECONNECT_HOST_RESTART_LIBVIRTD_SERVICE, self.getUuid(), String.class));
+                        boolean allowRestartLibvirtd = rcf.getResourceConfigValue(KVMGlobalConfig.RECONNECT_HOST_RESTART_LIBVIRTD_SERVICE, self.getUuid(), Boolean.class);
+                        if (allowRestartLibvirtd && !info.isNewAdded()) {
+                            long activeVmCount = Q.New(VmInstanceVO.class)
+                                    .eq(VmInstanceVO_.hostUuid, self.getUuid())
+                                    .in(VmInstanceVO_.state, Arrays.asList(VmInstanceState.Running, VmInstanceState.Unknown))
+                                    .count();
+                            int threshold = rcf.getResourceConfigValue(KVMGlobalConfig.RECONNECT_HOST_RESTART_LIBVIRTD_RUNNING_VM_THRESHOLD, self.getUuid(), Integer.class);
+                            if (!KVMHostUtils.shouldRestartLibvirtdOnReconnect(allowRestartLibvirtd, false, activeVmCount, threshold)) {
+                                logger.warn(String.format("skip restarting libvirtd on host[uuid:%s] reconnect because active VM count[%s] exceeds threshold[%s]", self.getUuid(), activeVmCount, threshold));
+                                allowRestartLibvirtd = false;
+                            }
+                        }
+                        deployArguments.setRestartLibvirtd(String.valueOf(allowRestartLibvirtd));
                         deployArguments.setHostname(String.format("%s.zstack.org", self.getManagementIp().replaceAll("\\.", "-")));
                         deployArguments.setSkipPackages(info.getSkipPackages());
                         deployArguments.setUpdatePackages(String.valueOf(CoreGlobalProperty.UPDATE_PKG_WHEN_CONNECT));
@@ -5975,11 +6033,9 @@ public class KVMHost extends HostBase implements Host {
                         // ZSTAC-84446: force ansible re-run only when policy allows;
                         // see KVMHostUtils#shouldForceTlsRedeploy.
                         Boolean needDeployTlsCert = (Boolean) data.get("NEED_DEPLOY_TLS_CERT");
-                        boolean allowRestart = rcf.getResourceConfigValue(
-                                KVMGlobalConfig.RECONNECT_HOST_RESTART_LIBVIRTD_SERVICE,
-                                self.getUuid(), Boolean.class);
                         if (KVMHostUtils.shouldForceTlsRedeploy(
-                                Boolean.TRUE.equals(needDeployTlsCert), allowRestart, info.isNewAdded())) {
+                                Boolean.TRUE.equals(needDeployTlsCert), allowRestartLibvirtd, info.isNewAdded())) {
+                            data.put("LIBVIRT_TLS_REDEPLOY_WILL_RUN", true);
                             runner.setForceRun(true);
                             deployArguments.setRestartLibvirtd("true");
                         } else if (Boolean.TRUE.equals(needDeployTlsCert)) {
@@ -6008,6 +6064,9 @@ public class KVMHost extends HostBase implements Host {
                                             deployArguments.getInit(), deployArguments.getRestartLibvirtd());
                                     // update host agent version when open grayScaleUpgrade
                                     upgradeChecker.updateAgentVersion(self.getUuid(), AnsibleConstant.KVM_AGENT_NAME, dbf.getDbVersion(), dbf.getDbVersion());
+                                }
+                                if (Boolean.TRUE.equals(data.get("LIBVIRT_TLS_REDEPLOY_WILL_RUN"))) {
+                                    clearLibvirtTlsRedeployPending();
                                 }
                                 trigger.next();
                             }
@@ -6163,8 +6222,11 @@ public class KVMHost extends HostBase implements Host {
                             cmd.excludePackages = rcf.getResourceConfigValue(
                                     ClusterGlobalConfig.ZSTACK_EXPERIMENTAL_EXCLUDE_DEPENDENCY, self.getClusterUuid(), String.class);
                         }
-                        new Http<>(updateDependencyPath, cmd, UpdateDependencyRsp.class)
-                                .call(new ReturnValueCompletion<UpdateDependencyRsp>(trigger) {
+                        Http<UpdateDependencyRsp> http = new Http<>(updateDependencyPath, cmd, UpdateDependencyRsp.class);
+                        if (!info.isNewAdded()) {
+                            http.setTimeout(TimeUnit.MINUTES, 5);
+                        }
+                        http.call(new ReturnValueCompletion<UpdateDependencyRsp>(trigger) {
                                     @Override
                                     public void success(UpdateDependencyRsp ret) {
                                         if (ret.isSuccess()) {

--- a/plugin/kvm/src/main/java/org/zstack/kvm/KVMHostUtils.java
+++ b/plugin/kvm/src/main/java/org/zstack/kvm/KVMHostUtils.java
@@ -209,6 +209,23 @@ public class KVMHostUtils {
         }
     }
 
+    public static boolean shouldRestartLibvirtdOnReconnect(boolean allowRestartLibvirtd,
+                                                           boolean isNewAdded,
+                                                           long activeVmCount,
+                                                           int threshold) {
+        if (!allowRestartLibvirtd) {
+            return false;
+        }
+        return isNewAdded || activeVmCount <= threshold;
+    }
+
+    public static boolean shouldUseTlsForMigration(boolean libvirtTlsEnabled,
+                                                   boolean srcAllowRestartLibvirtd,
+                                                   boolean dstAllowRestartLibvirtd,
+                                                   boolean tlsRedeployPending) {
+        return libvirtTlsEnabled && srcAllowRestartLibvirtd && dstAllowRestartLibvirtd && !tlsRedeployPending;
+    }
+
     private static SshShell newSsh(String host, String user, String pwd, int port) {
         SshShell s = new SshShell();
         s.setHostname(host);

--- a/test/src/test/groovy/org/zstack/test/integration/kvm/host/ReconnectHostCase.groovy
+++ b/test/src/test/groovy/org/zstack/test/integration/kvm/host/ReconnectHostCase.groovy
@@ -3,14 +3,18 @@ package org.zstack.test.integration.kvm.host
 import org.springframework.http.HttpEntity
 import org.springframework.web.util.UriComponentsBuilder
 import org.zstack.core.Platform
+import org.zstack.core.ansible.RunAnsibleMsg
 import org.zstack.core.cloudbus.CloudBus
 import org.zstack.core.db.Q
 import org.zstack.core.db.SQL
 import org.zstack.header.host.*
+import org.zstack.header.message.AbstractBeforeDeliveryMessageInterceptor
+import org.zstack.header.message.Message
 import org.zstack.header.rest.RESTConstant
 import org.zstack.header.rest.RESTFacade
-import org.zstack.header.vm.VmInstanceState
+import org.zstack.header.vm.*
 import org.zstack.kvm.*
+import org.zstack.sdk.GetResourceConfigResult
 import org.zstack.sdk.HostInventory
 import org.zstack.sdk.VmInstanceInventory
 import org.zstack.test.integration.kvm.Env
@@ -46,6 +50,7 @@ class ReconnectHostCase extends SubCase {
         env.create {
             host = env.inventoryByName("kvm")
             restf = bean(RESTFacade.class)
+            testRestartLibvirtdOnReconnectWithRunningVmThreshold()
             testReconnectHostVmState()
             testReconnectFailureHostVmState()
             testUpdateHostDuringConnecting()
@@ -118,6 +123,85 @@ class ReconnectHostCase extends SubCase {
         }
 
         env.cleanMessageHandlers()
+    }
+
+    void testRestartLibvirtdOnReconnectWithRunningVmThreshold() {
+        List<String> restartLibvirtdValues = []
+        CloudBus bus = bean(CloudBus.class)
+        bus.installBeforeDeliveryMessageInterceptor(new AbstractBeforeDeliveryMessageInterceptor() {
+            @Override
+            void beforeDeliveryMessage(Message msg) {
+                RunAnsibleMsg runMsg = msg as RunAnsibleMsg
+                if (runMsg.deployArguments instanceof KVMHostDeployArguments) {
+                    restartLibvirtdValues.add((runMsg.deployArguments as KVMHostDeployArguments).restartLibvirtd)
+                }
+            }
+        }, RunAnsibleMsg.class)
+
+        long activeVmCount = Q.New(VmInstanceVO.class)
+                .eq(VmInstanceVO_.hostUuid, host.uuid)
+                .in(VmInstanceVO_.state, [VmInstanceState.Running, VmInstanceState.Unknown])
+                .count()
+        assert activeVmCount > 0
+
+        String restartConfigName = KVMGlobalConfig.RECONNECT_HOST_RESTART_LIBVIRTD_SERVICE.name
+        String thresholdConfigName = KVMGlobalConfig.RECONNECT_HOST_RESTART_LIBVIRTD_RUNNING_VM_THRESHOLD.name
+        String originalRestartLibvirtd = (getResourceConfig {
+            category = KVMGlobalConfig.CATEGORY
+            name = restartConfigName
+            resourceUuid = host.uuid
+        } as GetResourceConfigResult).value
+        String originalThreshold = (getResourceConfig {
+            category = KVMGlobalConfig.CATEGORY
+            name = thresholdConfigName
+            resourceUuid = host.uuid
+        } as GetResourceConfigResult).value
+
+        updateResourceConfig {
+            category = KVMGlobalConfig.CATEGORY
+            name = restartConfigName
+            value = "true"
+            resourceUuid = host.uuid
+        }
+
+        try {
+            updateResourceConfig {
+                category = KVMGlobalConfig.CATEGORY
+                name = thresholdConfigName
+                value = activeVmCount.toString()
+                resourceUuid = host.uuid
+            }
+            reconnectHost {
+                uuid = host.uuid
+            }
+            assert restartLibvirtdValues[-1] == "true"
+
+            int recorded = restartLibvirtdValues.size()
+            updateResourceConfig {
+                category = KVMGlobalConfig.CATEGORY
+                name = thresholdConfigName
+                value = (activeVmCount - 1).toString()
+                resourceUuid = host.uuid
+            }
+            reconnectHost {
+                uuid = host.uuid
+            }
+            assert restartLibvirtdValues.size() > recorded
+            assert restartLibvirtdValues[-1] == "false"
+        } finally {
+            updateResourceConfig {
+                category = KVMGlobalConfig.CATEGORY
+                name = thresholdConfigName
+                value = originalThreshold
+                resourceUuid = host.uuid
+            }
+            updateResourceConfig {
+                category = KVMGlobalConfig.CATEGORY
+                name = restartConfigName
+                value = originalRestartLibvirtd
+                resourceUuid = host.uuid
+            }
+        }
     }
 
     void testUpdateHostDuringConnecting() {

--- a/test/src/test/groovy/org/zstack/test/integration/kvm/host/ReconnectHostCase.groovy
+++ b/test/src/test/groovy/org/zstack/test/integration/kvm/host/ReconnectHostCase.groovy
@@ -201,6 +201,7 @@ class ReconnectHostCase extends SubCase {
                 value = originalRestartLibvirtd
                 resourceUuid = host.uuid
             }
+            env.cleanMessageHandlers()
         }
     }
 

--- a/test/src/test/groovy/org/zstack/test/integration/kvm/vm/migrate/LibvirtTlsMigrateCase.groovy
+++ b/test/src/test/groovy/org/zstack/test/integration/kvm/vm/migrate/LibvirtTlsMigrateCase.groovy
@@ -1,6 +1,7 @@
 package org.zstack.test.integration.kvm.vm.migrate
 
 import org.springframework.http.HttpEntity
+import org.zstack.core.jsonlabel.JsonLabel
 import org.zstack.kvm.KVMAgentCommands
 import org.zstack.kvm.KVMConstant
 import org.zstack.kvm.KVMGlobalConfig
@@ -24,7 +25,7 @@ import org.zstack.utils.gson.JSONObjectUtil
  * migration TLS flag propagation is tested here.
  *
  * Key logic under test (KVMHost.java):
- *   cmd.setUseTls(LIBVIRT_TLS_ENABLED && RECONNECT_HOST_RESTART_LIBVIRTD_SERVICE)
+ *   cmd.setUseTls(LIBVIRT_TLS_ENABLED && restart-libvirtd enabled && no pending TLS redeploy)
  *   cmd.setSrcHostManagementIp(srcHostMnIp)
  */
 class LibvirtTlsMigrateCase extends SubCase {
@@ -135,6 +136,8 @@ class LibvirtTlsMigrateCase extends SubCase {
             testMigrateWithTlsEnabled()
             testMigrateWithTlsDisabled()
             testMigrateWithRestartLibvirtdDisabled()
+            testMigrateTlsFollowsPendingRedeployState()
+            testMigrateTlsRequiresBothHostsRestartEnabled()
             testGlobalConfigValidation()
         }
     }
@@ -235,8 +238,80 @@ class LibvirtTlsMigrateCase extends SubCase {
         KVMGlobalConfig.RECONNECT_HOST_RESTART_LIBVIRTD_SERVICE.updateValue("true")
     }
 
+    void testMigrateTlsFollowsPendingRedeployState() {
+        def vm = env.inventoryByName("vm") as VmInstanceInventory
+        def host1 = env.inventoryByName("kvm1") as HostInventory
+        def host2 = env.inventoryByName("kvm2") as HostInventory
+        String host2LabelKey = KVMHost.libvirtTlsRedeployPendingLabel(host2.uuid)
+
+        KVMGlobalConfig.LIBVIRT_TLS_ENABLED.updateValue("true")
+        KVMGlobalConfig.RECONNECT_HOST_RESTART_LIBVIRTD_SERVICE.updateValue("true")
+        new JsonLabel().createIfAbsent(host2LabelKey, true, host2.uuid)
+
+        try {
+            KVMAgentCommands.MigrateVmCmd cmd = null
+            env.afterSimulator(KVMConstant.KVM_MIGRATE_VM_PATH) { rsp, HttpEntity<String> e ->
+                cmd = JSONObjectUtil.toObject(e.body, KVMAgentCommands.MigrateVmCmd.class)
+                return rsp
+            }
+
+            migrateVm {
+                vmInstanceUuid = vm.uuid
+                hostUuid = host1.uuid
+            }
+            assert cmd != null : "MigrateVmCmd should have been captured"
+            assert !cmd.useTls : "useTls should be false when TLS redeploy is pending on source host"
+
+            cmd = null
+            migrateVm {
+                vmInstanceUuid = vm.uuid
+                hostUuid = host2.uuid
+            }
+            assert cmd != null : "MigrateVmCmd should have been captured"
+            assert !cmd.useTls : "useTls should be false when TLS redeploy is pending on destination host"
+        } finally {
+            new JsonLabel().delete(host2LabelKey)
+        }
+    }
+
+    void testMigrateTlsRequiresBothHostsRestartEnabled() {
+        def vm = env.inventoryByName("vm") as VmInstanceInventory
+        def host1 = env.inventoryByName("kvm1") as HostInventory
+
+        KVMGlobalConfig.LIBVIRT_TLS_ENABLED.updateValue("true")
+        KVMGlobalConfig.RECONNECT_HOST_RESTART_LIBVIRTD_SERVICE.updateValue("true")
+        updateResourceConfig {
+            category = KVMGlobalConfig.CATEGORY
+            name = KVMGlobalConfig.RECONNECT_HOST_RESTART_LIBVIRTD_SERVICE.name
+            value = "false"
+            resourceUuid = host1.uuid
+        }
+
+        try {
+            KVMAgentCommands.MigrateVmCmd cmd = null
+            env.afterSimulator(KVMConstant.KVM_MIGRATE_VM_PATH) { rsp, HttpEntity<String> e ->
+                cmd = JSONObjectUtil.toObject(e.body, KVMAgentCommands.MigrateVmCmd.class)
+                return rsp
+            }
+
+            migrateVm {
+                vmInstanceUuid = vm.uuid
+                hostUuid = host1.uuid
+            }
+            assert cmd != null : "MigrateVmCmd should have been captured"
+            assert !cmd.useTls : "useTls should be false when restartLibvirtd is disabled on destination host"
+        } finally {
+            updateResourceConfig {
+                category = KVMGlobalConfig.CATEGORY
+                name = KVMGlobalConfig.RECONNECT_HOST_RESTART_LIBVIRTD_SERVICE.name
+                value = "true"
+                resourceUuid = host1.uuid
+            }
+        }
+    }
+
     /**
-     * Case 4: Validate that libvirt.tls.enabled GlobalConfig only accepts true/false
+     * Case 6: Validate that libvirt.tls.enabled GlobalConfig only accepts true/false
      */
     void testGlobalConfigValidation() {
         // Valid values via SDK action

--- a/test/src/test/java/org/zstack/test/kvm/KVMHostUtilsTest.java
+++ b/test/src/test/java/org/zstack/test/kvm/KVMHostUtilsTest.java
@@ -187,6 +187,34 @@ public class KVMHostUtilsTest {
     }
 
     @Test
+    public void shouldRestartLibvirtdOnReconnect_skipsWhenRunningVmExceedsThreshold() {
+        Assert.assertFalse(KVMHostUtils.shouldRestartLibvirtdOnReconnect(true, false, 101, 100));
+        Assert.assertFalse(KVMHostUtils.shouldRestartLibvirtdOnReconnect(true, false, 1, 0));
+    }
+
+    @Test
+    public void shouldRestartLibvirtdOnReconnect_allowsNewHostAndBelowThreshold() {
+        Assert.assertTrue(KVMHostUtils.shouldRestartLibvirtdOnReconnect(true, true, 101, 100));
+        Assert.assertTrue(KVMHostUtils.shouldRestartLibvirtdOnReconnect(true, false, 100, 100));
+        Assert.assertTrue(KVMHostUtils.shouldRestartLibvirtdOnReconnect(true, false, 0, 0));
+    }
+
+    @Test
+    public void shouldForceTlsRedeploy_afterReconnectRestartGuardSkips() {
+        boolean allowRestart = KVMHostUtils.shouldRestartLibvirtdOnReconnect(true, false, 101, 100);
+        Assert.assertFalse(KVMHostUtils.shouldForceTlsRedeploy(true, allowRestart, false));
+    }
+
+    @Test
+    public void shouldUseTlsForMigration_followsTlsRedeployState() {
+        Assert.assertFalse(KVMHostUtils.shouldUseTlsForMigration(false, true, true, false));
+        Assert.assertFalse(KVMHostUtils.shouldUseTlsForMigration(true, false, true, false));
+        Assert.assertFalse(KVMHostUtils.shouldUseTlsForMigration(true, true, false, false));
+        Assert.assertFalse(KVMHostUtils.shouldUseTlsForMigration(true, true, true, true));
+        Assert.assertTrue(KVMHostUtils.shouldUseTlsForMigration(true, true, true, false));
+    }
+
+    @Test
     public void shouldForceTlsRedeploy_reconnectWithoutRestartSkips() {
         Assert.assertFalse(KVMHostUtils.shouldForceTlsRedeploy(true, false, false));
     }


### PR DESCRIPTION
## Root Cause
During host reconnect, libvirtd was force-restarted regardless of running VMs on the host. This occurred because forceRun had no VM threshold guard - every reconnect would restart libvirtd, disrupting all running VMs.

## Fix
- New GlobalConfig: reconnect.host.restart.libvirtd.running.vm.threshold (default: 100)
- Before restarting libvirtd, query count of Running/Unknown VMs on the host
- If count exceeds threshold, skip libvirtd restart
- TLS redeploy pending tracker: JsonLabel-based lifecycle with migration gate
- 5-minute timeout on update-dependency HTTP call
- New hosts always get libvirtd restart

## Risk
Low. New hosts bypass the guard. TLS pending label self-heals on next reconnect. Migration gate only disables TLS (not migration itself). Default threshold of 100 means backwards compatibility.

Resolves: ZSTAC-84691

sync from gitlab !9942