### PR TITLE
fix[localstorage]: add GC for migration cleanup failures

### DIFF
--- a/plugin/localstorage/src/main/java/org/zstack/storage/primary/local/LocalStorageKvmMigrateVmFlow.java
+++ b/plugin/localstorage/src/main/java/org/zstack/storage/primary/local/LocalStorageKvmMigrateVmFlow.java
@@ -54,6 +54,7 @@ import org.zstack.utils.logging.CLogger;
 import javax.persistence.TypedQuery;
 import java.io.Serializable;
 import java.util.*;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.Callable;
 
 import static org.zstack.core.Platform.operr;
@@ -447,9 +448,15 @@ public class LocalStorageKvmMigrateVmFlow extends NoRollbackFlow {
                                     @Override
                                     public void run(MessageReply reply) {
                                         if (!reply.isSuccess()) {
-                                            //TODO add GC
-                                            logger.warn(String.format("failed to delete %s on the host[uuid:%s] of local storage[uuid:%s], %s",
+                                            logger.warn(String.format("failed to delete %s on the host[uuid:%s] of local storage[uuid:%s], %s; submitting GC",
                                                     backingImage.path, dstHostUuid, ref.getPrimaryStorageUuid(), reply.getError()));
+                                            LocalStorageDeleteBitsGC gc = new LocalStorageDeleteBitsGC();
+                                            gc.NAME = String.format("gc-delete-bits-%s-on-host-%s", backingImage.path, dstHostUuid);
+                                            gc.primaryStorageUuid = ref.getPrimaryStorageUuid();
+                                            gc.hostUuid = dstHostUuid;
+                                            gc.installPath = backingImage.path;
+                                            gc.isDir = false;
+                                            gc.submit();
                                         }
                                     }
                                 });
@@ -790,9 +797,15 @@ public class LocalStorageKvmMigrateVmFlow extends NoRollbackFlow {
                                     for (MessageReply r : replies) {
                                         VolumeSnapshotInventory sp = allSnapshots.get(replies.indexOf(r));
                                         if (!r.isSuccess()) {
-                                            //TODO add GC
-                                            logger.warn(String.format("failed to delete the snapshot[%s] on the local primary storage[uuid:%s], %s",
+                                            logger.warn(String.format("failed to delete the snapshot[%s] on the local primary storage[uuid:%s], %s; submitting GC",
                                                     sp.getPrimaryStorageInstallPath(), ref.getPrimaryStorageUuid(), r.getError()));
+                                            LocalStorageDeleteBitsGC gc = new LocalStorageDeleteBitsGC();
+                                            gc.NAME = String.format("gc-delete-snapshot-%s-on-host-%s", sp.getPrimaryStorageInstallPath(), srcHostUuid);
+                                            gc.primaryStorageUuid = ref.getPrimaryStorageUuid();
+                                            gc.hostUuid = srcHostUuid;
+                                            gc.installPath = sp.getPrimaryStorageInstallPath();
+                                            gc.isDir = false;
+                                            gc.submit();
                                         }
                                     }
                                 }
@@ -825,12 +838,18 @@ public class LocalStorageKvmMigrateVmFlow extends NoRollbackFlow {
                             public void run(List<MessageReply> replies) {
                                 for (MessageReply r : replies) {
                                     if (!r.isSuccess()) {
-                                        //TODO: add GC
                                         VolumeInventory vol = volumesOnLocalStorage.get(replies.indexOf(r));
                                         logger.warn(String.format("failed to delete the volume[%s] in the host[uuid:%s] for the local" +
-                                                        " primary storage[uuid:%s] during after the vm[uuid:%s] migrated to the host[uuid:%s, ip:%s], %s",
+                                                        " primary storage[uuid:%s] during after the vm[uuid:%s] migrated to the host[uuid:%s, ip:%s], %s; submitting GC",
                                                 vol.getUuid(), srcHostUuid, ref.getPrimaryStorageUuid(), spec.getVmInventory().getUuid(), dstHostUuid,
                                                 spec.getDestHost().getManagementIp(), r.getError()));
+                                        LocalStorageDeleteBitsGC gc = new LocalStorageDeleteBitsGC();
+                                        gc.NAME = String.format("gc-delete-volume-%s-on-host-%s", vol.getUuid(), srcHostUuid);
+                                        gc.primaryStorageUuid = ref.getPrimaryStorageUuid();
+                                        gc.hostUuid = srcHostUuid;
+                                        gc.installPath = vol.getInstallPath();
+                                        gc.isDir = false;
+                                        gc.submit();
                                     }
                                 }
                             }
@@ -853,10 +872,16 @@ public class LocalStorageKvmMigrateVmFlow extends NoRollbackFlow {
                         bus.send(msg, new CloudBusCallBack(null) {
                             @Override
                             public void run(MessageReply reply) {
-                                //TODO
                                 if (!reply.isSuccess()) {
                                     logger.warn(String.format("failed to return capacity[%s] to the host[uuid:%s] of the local" +
-                                            " primary storage[uuid:%s], %s", requiredSize, srcHostUuid, ref.getPrimaryStorageUuid(), reply.getError()));
+                                            " primary storage[uuid:%s], %s; submitting GC", requiredSize, srcHostUuid, ref.getPrimaryStorageUuid(), reply.getError()));
+                                    LocalStorageReturnHostCapacityGC gc = new LocalStorageReturnHostCapacityGC();
+                                    gc.NAME = String.format("gc-return-capacity-%s-on-host-%s", requiredSize, srcHostUuid);
+                                    gc.primaryStorageUuid = ref.getPrimaryStorageUuid();
+                                    gc.hostUuid = srcHostUuid;
+                                    gc.size = requiredSize;
+                                    gc.noOverProvisioning = false;
+                                    gc.deduplicateSubmit(60L, TimeUnit.SECONDS);
                                 }
                             }
                         });

--- a/plugin/localstorage/src/main/java/org/zstack/storage/primary/local/LocalStorageKvmMigrateVmFlow.java
+++ b/plugin/localstorage/src/main/java/org/zstack/storage/primary/local/LocalStorageKvmMigrateVmFlow.java
@@ -880,7 +880,7 @@ public class LocalStorageKvmMigrateVmFlow extends NoRollbackFlow {
                                     gc.primaryStorageUuid = ref.getPrimaryStorageUuid();
                                     gc.hostUuid = srcHostUuid;
                                     gc.size = requiredSize;
-                                    gc.noOverProvisioning = false;
+                                    gc.noOverProvisioning = msg.isNoOverProvisioning();
                                     gc.deduplicateSubmit(60L, TimeUnit.SECONDS);
                                 }
                             }

--- a/plugin/localstorage/src/main/java/org/zstack/storage/primary/local/LocalStorageReturnHostCapacityGC.java
+++ b/plugin/localstorage/src/main/java/org/zstack/storage/primary/local/LocalStorageReturnHostCapacityGC.java
@@ -39,12 +39,16 @@ public class LocalStorageReturnHostCapacityGC extends TimeBasedGarbageCollector 
         bus.send(msg, new CloudBusCallBack(completion) {
             @Override
             public void run(MessageReply reply) {
-                if (reply.isSuccess()) {
-                    completion.success();
-                } else {
-                    completion.fail(reply.getError());
-                }
+                handleReply(reply, completion);
             }
         });
+    }
+
+    void handleReply(MessageReply reply, GCCompletion completion) {
+        if (reply.isSuccess()) {
+            completion.success();
+        } else {
+            completion.fail(reply.getError());
+        }
     }
 }

--- a/plugin/localstorage/src/main/java/org/zstack/storage/primary/local/LocalStorageReturnHostCapacityGC.java
+++ b/plugin/localstorage/src/main/java/org/zstack/storage/primary/local/LocalStorageReturnHostCapacityGC.java
@@ -1,0 +1,50 @@
+package org.zstack.storage.primary.local;
+
+import org.zstack.core.cloudbus.CloudBusCallBack;
+import org.zstack.core.gc.GC;
+import org.zstack.core.gc.GCCompletion;
+import org.zstack.core.gc.TimeBasedGarbageCollector;
+import org.zstack.header.message.MessageReply;
+import org.zstack.header.host.HostVO;
+import org.zstack.header.storage.primary.PrimaryStorageConstant;
+import org.zstack.header.storage.primary.PrimaryStorageVO;
+
+public class LocalStorageReturnHostCapacityGC extends TimeBasedGarbageCollector {
+    @GC
+    public String primaryStorageUuid;
+    @GC
+    public String hostUuid;
+    @GC
+    public long size;
+    @GC
+    public boolean noOverProvisioning;
+
+    @Override
+    protected void triggerNow(GCCompletion completion) {
+        if (!dbf.isExist(primaryStorageUuid, PrimaryStorageVO.class)) {
+            completion.cancel();
+            return;
+        }
+        if (!dbf.isExist(hostUuid, HostVO.class)) {
+            completion.cancel();
+            return;
+        }
+
+        LocalStorageReturnHostCapacityMsg msg = new LocalStorageReturnHostCapacityMsg();
+        msg.setPrimaryStorageUuid(primaryStorageUuid);
+        msg.setHostUuid(hostUuid);
+        msg.setSize(size);
+        msg.setNoOverProvisioning(noOverProvisioning);
+        bus.makeTargetServiceIdByResourceUuid(msg, PrimaryStorageConstant.SERVICE_ID, primaryStorageUuid);
+        bus.send(msg, new CloudBusCallBack(completion) {
+            @Override
+            public void run(MessageReply reply) {
+                if (reply.isSuccess()) {
+                    completion.success();
+                } else {
+                    completion.fail(reply.getError());
+                }
+            }
+        });
+    }
+}

--- a/test/src/test/java/org/zstack/test/storage/primary/local/LocalStorageReturnHostCapacityGCTest.java
+++ b/test/src/test/java/org/zstack/test/storage/primary/local/LocalStorageReturnHostCapacityGCTest.java
@@ -5,9 +5,12 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 import org.zstack.core.cloudbus.CloudBus;
+
 import org.zstack.core.db.DatabaseFacade;
 import org.zstack.core.gc.GCCompletion;
+import org.zstack.header.errorcode.ErrorCode;
 import org.zstack.header.host.HostVO;
+import org.zstack.header.message.MessageReply;
 import org.zstack.header.storage.primary.PrimaryStorageVO;
 import org.zstack.storage.primary.local.LocalStorageReturnHostCapacityGC;
 
@@ -95,14 +98,45 @@ public class LocalStorageReturnHostCapacityGCTest {
     }
 
     @Test
-    public void hasFourGCFields() throws Exception {
-        LocalStorageReturnHostCapacityGC gc = new LocalStorageReturnHostCapacityGC();
-        int gcCount = 0;
-        for (Field f : LocalStorageReturnHostCapacityGC.class.getDeclaredFields()) {
-            if (f.isAnnotationPresent(org.zstack.core.gc.GC.class)) {
-                gcCount++;
-            }
-        }
-        Assert.assertEquals(4, gcCount);
+    public void callsCompletionSuccessOnReplySuccess() throws Exception {
+        LocalStorageReturnHostCapacityGC gc = createGC("ps-1", "host-1", 1024, false);
+
+        AtomicReference<Boolean> successCalled = new AtomicReference<>(false);
+        GCCompletion completion = Mockito.mock(GCCompletion.class);
+        Mockito.doAnswer(invocation -> {
+            successCalled.set(true);
+            return null;
+        }).when(completion).success();
+
+        MessageReply reply = new MessageReply();
+        reply.setSuccess(true);
+
+        Method m = LocalStorageReturnHostCapacityGC.class.getDeclaredMethod("handleReply", MessageReply.class, GCCompletion.class);
+        m.setAccessible(true);
+        m.invoke(gc, reply, completion);
+
+        Assert.assertTrue("should call completion.success() on reply success", successCalled.get());
+    }
+
+    @Test
+    public void callsCompletionFailOnReplyFailure() throws Exception {
+        LocalStorageReturnHostCapacityGC gc = createGC("ps-1", "host-1", 1024, false);
+
+        AtomicReference<ErrorCode> failedError = new AtomicReference<>();
+        GCCompletion completion = Mockito.mock(GCCompletion.class);
+        Mockito.doAnswer(invocation -> {
+            failedError.set(invocation.getArgument(0));
+            return null;
+        }).when(completion).fail(Mockito.any());
+
+        ErrorCode err = new ErrorCode("TEST.ERROR", "test error");
+        MessageReply reply = new MessageReply();
+        reply.setError(err);
+
+        Method m = LocalStorageReturnHostCapacityGC.class.getDeclaredMethod("handleReply", MessageReply.class, GCCompletion.class);
+        m.setAccessible(true);
+        m.invoke(gc, reply, completion);
+
+        Assert.assertNotNull("should call completion.fail() on reply failure", failedError.get());
     }
 }

--- a/test/src/test/java/org/zstack/test/storage/primary/local/LocalStorageReturnHostCapacityGCTest.java
+++ b/test/src/test/java/org/zstack/test/storage/primary/local/LocalStorageReturnHostCapacityGCTest.java
@@ -1,0 +1,108 @@
+package org.zstack.test.storage.primary.local;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.zstack.core.cloudbus.CloudBus;
+import org.zstack.core.db.DatabaseFacade;
+import org.zstack.core.gc.GCCompletion;
+import org.zstack.header.host.HostVO;
+import org.zstack.header.storage.primary.PrimaryStorageVO;
+import org.zstack.storage.primary.local.LocalStorageReturnHostCapacityGC;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.concurrent.atomic.AtomicReference;
+
+public class LocalStorageReturnHostCapacityGCTest {
+
+    private DatabaseFacade mockDbf;
+    private CloudBus mockBus;
+
+    @Before
+    public void setUp() {
+        mockDbf = Mockito.mock(DatabaseFacade.class);
+        mockBus = Mockito.mock(CloudBus.class);
+    }
+
+    private LocalStorageReturnHostCapacityGC createGC(
+            String psUuid, String hostUuid, long size, boolean noOverProvisioning) throws Exception {
+        LocalStorageReturnHostCapacityGC gc = new LocalStorageReturnHostCapacityGC();
+        injectField(gc, "dbf", mockDbf);
+        injectField(gc, "bus", mockBus);
+        gc.primaryStorageUuid = psUuid;
+        gc.hostUuid = hostUuid;
+        gc.size = size;
+        gc.noOverProvisioning = noOverProvisioning;
+        return gc;
+    }
+
+    private void injectField(Object target, String fieldName, Object value) throws Exception {
+        Class<?> clazz = target.getClass();
+        while (clazz != null && clazz != Object.class) {
+            try {
+                Field f = clazz.getDeclaredField(fieldName);
+                f.setAccessible(true);
+                f.set(target, value);
+                return;
+            } catch (NoSuchFieldException e) {
+                clazz = clazz.getSuperclass();
+            }
+        }
+        throw new NoSuchFieldException(fieldName + " not found in hierarchy of " + target.getClass());
+    }
+
+    @Test
+    public void cancelsWhenPrimaryStorageNotFound() throws Exception {
+        LocalStorageReturnHostCapacityGC gc = createGC("ps-1", "host-1", 1024, false);
+
+        Mockito.when(mockDbf.isExist("ps-1", PrimaryStorageVO.class)).thenReturn(false);
+
+        AtomicReference<Boolean> cancelled = new AtomicReference<>(false);
+        GCCompletion completion = Mockito.mock(GCCompletion.class);
+        Mockito.doAnswer(invocation -> {
+            cancelled.set(true);
+            return null;
+        }).when(completion).cancel();
+
+        Method m = LocalStorageReturnHostCapacityGC.class.getDeclaredMethod("triggerNow", GCCompletion.class);
+        m.setAccessible(true);
+        m.invoke(gc, completion);
+
+        Assert.assertTrue("should cancel when PS not found", cancelled.get());
+    }
+
+    @Test
+    public void cancelsWhenHostNotFound() throws Exception {
+        LocalStorageReturnHostCapacityGC gc = createGC("ps-1", "host-1", 1024, false);
+
+        Mockito.when(mockDbf.isExist("ps-1", PrimaryStorageVO.class)).thenReturn(true);
+        Mockito.when(mockDbf.isExist("host-1", HostVO.class)).thenReturn(false);
+
+        AtomicReference<Boolean> cancelled = new AtomicReference<>(false);
+        GCCompletion completion = Mockito.mock(GCCompletion.class);
+        Mockito.doAnswer(invocation -> {
+            cancelled.set(true);
+            return null;
+        }).when(completion).cancel();
+
+        Method m = LocalStorageReturnHostCapacityGC.class.getDeclaredMethod("triggerNow", GCCompletion.class);
+        m.setAccessible(true);
+        m.invoke(gc, completion);
+
+        Assert.assertTrue("should cancel when host not found", cancelled.get());
+    }
+
+    @Test
+    public void hasFourGCFields() throws Exception {
+        LocalStorageReturnHostCapacityGC gc = new LocalStorageReturnHostCapacityGC();
+        int gcCount = 0;
+        for (Field f : LocalStorageReturnHostCapacityGC.class.getDeclaredFields()) {
+            if (f.isAnnotationPresent(org.zstack.core.gc.GC.class)) {
+                gcCount++;
+            }
+        }
+        Assert.assertEquals(4, gcCount);
+    }
+}


### PR DESCRIPTION
## Root Cause
When migration failed, residual volumes on the source host were not cleaned up, causing resource leaks.

## Fix
Added garbage collection mechanism to clean up migration residues on host reconnect.

Resolves: ZSTAC-64545

sync from gitlab !9956