### PR TITLE
<fix>[sdk]: Expose CDN template GPU vendor

### DIFF
--- a/conf/db/upgrade/V5.5.22__schema.sql
+++ b/conf/db/upgrade/V5.5.22__schema.sql
@@ -161,6 +161,7 @@ CREATE TABLE IF NOT EXISTS `zstack`.`CdnModelServiceTemplateVO` (
     `version` varchar(255) DEFAULT NULL,
     `platform` varchar(255) DEFAULT NULL,
     `framework` varchar(255) DEFAULT NULL,
+    `gpuVendor` varchar(255) DEFAULT NULL,
     `size` bigint DEFAULT NULL,
     `projectId` varchar(255) DEFAULT NULL,
     `projectName` varchar(255) DEFAULT NULL,
@@ -177,6 +178,7 @@ CREATE TABLE IF NOT EXISTS `zstack`.`CdnModelServiceTemplateVO` (
         REFERENCES `zstack`.`ModelServiceVO` (`uuid`) ON DELETE SET NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 CALL ADD_COLUMN('CdnModelServiceTemplateVO', 'framework', 'varchar(255)', 1, NULL);
+CALL ADD_COLUMN('CdnModelServiceTemplateVO', 'gpuVendor', 'varchar(255)', 1, NULL);
 
 -- dGPU billing support tables
 

--- a/sdk/src/main/java/org/zstack/sdk/CdnModelServiceTemplateInventory.java
+++ b/sdk/src/main/java/org/zstack/sdk/CdnModelServiceTemplateInventory.java
@@ -44,6 +44,14 @@ public class CdnModelServiceTemplateInventory  {
         return this.framework;
     }
 
+    public java.lang.String gpuVendor;
+    public void setGpuVendor(java.lang.String gpuVendor) {
+        this.gpuVendor = gpuVendor;
+    }
+    public java.lang.String getGpuVendor() {
+        return this.gpuVendor;
+    }
+
     public java.lang.Long size;
     public void setSize(java.lang.Long size) {
         this.size = size;


### PR DESCRIPTION
## 问题
ZSTAC-85292 reopen 后确认 CDN 模型服务模板列表仍缺少 `gpuVendor` 字段。

## 修改
- `CdnModelServiceTemplateVO` schema 增加 `gpuVendor`
- SDK `CdnModelServiceTemplateInventory` 增加 `gpuVendor` accessor

## 验证
在 PR docker `zstack-zstac-85292-check` 中已执行：
- `./runMavenProfile premium` PASS
- `./runMavenProfile sdk` PASS
- `./runMavenProfile docpremium` PASS

Resolves: ZSTAC-85292

sync from gitlab !10002