### PR TITLE
<fix>[fiberchannel]: backport refresh FC by cluster @@2

### DIFF
--- a/sdk/src/main/java/org/zstack/sdk/RefreshFiberChannelStorageAction.java
+++ b/sdk/src/main/java/org/zstack/sdk/RefreshFiberChannelStorageAction.java
@@ -29,6 +29,9 @@ public class RefreshFiberChannelStorageAction extends AbstractAction {
     public java.lang.String zoneUuid;
 
     @Param(required = false, nonempty = false, nullElements = false, emptyString = true, noTrim = false)
+    public java.lang.String clusterUuid;
+
+    @Param(required = false, nonempty = false, nullElements = false, emptyString = true, noTrim = false)
     public java.util.List scsiLunUuids;
 
     @Param(required = false)


### PR DESCRIPTION
## Summary
Backport the 5.1.8 two-repository fix for ZSTAC-66480 to 4.8.38 for clone issue ZSTAC-66482.

Paired MR: premium branch `fix/4.8.38/ZSTAC-66482@@2`

Source MR: http://dev.zstack.io:9080/zstackio/zstack/-/merge_requests/6374
Source commit: 979a319aeae2b5492efbd80bb56326b770cbbe1c

## Changes
- Add optional `clusterUuid` parameter to `RefreshFiberChannelStorageAction` SDK action.

## Testing
- [x] git diff --check zstack/4.8.38..HEAD

Resolves/Related: ZSTAC-66482
Backport-From: ZSTAC-66480

sync from gitlab !10008