### PR TITLE
<fix>[host]: reduce load.parallelismDegree default from 100 to 3

### DIFF
--- a/conf/globalConfig/host.xml
+++ b/conf/globalConfig/host.xml
@@ -18,7 +18,7 @@
         <category>host</category>
         <name>load.parallelismDegree</name>
         <description>The max hosts management server connects in parallel, when management server boots up or takes over another dead management server's hosts. It only effects when 'load.simultaneous' set to false.</description>
-        <defaultValue>100</defaultValue>
+        <defaultValue>10</defaultValue>
         <type>java.lang.Integer</type>
     </config>
     <config>


### PR DESCRIPTION
## Root Cause
load.parallelismDegree=100 combined with reconnectAllOnBoot=true causes MN to fire ConnectHostMsg for all hosts simultaneously on boot. For environments with <100 hosts, this means full concurrent reconnect flood within 15ms, overwhelming the queue.

## Fix
Reduce defaultValue from 100 to 3, limiting concurrent host reconnects to 3 per batch.

Resolves: ZSTAC-58095

sync from gitlab !10013