### PR TITLE
<fix>[ctl]: heal zstack-ctl build deps

### DIFF
--- a/conf/tools/install.sh
+++ b/conf/tools/install.sh
@@ -29,7 +29,125 @@ install_virtualenv() {
     virtualenv --version | grep 12.1.1 >/dev/null || pip install -i $pypi_path --ignore-installed virtualenv==12.1.1
 }
 
+zstack_local_repo_args() {
+    grep -R "^\[zstack-local\]" /etc/yum.repos.d/*.repo >/dev/null 2>&1 && echo "--disablerepo=* --enablerepo=zstack-local"
+}
+
+yum_install_packages() {
+    local repo_args=`zstack_local_repo_args`
+    yum -y $repo_args install $@
+}
+
+yum_reinstall_packages() {
+    local repo_args=`zstack_local_repo_args`
+    yum -y $repo_args reinstall $@ || yum -y $repo_args install $@
+}
+
+ensure_rpm_packages_installed() {
+    local missing_list=`LANG=en_US.UTF-8 rpm -q $@ 2>/dev/null | grep 'not installed' | awk 'BEGIN{ORS=" "}{ print $2 }'`
+    [ -z "$missing_list" ] && return 0
+
+    echo "Installing zstack-ctl build dependencies: $missing_list"
+    yum_install_packages $missing_list
+}
+
+verify_rpm_packages() {
+    local broken_list=""
+    local pkg
+
+    for pkg in $@; do
+        rpm -q $pkg >/dev/null 2>&1 || continue
+        rpm -V $pkg >/dev/null 2>&1 || broken_list="$broken_list $pkg"
+    done
+
+    [ -z "$broken_list" ] && return 0
+
+    echo "Reinstalling broken zstack-ctl build dependencies:$broken_list"
+    yum_reinstall_packages $broken_list
+}
+
+python2_cflags_need_annobin() {
+    python2 - <<'PY' 2>/dev/null | grep -q 'annobin'
+import sysconfig
+print(sysconfig.get_config_var("CFLAGS") or "")
+PY
+}
+
+python2_cflags_need_redhat_rpm_config() {
+    python2 - <<'PY' 2>/dev/null | grep -qE 'redhat|^-specs=| -specs='
+import sysconfig
+print(sysconfig.get_config_var("CFLAGS") or "")
+PY
+}
+
+verify_python2_c_extension_build() {
+    local tmp_c=`mktemp /tmp/zstackctl-build-check.XXXXXX.c`
+    local tmp_o=${tmp_c%.c}.o
+    local py_cflags=`python2 - <<'PY'
+import sysconfig
+print(sysconfig.get_config_var("CFLAGS") or "")
+PY
+`
+    local py_include=`python2 - <<'PY'
+import sysconfig
+include_dir = sysconfig.get_config_var("INCLUDEPY") or ""
+print("-I%s" % include_dir if include_dir else "")
+PY
+`
+
+    cat > $tmp_c <<'EOF'
+#include <Python.h>
+#include <ffi.h>
+#include <openssl/ssl.h>
+int main(void) { return 0; }
+EOF
+
+    gcc $py_cflags $py_include -c $tmp_c -o $tmp_o
+    local ret=$?
+    rm -f $tmp_c $tmp_o
+
+    if [ $ret -ne 0 ]; then
+        echo "Failed to compile a minimal Python2 C extension. Please check gcc, python2-devel, libffi-devel, openssl-devel, redhat-rpm-config and annobin."
+        return 1
+    fi
+
+    return 0
+}
+
+ensure_zstack_ctl_build_deps() {
+    command -v rpm >/dev/null 2>&1 || return 0
+    command -v yum >/dev/null 2>&1 || return 0
+
+    local base_deps="python2 python2-devel python2-setuptools gcc libffi-devel openssl-devel"
+    ensure_rpm_packages_installed $base_deps || return 1
+    local need_redhat_rpm_config=false
+    local need_annobin=false
+
+    if python2_cflags_need_redhat_rpm_config; then
+        need_redhat_rpm_config=true
+        ensure_rpm_packages_installed redhat-rpm-config || return 1
+    fi
+
+    if python2_cflags_need_annobin; then
+        need_annobin=true
+        ensure_rpm_packages_installed annobin || return 1
+    fi
+
+    if $need_redhat_rpm_config; then
+        verify_rpm_packages redhat-rpm-config || return 1
+    fi
+    if $need_annobin; then
+        verify_rpm_packages annobin || return 1
+    fi
+
+    verify_python2_c_extension_build
+}
+
 cd $cwd
+
+if [ $tool = 'zstack-ctl' ]; then
+    ensure_zstack_ctl_build_deps || exit 1
+fi
 
 install_pip
 install_virtualenv
@@ -216,4 +334,3 @@ elif [ x"$tool" = x"zstack-ui" ]; then
 else
     usage
 fi
-


### PR DESCRIPTION
Run a minimal build dependency check before zstack-ctl recreates its
virtualenv. The check installs missing Python2, gcc, libffi, and
OpenSSL packages from zstack-local, restores Red Hat spec or plugin
packages when Python CFLAGS requires them, and verifies a tiny Python C
extension can compile before pip builds zstackctl dependencies.

This lets a rerun of the upgrade command recover hosts where annobin or
related build files were lost during an interrupted upgrade.

JIRA: ZSTAC-74634
Change-Id: Ia7a75fa179f7685d46f93a0c37ed022e51fd9a7d

sync from gitlab !10016