### PR TITLE
<fix>[network]: skip non kvm vxlan attach

### DIFF
--- a/plugin/vxlan/src/main/java/org/zstack/network/l2/vxlan/vxlanNetworkPool/KVMRealizeL2VxlanNetworkBackend.java
+++ b/plugin/vxlan/src/main/java/org/zstack/network/l2/vxlan/vxlanNetworkPool/KVMRealizeL2VxlanNetworkBackend.java
@@ -461,6 +461,11 @@ public class KVMRealizeL2VxlanNetworkBackend implements L2NetworkRealizationExte
 
     @Override
     public void instantiateResourceOnAttachingNic(VmInstanceSpec spec, L3NetworkInventory l3, Completion completion) {
+        if (!KVMConstant.KVM_HYPERVISOR_TYPE.equals(spec.getDestHost().getHypervisorType())) {
+            completion.success();
+            return;
+        }
+
         L2NetworkVO vo = Q.New(L2NetworkVO.class).eq(L2NetworkVO_.uuid, l3.getL2NetworkUuid()).find();
         if (!vo.getType().equals(VxlanNetworkConstant.VXLAN_NETWORK_TYPE)) {
             completion.success();


### PR DESCRIPTION
## Summary
Fix DPU baremetal VXLAN NIC hotplug failure caused by the KVM VXLAN attach-resource extension sending KVM agent messages to a non-KVM host.

## Changes
- Skip `KVMRealizeL2VxlanNetworkBackend.instantiateResourceOnAttachingNic()` when the target host hypervisor is not KVM.
- Keep existing KVM VXLAN realization behavior unchanged for KVM hosts.

## Testing
- [x] `mvn -pl plugin/vxlan -DskipTests compile`

Related DPU agent MR: http://dev.zstack.io:9080/zstackio/zstack-bm2-dpu-agent/-/merge_requests/9

Resolves: ZCF-0

sync from gitlab !10020