### PR TITLE
<fix>[kvm]: delete CpuFeaturesHistoryVO when CPU feature MD5 changes

### DIFF
--- a/plugin/kvm/src/main/java/org/zstack/kvm/KVMAgentCommands.java
+++ b/plugin/kvm/src/main/java/org/zstack/kvm/KVMAgentCommands.java
@@ -515,6 +515,8 @@ public class KVMAgentCommands {
         private List<String> libvirtCapabilities;
         @GrayVersion(value = "5.0.0")
         private VirtualizerInfoTO virtualizerInfo;
+        @GrayVersion("5.5.6")
+        private String cpuFeatureMd5;
 
         public String getOsDistribution() {
             return osDistribution;
@@ -759,6 +761,14 @@ public class KVMAgentCommands {
 
         public void setLibvirtPackageVersion(String libvirtPackageVersion) {
             this.libvirtPackageVersion = libvirtPackageVersion;
+        }
+
+        public String getCpuFeatureMd5() {
+            return cpuFeatureMd5;
+        }
+
+        public void setCpuFeatureMd5(String cpuFeatureMd5) {
+            this.cpuFeatureMd5 = cpuFeatureMd5;
         }
     }
 

--- a/plugin/kvm/src/main/java/org/zstack/kvm/KVMHost.java
+++ b/plugin/kvm/src/main/java/org/zstack/kvm/KVMHost.java
@@ -6070,8 +6070,27 @@ public class KVMHost extends HostBase implements Host {
                 }
 
                 deleteCpuHistoryVOIfCpuModeNameChange(ret.getCpuModelName());
+                deleteCpuHistoryVOIfCpuFeatureMd5Change(ret.getCpuFeatureMd5());
             }
         };
+    }
+
+    private void deleteCpuHistoryVOIfCpuFeatureMd5Change(String newMd5) {
+        if (newMd5 == null) {
+            return;
+        }
+
+        String oldMd5 = KVMSystemTags.CPU_FEATURE_MD5.getTokenByResourceUuid(self.getUuid(), KVMSystemTags.CPU_FEATURE_MD5_TOKEN);
+
+        if (oldMd5 == null || !oldMd5.equals(newMd5)) {
+            SQL.New(CpuFeaturesHistoryVO.class).eq(CpuFeaturesHistoryVO_.srcHostUuid, self.getUuid()).delete();
+            SQL.New(CpuFeaturesHistoryVO.class).eq(CpuFeaturesHistoryVO_.dstHostUuid, self.getUuid()).delete();
+
+            logger.debug(String.format("host[uuid:%s] CPU feature %s, old MD5: %s, new MD5: %s, deleted related CpuFeaturesHistoryVO records",
+                    self.getUuid(), oldMd5 == null ? "first recorded" : "changed", oldMd5, newMd5));
+        }
+
+        createTagWithoutNonValue(KVMSystemTags.CPU_FEATURE_MD5, KVMSystemTags.CPU_FEATURE_MD5_TOKEN, newMd5, true);
     }
 
     private void deleteCpuHistoryVOIfCpuModeNameChange(String cpuModelName){

--- a/plugin/kvm/src/main/java/org/zstack/kvm/KVMSystemTags.java
+++ b/plugin/kvm/src/main/java/org/zstack/kvm/KVMSystemTags.java
@@ -32,6 +32,9 @@ public class KVMSystemTags {
     public static final String CPU_MODEL_NAME_TOKEN = "name";
     public static PatternedSystemTag CPU_MODEL_NAME = new PatternedSystemTag(String.format("cpuModelName::{%s}", CPU_MODEL_NAME_TOKEN), HostVO.class);
 
+    public static final String CPU_FEATURE_MD5_TOKEN = "cpuFeatureMd5";
+    public static PatternedSystemTag CPU_FEATURE_MD5 = new PatternedSystemTag(String.format("cpuFeatureMd5::{%s}", CPU_FEATURE_MD5_TOKEN), HostVO.class);
+
     public static final String CHECK_CLUSTER_CPU_MODEL_TOKEN = "enable";
     public static PatternedSystemTag CHECK_CLUSTER_CPU_MODEL = new PatternedSystemTag(String.format("check::cluster::cpu::model::{%s}", CHECK_CLUSTER_CPU_MODEL_TOKEN), ClusterVO.class);
 


### PR DESCRIPTION
## Summary
- Backport ZSTAC-76397 fix for ZSTAC-80347 to 4.8.38.
- Add cpuFeatureMd5 to HostFactResponse and store it with CPU_FEATURE_MD5 system tag.
- Delete related CpuFeaturesHistoryVO records when a host CPU feature MD5 changes.

## Source
- Original Jira: ZSTAC-76397
- Clone Jira: ZSTAC-80347
- Cherry-picked from commit: 671696650ee5b92b69ed7411228164647e4843c1

## Test
- Not run per request.

sync from gitlab !10037