### PR TITLE
<fix>[zbs]: fix linked-clone parent volume residual

### DIFF
--- a/plugin/zbs/src/main/java/org/zstack/storage/zbs/ZbsHelper.java
+++ b/plugin/zbs/src/main/java/org/zstack/storage/zbs/ZbsHelper.java
@@ -19,6 +19,10 @@ public class ZbsHelper {
         return cbdPath.replaceFirst(".+?/", "zbs://");
     }
 
+    public static String normalizeToZbsPath(String path) {
+        return path != null && path.startsWith("cbd:") ? convertCbdPathToZbsPath(path) : path;
+    }
+
     public static String convertZbsPathToCbdPath(String zbsPath, Function<String, String> physicalPoolGetter) {
         String logicalPool = getPoolFromVolumePath(zbsPath);
         String physicalPool = physicalPoolGetter.apply(logicalPool);

--- a/plugin/zbs/src/main/java/org/zstack/storage/zbs/ZbsStorageController.java
+++ b/plugin/zbs/src/main/java/org/zstack/storage/zbs/ZbsStorageController.java
@@ -1022,7 +1022,7 @@ public class ZbsStorageController implements PrimaryStorageControllerSvc, Primar
                 stats.setSize(returnValue.getSize());
                 stats.setActualSize(returnValue.getActualSize());
                 stats.setFormat(VolumeConstant.VOLUME_FORMAT_RAW);
-                stats.setParentUri(returnValue.getParentUri());
+                stats.setParentUri(ZbsHelper.normalizeToZbsPath(returnValue.getParentUri()));
                 comp.success(stats);
             }
 
@@ -1046,7 +1046,7 @@ public class ZbsStorageController implements PrimaryStorageControllerSvc, Primar
                 stats.setSize(returnValue.getSize());
                 stats.setActualSize(returnValue.getActualSize());
                 stats.setFormat(VolumeConstant.VOLUME_FORMAT_RAW);
-                stats.setParentUri(returnValue.getParentUri());
+                stats.setParentUri(ZbsHelper.normalizeToZbsPath(returnValue.getParentUri()));
                 comp.success(stats);
             }
 
@@ -1069,7 +1069,7 @@ public class ZbsStorageController implements PrimaryStorageControllerSvc, Primar
             public void success(BatchQueryVolumeRsp returnValue) {
                 List<VolumeStats> stats = returnValue.getVolumes().entrySet().stream().map(v -> {
                     VolumeStats s = new VolumeStats();
-                    s.setInstallPath(v.getKey());
+                    s.setInstallPath(ZbsHelper.normalizeToZbsPath(v.getKey()));
                     s.setSize(v.getValue().get("length"));
                     s.setActualSize(v.getValue().get("usedSize"));
                     s.setFormat(VolumeConstant.VOLUME_FORMAT_RAW);

--- a/test/src/test/groovy/org/zstack/test/integration/storage/primary/addon/zbs/ZbsPrimaryStorageCase.groovy
+++ b/test/src/test/groovy/org/zstack/test/integration/storage/primary/addon/zbs/ZbsPrimaryStorageCase.groovy
@@ -1,10 +1,17 @@
 package org.zstack.test.integration.storage.primary.addon.zbs
 
 import org.springframework.http.HttpEntity
+import org.zstack.core.cloudbus.CloudBus
 import org.zstack.core.cloudbus.EventCallback
 import org.zstack.core.cloudbus.EventFacade
 import org.zstack.core.db.DatabaseFacade
 import org.zstack.core.db.Q
+import org.zstack.header.message.MessageReply
+import org.zstack.header.storage.primary.GetVolumeBackingChainFromPrimaryStorageMsg
+import org.zstack.header.storage.primary.GetVolumeBackingChainFromPrimaryStorageReply
+import org.zstack.header.storage.primary.PrimaryStorageConstant
+import org.zstack.header.volume.BatchSyncVolumeSizeOnPrimaryStorageMsg
+import org.zstack.header.volume.BatchSyncVolumeSizeOnPrimaryStorageReply
 import org.zstack.header.storage.addon.primary.ExternalPrimaryStorageVO
 import org.zstack.header.storage.addon.primary.ExternalPrimaryStorageSpaceVO
 import org.zstack.header.storage.addon.primary.ExternalPrimaryStorageVO_
@@ -191,6 +198,8 @@ class ZbsPrimaryStorageCase extends SubCase {
             testDataVolumeNegativeScenario()
             testDecodeMdsUriWithSpecialPassword()
             testMdsReconnectAfterMaximumPingFailures()
+            testGetBackingChainNormalizesCbdParentUri()
+            testBatchStatsNormalizesCbdInstallPath()
         }
     }
 
@@ -1093,6 +1102,72 @@ class ZbsPrimaryStorageCase extends SubCase {
 
         PrimaryStorageGlobalConfig.PING_INTERVAL.updateValue(originalPingInterval)
         env.cleanAfterSimulatorHandlers()
+    }
+
+    void testGetBackingChainNormalizesCbdParentUri() {
+        String childSnapPath = "zbs://lpool1/volume_child@snapshot_s1"
+        String parentZbsPath = "zbs://lpool1/volume_parent"
+        String parentCbdPath = "cbd:pool1/lpool1/volume_parent"
+
+        env.simulator(ZbsStorageController.QUERY_VOLUME_PATH) { HttpEntity<String> e, EnvSpec spec ->
+            def cmd = JSONObjectUtil.toObject(e.body, ZbsStorageController.QueryVolumeCmd.class)
+            def rsp = new ZbsStorageController.QueryVolumeRsp()
+            rsp.size = SizeUnit.GIGABYTE.toByte(8)
+            rsp.actualSize = SizeUnit.MEGABYTE.toByte(1)
+            if (cmd.path.contains("volume_child")) {
+                rsp.parentUri = parentCbdPath
+            } else {
+                rsp.parentUri = null
+            }
+            return rsp
+        }
+
+        CloudBus bus = bean(CloudBus.class)
+        GetVolumeBackingChainFromPrimaryStorageMsg msg = new GetVolumeBackingChainFromPrimaryStorageMsg()
+        msg.setPrimaryStorageUuid(ps.uuid)
+        msg.setVolumeUuid(childSnapPath)
+        msg.setRootInstallPaths([childSnapPath])
+        bus.makeTargetServiceIdByResourceUuid(msg, PrimaryStorageConstant.SERVICE_ID, ps.uuid)
+        MessageReply reply = bus.call(msg)
+
+        assert reply.isSuccess() : "backing chain walk must not fail on cbd-form parentUri: ${reply.error}"
+        GetVolumeBackingChainFromPrimaryStorageReply r = reply as GetVolumeBackingChainFromPrimaryStorageReply
+        List<String> chain = r.getBackingChainInstallPath(childSnapPath)
+        assert chain != null && chain.contains(parentZbsPath) :
+                "parent must be resolved as a zbs:// path, got ${chain}"
+
+        env.cleanSimulatorHandlers()
+    }
+
+    void testBatchStatsNormalizesCbdInstallPath() {
+        String volUuid = "vol85707batch"
+        String zbsPath = "zbs://lpool1/volume_batch"
+        long usedSize = SizeUnit.MEGABYTE.toByte(7)
+
+        env.simulator(ZbsStorageController.BATCH_QUERY_VOLUME_PATH) { HttpEntity<String> e, EnvSpec spec ->
+            def cmd = JSONObjectUtil.toObject(e.body, ZbsStorageController.BatchQueryVolumeCmd.class)
+            def rsp = new ZbsStorageController.BatchQueryVolumeRsp()
+            Map<String, Map<String, Long>> volumes = new HashMap<>()
+            cmd.installPaths.each { cbd ->
+                volumes.put(cbd, ["length": SizeUnit.GIGABYTE.toByte(8), "usedSize": usedSize])
+            }
+            rsp.setVolumes(volumes)
+            return rsp
+        }
+
+        CloudBus bus = bean(CloudBus.class)
+        BatchSyncVolumeSizeOnPrimaryStorageMsg msg = new BatchSyncVolumeSizeOnPrimaryStorageMsg()
+        msg.setPrimaryStorageUuid(ps.uuid)
+        msg.setVolumeUuidInstallPaths([(volUuid): zbsPath])
+        bus.makeTargetServiceIdByResourceUuid(msg, PrimaryStorageConstant.SERVICE_ID, ps.uuid)
+        MessageReply reply = bus.call(msg)
+
+        assert reply.isSuccess() : "batch size sync must not fail on cbd-form install path: ${reply.error}"
+        BatchSyncVolumeSizeOnPrimaryStorageReply r = reply as BatchSyncVolumeSizeOnPrimaryStorageReply
+        assert r.actualSizes.get(volUuid) == usedSize :
+                "actualSize must map back to uuid via zbs:// install path, got ${r.actualSizes}"
+
+        env.cleanSimulatorHandlers()
     }
 
     void deleteVolume(String volUuid) {


### PR DESCRIPTION
## Summary
【zbs主存储】删除链接克隆子卷后，链接克隆的父卷和快照残留。

## Root cause
ZBS `stats()`/`flatten()` 把卷的 `installPath` 归一化成 `zbs://` 路径，但 `parentUri` 原样存成 agent 返回的 `cbd:` 路径。快照引用 GC 沿 backing chain 回溯时把这个 `cbd:` 路径再喂回 `controller.stats()`，`prepareCmd()` 二次执行 `convertZbsPathToCbdPath`，`getPoolFromVolumePath` 把物理池名误解析，backing chain 查询以 `ORG_ZSTACK_STORAGE_ZBS_10026` 失败并回滚，导致父卷与快照残留在存储上。

## Changes
- `ZbsHelper.normalizeToZbsPath()`：仅对 `cbd:` 前缀路径转回 `zbs://`（`convertCbdPathToZbsPath` 非幂等，带 guard）
- `ZbsStorageController` `stats()`/`flatten()`：设置 `parentUri` 时归一化，使 backing chain 全程只跑 `zbs://`

```
 ZbsHelper.java            |  4 +++
 ZbsStorageController.java |  4 +--
 ZbsPrimaryStorageCase.groovy | 41 +++++++++
```

## Testing
- [x] 全量编译通过（AspectJ 织入）
- [x] `ZbsPrimaryStorageCase` 新增 `testGetBackingChainNormalizesCbdParentUri`，红绿验证：修复前以 ZBS_10026 失败、修复后通过（Tests run: 1, Failures: 0）
- [ ] CI pipeline

影响版本：5.5.12 / 5.5.16 / 5.5.22 / 5.5.24 / 5.5.28（master 不受影响，ZBS 已重写）

Resolves: ZSTAC-85707

sync from gitlab !10071