### PR TITLE
<feature>[vpc-dns]: restore vpc dns records

### DIFF
--- a/conf/db/upgrade/V5.4.7.1__schema.sql
+++ b/conf/db/upgrade/V5.4.7.1__schema.sql
@@ -1,0 +1,19 @@
+CREATE TABLE IF NOT EXISTS `zstack`.`VpcRouterDnsRecordVO` (
+    `id` BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+    `uuid` VARCHAR(32) NOT NULL,
+    `vpcRouterUuid` VARCHAR(32) DEFAULT NULL,
+    `vpcHaGroupUuid` VARCHAR(32) DEFAULT NULL,
+    `type` VARCHAR(16) NOT NULL DEFAULT 'A',
+    `domain` VARCHAR(255) NOT NULL,
+    `ip` VARCHAR(255) NOT NULL,
+    `createDate` TIMESTAMP NOT NULL DEFAULT '0000-00-00 00:00:00',
+    `lastOpDate` TIMESTAMP NOT NULL DEFAULT '0000-00-00 00:00:00' ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `ukVpcRouterDnsRecordVOuuid` (`uuid`),
+    INDEX `idxVpcRouterDnsRecordVOvpcRouterUuid` (`vpcRouterUuid`),
+    INDEX `idxVpcRouterDnsRecordVOvpcHaGroupUuid` (`vpcHaGroupUuid`),
+    INDEX `idxVpcRouterDnsRecordVOtype` (`type`),
+    INDEX `idxVpcRouterDnsRecordVOdomain` (`domain`),
+    CONSTRAINT `fkVpcRouterDnsRecordVOVpcRouterVmVO` FOREIGN KEY (`vpcRouterUuid`) REFERENCES `zstack`.`VpcRouterVmVO` (`uuid`) ON DELETE CASCADE,
+    CONSTRAINT `fkVpcRouterDnsRecordVOVpcHaGroupVO` FOREIGN KEY (`vpcHaGroupUuid`) REFERENCES `zstack`.`VpcHaGroupVO` (`uuid`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;

--- a/conf/i18n.json
+++ b/conf/i18n.json
@@ -35558,6 +35558,92 @@
     "fileName": "src/main/java/org/zstack/vpc/VpcApiInterceptor.java"
   },
   {
+    "raw": "domain[%s] is not a valid format",
+    "en_US": "domain[{0}] is not a valid format",
+    "zh_CN": "domain[{0}]格式无效",
+    "arguments": [
+      "domain"
+    ],
+    "line": 627,
+    "fileName": "src/main/java/org/zstack/vpc/VpcApiInterceptor.java"
+  },
+  {
+    "raw": "ip[%s] is not a valid IPv4 address",
+    "en_US": "ip[{0}] is not a valid IPv4 address",
+    "zh_CN": "ip[{0}]不是有效的IPv4地址",
+    "arguments": [
+      "msg.getIp()"
+    ],
+    "line": 576,
+    "fileName": "src/main/java/org/zstack/vpc/VpcApiInterceptor.java"
+  },
+  {
+    "raw": "ip[%s] is not in private network range of vpc router[uuid:%s]",
+    "en_US": "ip[{0}] is not in private network range of vpc router[uuid:{1}]",
+    "zh_CN": "ip[{0}]不在vpc router[uuid:{1}]的私有网络范围内",
+    "arguments": [
+      "ip",
+      "vpcRouterUuid"
+    ],
+    "line": 631,
+    "fileName": "src/main/java/org/zstack/vpc/VpcApiInterceptor.java"
+  },
+  {
+    "raw": "vpc router[uuid:%s] is not in state[%s]",
+    "en_US": "vpc router[uuid:{0}] is not in state[{1}]",
+    "zh_CN": "vpc router[uuid:{0}]不处于[{1}]状态",
+    "arguments": [
+      "vpcRouterUuid",
+      "VmInstanceState.Running"
+    ],
+    "line": 603,
+    "fileName": "src/main/java/org/zstack/vpc/VpcApiInterceptor.java"
+  },
+  {
+    "raw": "dns record[domain:%s] has been added to vpc router[uuid:%s]",
+    "en_US": "dns record[domain:{0}] has been added to vpc router[uuid:{1}]",
+    "zh_CN": "dns record[domain:{0}]已添加到vpc router[uuid:{1}]",
+    "arguments": [
+      "msg.getDomain()",
+      "msg.getUuid()"
+    ],
+    "line": 586,
+    "fileName": "src/main/java/org/zstack/vpc/VpcApiInterceptor.java"
+  },
+  {
+    "raw": "dns record count of vpc router[uuid:%s] exceeds the limit[%s]",
+    "en_US": "dns record count of vpc router[uuid:{0}] exceeds the limit[{1}]",
+    "zh_CN": "vpc router[uuid:{0}]的dns record数量超过上限[{1}]",
+    "arguments": [
+      "msg.getUuid()",
+      "MAX_DNS_RECORDS_PER_VPC_ROUTER"
+    ],
+    "line": 593,
+    "fileName": "src/main/java/org/zstack/vpc/VpcApiInterceptor.java"
+  },
+  {
+    "raw": "dns record[domain:%s] is not added to vpc router[uuid:%s]",
+    "en_US": "dns record[domain:{0}] is not added to vpc router[uuid:{1}]",
+    "zh_CN": "dns record[domain:{0}]未添加到vpc router[uuid:{1}]",
+    "arguments": [
+      "msg.getDomain()",
+      "msg.getUuid()"
+    ],
+    "line": 637,
+    "fileName": "src/main/java/org/zstack/vpc/VpcApiInterceptor.java"
+  },
+  {
+    "raw": "failed to sync dns record to vpc router[uuid:%s], because: %s",
+    "en_US": "failed to sync dns record to vpc router[uuid:{0}], because: {1}",
+    "zh_CN": "同步dns record到vpc router[uuid:{0}]失败，原因：{1}",
+    "arguments": [
+      "vrUuid",
+      "rsp.getError()"
+    ],
+    "line": 68,
+    "fileName": "src/main/java/org/zstack/vpc/VpcRouterDnsRecordBackend.java"
+  },
+  {
     "raw": "no ip ranges attached with l3 network[uuid:%s]",
     "en_US": "no ip ranges attached with l3 network[uuid:{0}]",
     "zh_CN": "在三层网络[uuid:{0}]上没有IP范围被绑定",

--- a/conf/i18n/messages_en_US.properties
+++ b/conf/i18n/messages_en_US.properties
@@ -14058,6 +14058,37 @@ No\ VNC\ ports\ available = No VNC ports available
 # args: msg.getDns()
 dns[%s]\ is\ not\ a\ IP\ address = dns[{0}] is not a IP address
 
+# args: domain
+domain[%s]\ is\ not\ a\ valid\ format = domain[{0}] is not a valid format
+
+# at: src/main/java/org/zstack/vpc/VpcApiInterceptor.java:576
+# args: msg.getIp()
+ip[%s]\ is\ not\ a\ valid\ IPv4\ address = ip[{0}] is not a valid IPv4 address
+
+# at: src/main/java/org/zstack/vpc/VpcApiInterceptor.java:631
+# args: ip, vpcRouterUuid
+ip[%s]\ is\ not\ in\ private\ network\ range\ of\ vpc\ router[uuid\:%s] = ip[{0}] is not in private network range of vpc router[uuid:{1}]
+
+# at: src/main/java/org/zstack/vpc/VpcApiInterceptor.java:603
+# args: vpcRouterUuid, VmInstanceState.Running
+vpc\ router[uuid\:%s]\ is\ not\ in\ state[%s] = vpc router[uuid:{0}] is not in state[{1}]
+
+# at: src/main/java/org/zstack/vpc/VpcApiInterceptor.java:586
+# args: msg.getDomain(), msg.getUuid()
+dns\ record[domain\:%s]\ has\ been\ added\ to\ vpc\ router[uuid\:%s] = dns record[domain:{0}] has been added to vpc router[uuid:{1}]
+
+# at: src/main/java/org/zstack/vpc/VpcApiInterceptor.java:593
+# args: msg.getUuid(), MAX_DNS_RECORDS_PER_VPC_ROUTER
+dns\ record\ count\ of\ vpc\ router[uuid\:%s]\ exceeds\ the\ limit[%s] = dns record count of vpc router[uuid:{0}] exceeds the limit[{1}]
+
+# at: src/main/java/org/zstack/vpc/VpcApiInterceptor.java:637
+# args: msg.getDomain(), msg.getUuid()
+dns\ record[domain\:%s]\ is\ not\ added\ to\ vpc\ router[uuid\:%s] = dns record[domain:{0}] is not added to vpc router[uuid:{1}]
+
+# at: src/main/java/org/zstack/vpc/VpcRouterDnsRecordBackend.java:68
+# args: vrUuid,rsp.getError()
+failed\ to\ sync\ dns\ record\ to\ vpc\ router[uuid\:%s],\ because\:\ %s = failed to sync dns record to vpc router[uuid:{0}], because: {1}
+
 # at: src/main/java/org/zstack/vpc/VpcApiInterceptor.java:338
 # args: l3NetworkVO.getUuid()
 no\ ip\ ranges\ attached\ with\ l3\ network[uuid\:%s] = no ip ranges attached with l3 network[uuid:{0}]

--- a/conf/i18n/messages_zh_CN.properties
+++ b/conf/i18n/messages_zh_CN.properties
@@ -14058,6 +14058,37 @@ No\ VNC\ ports\ available = 未找到可用的VNC端口
 # args: msg.getDns()
 dns[%s]\ is\ not\ a\ IP\ address = dns地址[{0}]不是有效的IP地址
 
+# args: domain
+domain[%s]\ is\ not\ a\ valid\ format = domain[{0}]格式无效
+
+# at: src/main/java/org/zstack/vpc/VpcApiInterceptor.java:576
+# args: msg.getIp()
+ip[%s]\ is\ not\ a\ valid\ IPv4\ address = ip[{0}]不是有效的IPv4地址
+
+# at: src/main/java/org/zstack/vpc/VpcApiInterceptor.java:631
+# args: ip, vpcRouterUuid
+ip[%s]\ is\ not\ in\ private\ network\ range\ of\ vpc\ router[uuid\:%s] = ip[{0}]不在vpc router[uuid:{1}]的私有网络范围内
+
+# at: src/main/java/org/zstack/vpc/VpcApiInterceptor.java:603
+# args: vpcRouterUuid, VmInstanceState.Running
+vpc\ router[uuid\:%s]\ is\ not\ in\ state[%s] = vpc router[uuid:{0}]不处于[{1}]状态
+
+# at: src/main/java/org/zstack/vpc/VpcApiInterceptor.java:586
+# args: msg.getDomain(), msg.getUuid()
+dns\ record[domain\:%s]\ has\ been\ added\ to\ vpc\ router[uuid\:%s] = dns record[domain:{0}]已添加到vpc router[uuid:{1}]
+
+# at: src/main/java/org/zstack/vpc/VpcApiInterceptor.java:593
+# args: msg.getUuid(), MAX_DNS_RECORDS_PER_VPC_ROUTER
+dns\ record\ count\ of\ vpc\ router[uuid\:%s]\ exceeds\ the\ limit[%s] = vpc router[uuid:{0}]的dns record数量超过上限[{1}]
+
+# at: src/main/java/org/zstack/vpc/VpcApiInterceptor.java:637
+# args: msg.getDomain(), msg.getUuid()
+dns\ record[domain\:%s]\ is\ not\ added\ to\ vpc\ router[uuid\:%s] = dns record[domain:{0}]未添加到vpc router[uuid:{1}]
+
+# at: src/main/java/org/zstack/vpc/VpcRouterDnsRecordBackend.java:68
+# args: vrUuid,rsp.getError()
+failed\ to\ sync\ dns\ record\ to\ vpc\ router[uuid\:%s],\ because\:\ %s = 同步dns record到vpc router[uuid:{0}]失败，原因：{1}
+
 # at: src/main/java/org/zstack/vpc/VpcApiInterceptor.java:338
 # args: l3NetworkVO.getUuid()
 no\ ip\ ranges\ attached\ with\ l3\ network[uuid\:%s] = 在三层网络[uuid:{0}]上没有IP范围被绑定

--- a/sdk/src/main/java/SourceClassMap.java
+++ b/sdk/src/main/java/SourceClassMap.java
@@ -429,6 +429,7 @@ public class SourceClassMap {
 			put("org.zstack.header.volume.block.ExponBlockVolumeInventory", "org.zstack.sdk.ExponBlockVolumeInventory");
 			put("org.zstack.header.volume.block.XskyBlockVolumeInventory", "org.zstack.sdk.XskyBlockVolumeInventory");
 			put("org.zstack.header.vpc.VpcRouterDnsInventory", "org.zstack.sdk.VpcRouterDnsInventory");
+			put("org.zstack.header.vpc.VpcRouterDnsRecordInventory", "org.zstack.sdk.VpcRouterDnsRecordInventory");
 			put("org.zstack.header.vpc.VpcRouterVmInventory", "org.zstack.sdk.VpcRouterVmInventory");
 			put("org.zstack.header.vpc.VpcSnatStateInventory", "org.zstack.sdk.VpcSnatStateInventory");
 			put("org.zstack.header.vpc.ha.VpcHaGroupApplianceVmRefInventory", "org.zstack.sdk.VpcHaGroupApplianceVmRefInventory");
@@ -1544,6 +1545,7 @@ public class SourceClassMap {
 			put("org.zstack.sdk.VpcHaGroupNetworkServiceRefInventory", "org.zstack.header.vpc.ha.VpcHaGroupNetworkServiceRefInventory");
 			put("org.zstack.sdk.VpcHaGroupVipRefInventory", "org.zstack.header.vpc.ha.VpcHaGroupVipRefInventory");
 			put("org.zstack.sdk.VpcRouterDnsInventory", "org.zstack.header.vpc.VpcRouterDnsInventory");
+			put("org.zstack.sdk.VpcRouterDnsRecordInventory", "org.zstack.header.vpc.VpcRouterDnsRecordInventory");
 			put("org.zstack.sdk.VpcRouterVmInventory", "org.zstack.header.vpc.VpcRouterVmInventory");
 			put("org.zstack.sdk.VpcSharedQosInventory", "org.zstack.header.vipQos.VpcSharedQosInventory");
 			put("org.zstack.sdk.VpcSharedQosRefVipInventory", "org.zstack.header.vipQos.VpcSharedQosRefVipInventory");

--- a/sdk/src/main/java/org/zstack/sdk/AddDnsRecordToVpcRouterAction.java
+++ b/sdk/src/main/java/org/zstack/sdk/AddDnsRecordToVpcRouterAction.java
@@ -1,0 +1,113 @@
+package org.zstack.sdk;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.zstack.sdk.*;
+
+public class AddDnsRecordToVpcRouterAction extends AbstractAction {
+
+    private static final HashMap<String, Parameter> parameterMap = new HashMap<>();
+
+    private static final HashMap<String, Parameter> nonAPIParameterMap = new HashMap<>();
+
+    public static class Result {
+        public ErrorCode error;
+        public org.zstack.sdk.AddDnsRecordToVpcRouterResult value;
+
+        public Result throwExceptionIfError() {
+            if (error != null) {
+                throw new ApiException(
+                    String.format("error[code: %s, description: %s, details: %s]", error.code, error.description, error.details)
+                );
+            }
+
+            return this;
+        }
+    }
+
+    @Param(required = true, nonempty = false, nullElements = false, emptyString = true, noTrim = false)
+    public java.lang.String uuid;
+
+    @Param(required = true, maxLength = 253, nonempty = false, nullElements = false, emptyString = false, noTrim = false)
+    public java.lang.String domain;
+
+    @Param(required = true, maxLength = 255, nonempty = false, nullElements = false, emptyString = false, noTrim = false)
+    public java.lang.String ip;
+
+    @Param(required = false)
+    public java.lang.String resourceUuid;
+
+    @Param(required = false, nonempty = false, nullElements = false, emptyString = true, noTrim = false)
+    public java.util.List tagUuids;
+
+    @Param(required = false)
+    public java.util.List systemTags;
+
+    @Param(required = false)
+    public java.util.List userTags;
+
+    @Param(required = false)
+    public String sessionId;
+
+    @Param(required = false)
+    public String accessKeyId;
+
+    @Param(required = false)
+    public String accessKeySecret;
+
+    @Param(required = false)
+    public String requestIp;
+
+    @NonAPIParam
+    public long timeout = -1;
+
+    @NonAPIParam
+    public long pollingInterval = -1;
+
+
+    private Result makeResult(ApiResult res) {
+        Result ret = new Result();
+        if (res.error != null) {
+            ret.error = res.error;
+            return ret;
+        }
+
+        org.zstack.sdk.AddDnsRecordToVpcRouterResult value = res.getResult(org.zstack.sdk.AddDnsRecordToVpcRouterResult.class);
+        ret.value = value == null ? new org.zstack.sdk.AddDnsRecordToVpcRouterResult() : value;
+
+        return ret;
+    }
+
+    public Result call() {
+        ApiResult res = ZSClient.call(this);
+        return makeResult(res);
+    }
+
+    public void call(final Completion<Result> completion) {
+        ZSClient.call(this, new InternalCompletion() {
+            @Override
+            public void complete(ApiResult res) {
+                completion.complete(makeResult(res));
+            }
+        });
+    }
+
+    protected Map<String, Parameter> getParameterMap() {
+        return parameterMap;
+    }
+
+    protected Map<String, Parameter> getNonAPIParameterMap() {
+        return nonAPIParameterMap;
+    }
+
+    protected RestInfo getRestInfo() {
+        RestInfo info = new RestInfo();
+        info.httpMethod = "POST";
+        info.path = "/vpc/virtual-routers/{uuid}/dns-record";
+        info.needSession = true;
+        info.needPoll = true;
+        info.parameterName = "params";
+        return info;
+    }
+
+}

--- a/sdk/src/main/java/org/zstack/sdk/AddDnsRecordToVpcRouterResult.java
+++ b/sdk/src/main/java/org/zstack/sdk/AddDnsRecordToVpcRouterResult.java
@@ -1,0 +1,14 @@
+package org.zstack.sdk;
+
+import org.zstack.sdk.VpcRouterDnsRecordInventory;
+
+public class AddDnsRecordToVpcRouterResult {
+    public VpcRouterDnsRecordInventory inventory;
+    public void setInventory(VpcRouterDnsRecordInventory inventory) {
+        this.inventory = inventory;
+    }
+    public VpcRouterDnsRecordInventory getInventory() {
+        return this.inventory;
+    }
+
+}

--- a/sdk/src/main/java/org/zstack/sdk/QueryVpcRouterDnsRecordAction.java
+++ b/sdk/src/main/java/org/zstack/sdk/QueryVpcRouterDnsRecordAction.java
@@ -1,0 +1,75 @@
+package org.zstack.sdk;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.zstack.sdk.*;
+
+public class QueryVpcRouterDnsRecordAction extends QueryAction {
+
+    private static final HashMap<String, Parameter> parameterMap = new HashMap<>();
+
+    private static final HashMap<String, Parameter> nonAPIParameterMap = new HashMap<>();
+
+    public static class Result {
+        public ErrorCode error;
+        public org.zstack.sdk.QueryVpcRouterDnsRecordResult value;
+
+        public Result throwExceptionIfError() {
+            if (error != null) {
+                throw new ApiException(
+                    String.format("error[code: %s, description: %s, details: %s]", error.code, error.description, error.details)
+                );
+            }
+
+            return this;
+        }
+    }
+
+
+
+    private Result makeResult(ApiResult res) {
+        Result ret = new Result();
+        if (res.error != null) {
+            ret.error = res.error;
+            return ret;
+        }
+
+        org.zstack.sdk.QueryVpcRouterDnsRecordResult value = res.getResult(org.zstack.sdk.QueryVpcRouterDnsRecordResult.class);
+        ret.value = value == null ? new org.zstack.sdk.QueryVpcRouterDnsRecordResult() : value;
+
+        return ret;
+    }
+
+    public Result call() {
+        ApiResult res = ZSClient.call(this);
+        return makeResult(res);
+    }
+
+    public void call(final Completion<Result> completion) {
+        ZSClient.call(this, new InternalCompletion() {
+            @Override
+            public void complete(ApiResult res) {
+                completion.complete(makeResult(res));
+            }
+        });
+    }
+
+    protected Map<String, Parameter> getParameterMap() {
+        return parameterMap;
+    }
+
+    protected Map<String, Parameter> getNonAPIParameterMap() {
+        return nonAPIParameterMap;
+    }
+
+    protected RestInfo getRestInfo() {
+        RestInfo info = new RestInfo();
+        info.httpMethod = "GET";
+        info.path = "/vpc/virtual-routers/dns-record";
+        info.needSession = true;
+        info.needPoll = false;
+        info.parameterName = "";
+        return info;
+    }
+
+}

--- a/sdk/src/main/java/org/zstack/sdk/QueryVpcRouterDnsRecordResult.java
+++ b/sdk/src/main/java/org/zstack/sdk/QueryVpcRouterDnsRecordResult.java
@@ -1,0 +1,22 @@
+package org.zstack.sdk;
+
+
+
+public class QueryVpcRouterDnsRecordResult {
+    public java.util.List inventories;
+    public void setInventories(java.util.List inventories) {
+        this.inventories = inventories;
+    }
+    public java.util.List getInventories() {
+        return this.inventories;
+    }
+
+    public java.lang.Long total;
+    public void setTotal(java.lang.Long total) {
+        this.total = total;
+    }
+    public java.lang.Long getTotal() {
+        return this.total;
+    }
+
+}

--- a/sdk/src/main/java/org/zstack/sdk/RemoveDnsRecordFromVpcRouterAction.java
+++ b/sdk/src/main/java/org/zstack/sdk/RemoveDnsRecordFromVpcRouterAction.java
@@ -1,0 +1,101 @@
+package org.zstack.sdk;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.zstack.sdk.*;
+
+public class RemoveDnsRecordFromVpcRouterAction extends AbstractAction {
+
+    private static final HashMap<String, Parameter> parameterMap = new HashMap<>();
+
+    private static final HashMap<String, Parameter> nonAPIParameterMap = new HashMap<>();
+
+    public static class Result {
+        public ErrorCode error;
+        public org.zstack.sdk.RemoveDnsRecordFromVpcRouterResult value;
+
+        public Result throwExceptionIfError() {
+            if (error != null) {
+                throw new ApiException(
+                    String.format("error[code: %s, description: %s, details: %s]", error.code, error.description, error.details)
+                );
+            }
+
+            return this;
+        }
+    }
+
+    @Param(required = true, nonempty = false, nullElements = false, emptyString = true, noTrim = false)
+    public java.lang.String uuid;
+
+    @Param(required = false)
+    public java.util.List systemTags;
+
+    @Param(required = false)
+    public java.util.List userTags;
+
+    @Param(required = false)
+    public String sessionId;
+
+    @Param(required = false)
+    public String accessKeyId;
+
+    @Param(required = false)
+    public String accessKeySecret;
+
+    @Param(required = false)
+    public String requestIp;
+
+    @NonAPIParam
+    public long timeout = -1;
+
+    @NonAPIParam
+    public long pollingInterval = -1;
+
+
+    private Result makeResult(ApiResult res) {
+        Result ret = new Result();
+        if (res.error != null) {
+            ret.error = res.error;
+            return ret;
+        }
+
+        org.zstack.sdk.RemoveDnsRecordFromVpcRouterResult value = res.getResult(org.zstack.sdk.RemoveDnsRecordFromVpcRouterResult.class);
+        ret.value = value == null ? new org.zstack.sdk.RemoveDnsRecordFromVpcRouterResult() : value;
+
+        return ret;
+    }
+
+    public Result call() {
+        ApiResult res = ZSClient.call(this);
+        return makeResult(res);
+    }
+
+    public void call(final Completion<Result> completion) {
+        ZSClient.call(this, new InternalCompletion() {
+            @Override
+            public void complete(ApiResult res) {
+                completion.complete(makeResult(res));
+            }
+        });
+    }
+
+    protected Map<String, Parameter> getParameterMap() {
+        return parameterMap;
+    }
+
+    protected Map<String, Parameter> getNonAPIParameterMap() {
+        return nonAPIParameterMap;
+    }
+
+    protected RestInfo getRestInfo() {
+        RestInfo info = new RestInfo();
+        info.httpMethod = "DELETE";
+        info.path = "/vpc/virtual-routers/dns-record/{uuid}";
+        info.needSession = true;
+        info.needPoll = true;
+        info.parameterName = "";
+        return info;
+    }
+
+}

--- a/sdk/src/main/java/org/zstack/sdk/RemoveDnsRecordFromVpcRouterResult.java
+++ b/sdk/src/main/java/org/zstack/sdk/RemoveDnsRecordFromVpcRouterResult.java
@@ -1,0 +1,14 @@
+package org.zstack.sdk;
+
+
+
+public class RemoveDnsRecordFromVpcRouterResult {
+    public java.util.List inventories;
+    public void setInventories(java.util.List inventories) {
+        this.inventories = inventories;
+    }
+    public java.util.List getInventories() {
+        return this.inventories;
+    }
+
+}

--- a/sdk/src/main/java/org/zstack/sdk/UpdateDnsRecordToVpcRouterAction.java
+++ b/sdk/src/main/java/org/zstack/sdk/UpdateDnsRecordToVpcRouterAction.java
@@ -1,0 +1,104 @@
+package org.zstack.sdk;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.zstack.sdk.*;
+
+public class UpdateDnsRecordToVpcRouterAction extends AbstractAction {
+
+    private static final HashMap<String, Parameter> parameterMap = new HashMap<>();
+
+    private static final HashMap<String, Parameter> nonAPIParameterMap = new HashMap<>();
+
+    public static class Result {
+        public ErrorCode error;
+        public org.zstack.sdk.UpdateDnsRecordToVpcRouterResult value;
+
+        public Result throwExceptionIfError() {
+            if (error != null) {
+                throw new ApiException(
+                    String.format("error[code: %s, description: %s, details: %s]", error.code, error.description, error.details)
+                );
+            }
+
+            return this;
+        }
+    }
+
+    @Param(required = true, nonempty = false, nullElements = false, emptyString = true, noTrim = false)
+    public java.lang.String uuid;
+
+    @Param(required = true, maxLength = 255, nonempty = false, nullElements = false, emptyString = false, noTrim = false)
+    public java.lang.String ip;
+
+    @Param(required = false)
+    public java.util.List systemTags;
+
+    @Param(required = false)
+    public java.util.List userTags;
+
+    @Param(required = false)
+    public String sessionId;
+
+    @Param(required = false)
+    public String accessKeyId;
+
+    @Param(required = false)
+    public String accessKeySecret;
+
+    @Param(required = false)
+    public String requestIp;
+
+    @NonAPIParam
+    public long timeout = -1;
+
+    @NonAPIParam
+    public long pollingInterval = -1;
+
+
+    private Result makeResult(ApiResult res) {
+        Result ret = new Result();
+        if (res.error != null) {
+            ret.error = res.error;
+            return ret;
+        }
+
+        org.zstack.sdk.UpdateDnsRecordToVpcRouterResult value = res.getResult(org.zstack.sdk.UpdateDnsRecordToVpcRouterResult.class);
+        ret.value = value == null ? new org.zstack.sdk.UpdateDnsRecordToVpcRouterResult() : value;
+
+        return ret;
+    }
+
+    public Result call() {
+        ApiResult res = ZSClient.call(this);
+        return makeResult(res);
+    }
+
+    public void call(final Completion<Result> completion) {
+        ZSClient.call(this, new InternalCompletion() {
+            @Override
+            public void complete(ApiResult res) {
+                completion.complete(makeResult(res));
+            }
+        });
+    }
+
+    protected Map<String, Parameter> getParameterMap() {
+        return parameterMap;
+    }
+
+    protected Map<String, Parameter> getNonAPIParameterMap() {
+        return nonAPIParameterMap;
+    }
+
+    protected RestInfo getRestInfo() {
+        RestInfo info = new RestInfo();
+        info.httpMethod = "PUT";
+        info.path = "/vpc/virtual-routers/dns-record/{uuid}";
+        info.needSession = true;
+        info.needPoll = true;
+        info.parameterName = "updateDnsRecordToVpcRouter";
+        return info;
+    }
+
+}

--- a/sdk/src/main/java/org/zstack/sdk/UpdateDnsRecordToVpcRouterResult.java
+++ b/sdk/src/main/java/org/zstack/sdk/UpdateDnsRecordToVpcRouterResult.java
@@ -1,0 +1,14 @@
+package org.zstack.sdk;
+
+import org.zstack.sdk.VpcRouterDnsRecordInventory;
+
+public class UpdateDnsRecordToVpcRouterResult {
+    public VpcRouterDnsRecordInventory inventory;
+    public void setInventory(VpcRouterDnsRecordInventory inventory) {
+        this.inventory = inventory;
+    }
+    public VpcRouterDnsRecordInventory getInventory() {
+        return this.inventory;
+    }
+
+}

--- a/sdk/src/main/java/org/zstack/sdk/VpcRouterDnsRecordInventory.java
+++ b/sdk/src/main/java/org/zstack/sdk/VpcRouterDnsRecordInventory.java
@@ -1,0 +1,71 @@
+package org.zstack.sdk;
+
+
+
+public class VpcRouterDnsRecordInventory  {
+
+    public java.lang.Long id;
+    public void setId(java.lang.Long id) {
+        this.id = id;
+    }
+    public java.lang.Long getId() {
+        return this.id;
+    }
+
+    public java.lang.String uuid;
+    public void setUuid(java.lang.String uuid) {
+        this.uuid = uuid;
+    }
+    public java.lang.String getUuid() {
+        return this.uuid;
+    }
+
+    public java.lang.String vpcRouterUuid;
+    public void setVpcRouterUuid(java.lang.String vpcRouterUuid) {
+        this.vpcRouterUuid = vpcRouterUuid;
+    }
+    public java.lang.String getVpcRouterUuid() {
+        return this.vpcRouterUuid;
+    }
+
+    public java.lang.String vpcHaGroupUuid;
+    public void setVpcHaGroupUuid(java.lang.String vpcHaGroupUuid) {
+        this.vpcHaGroupUuid = vpcHaGroupUuid;
+    }
+    public java.lang.String getVpcHaGroupUuid() {
+        return this.vpcHaGroupUuid;
+    }
+
+    public java.lang.String domain;
+    public void setDomain(java.lang.String domain) {
+        this.domain = domain;
+    }
+    public java.lang.String getDomain() {
+        return this.domain;
+    }
+
+    public java.lang.String ip;
+    public void setIp(java.lang.String ip) {
+        this.ip = ip;
+    }
+    public java.lang.String getIp() {
+        return this.ip;
+    }
+
+    public java.sql.Timestamp createDate;
+    public void setCreateDate(java.sql.Timestamp createDate) {
+        this.createDate = createDate;
+    }
+    public java.sql.Timestamp getCreateDate() {
+        return this.createDate;
+    }
+
+    public java.sql.Timestamp lastOpDate;
+    public void setLastOpDate(java.sql.Timestamp lastOpDate) {
+        this.lastOpDate = lastOpDate;
+    }
+    public java.sql.Timestamp getLastOpDate() {
+        return this.lastOpDate;
+    }
+
+}

--- a/sdk/src/main/java/org/zstack/sdk/VpcRouterVmInventory.java
+++ b/sdk/src/main/java/org/zstack/sdk/VpcRouterVmInventory.java
@@ -12,6 +12,14 @@ public class VpcRouterVmInventory extends org.zstack.sdk.VirtualRouterVmInventor
         return this.dns;
     }
 
+    public java.util.List dnsRecords;
+    public void setDnsRecords(java.util.List dnsRecords) {
+        this.dnsRecords = dnsRecords;
+    }
+    public java.util.List getDnsRecords() {
+        return this.dnsRecords;
+    }
+
     public java.util.List haRef;
     public void setHaRef(java.util.List haRef) {
         this.haRef = haRef;

--- a/testlib/src/main/java/org/zstack/testlib/ApiHelper.groovy
+++ b/testlib/src/main/java/org/zstack/testlib/ApiHelper.groovy
@@ -56076,5 +56076,106 @@ abstract class ApiHelper {
         }
     }
 
+    def addDnsRecordToVpcRouter(@DelegatesTo(strategy = Closure.OWNER_FIRST, value = org.zstack.sdk.AddDnsRecordToVpcRouterAction.class) Closure c) {
+        def a = new org.zstack.sdk.AddDnsRecordToVpcRouterAction()
+        a.sessionId = Test.currentEnvSpec?.session?.uuid
+        c.resolveStrategy = Closure.OWNER_FIRST
+        c.delegate = a
+        c()
+
+        if (System.getProperty("apipath") != null) {
+            if (a.apiId == null) {
+                a.apiId = Platform.uuid
+            }
+
+            def tracker = new ApiPathTracker(a.apiId)
+            def out = errorOut(a.call())
+            def path = tracker.getApiPath()
+            if (!path.isEmpty()) {
+                Test.apiPaths[a.class.name] = path.join(" --->\n")
+            }
+
+            return out
+        } else {
+            return errorOut(a.call())
+        }
+    }
+
+    def removeDnsRecordFromVpcRouter(@DelegatesTo(strategy = Closure.OWNER_FIRST, value = org.zstack.sdk.RemoveDnsRecordFromVpcRouterAction.class) Closure c) {
+        def a = new org.zstack.sdk.RemoveDnsRecordFromVpcRouterAction()
+        a.sessionId = Test.currentEnvSpec?.session?.uuid
+        c.resolveStrategy = Closure.OWNER_FIRST
+        c.delegate = a
+        c()
+
+        if (System.getProperty("apipath") != null) {
+            if (a.apiId == null) {
+                a.apiId = Platform.uuid
+            }
+
+            def tracker = new ApiPathTracker(a.apiId)
+            def out = errorOut(a.call())
+            def path = tracker.getApiPath()
+            if (!path.isEmpty()) {
+                Test.apiPaths[a.class.name] = path.join(" --->\n")
+            }
+
+            return out
+        } else {
+            return errorOut(a.call())
+        }
+    }
+
+    def updateDnsRecordToVpcRouter(@DelegatesTo(strategy = Closure.OWNER_FIRST, value = org.zstack.sdk.UpdateDnsRecordToVpcRouterAction.class) Closure c) {
+        def a = new org.zstack.sdk.UpdateDnsRecordToVpcRouterAction()
+        a.sessionId = Test.currentEnvSpec?.session?.uuid
+        c.resolveStrategy = Closure.OWNER_FIRST
+        c.delegate = a
+        c()
+
+        if (System.getProperty("apipath") != null) {
+            if (a.apiId == null) {
+                a.apiId = Platform.uuid
+            }
+
+            def tracker = new ApiPathTracker(a.apiId)
+            def out = errorOut(a.call())
+            def path = tracker.getApiPath()
+            if (!path.isEmpty()) {
+                Test.apiPaths[a.class.name] = path.join(" --->\n")
+            }
+
+            return out
+        } else {
+            return errorOut(a.call())
+        }
+    }
+
+    def getVpcRouterDnsRecord(@DelegatesTo(strategy = Closure.OWNER_FIRST, value = org.zstack.sdk.QueryVpcRouterDnsRecordAction.class) Closure c) {
+        def a = new org.zstack.sdk.QueryVpcRouterDnsRecordAction()
+        a.sessionId = Test.currentEnvSpec?.session?.uuid
+        c.resolveStrategy = Closure.OWNER_FIRST
+        c.delegate = a
+        c()
+
+        a.conditions = a.conditions.collect { it.toString() }
+
+        if (System.getProperty("apipath") != null) {
+            if (a.apiId == null) {
+                a.apiId = Platform.uuid
+            }
+
+            def tracker = new ApiPathTracker(a.apiId)
+            def out = errorOut(a.call())
+            def path = tracker.getApiPath()
+            if (!path.isEmpty()) {
+                Test.apiPaths[a.class.name] = path.join(" --->\n")
+            }
+
+            return out
+        } else {
+            return errorOut(a.call())
+        }
+    }
 
 }

--- a/utils/src/main/java/org/zstack/utils/network/NetworkUtils.java
+++ b/utils/src/main/java/org/zstack/utils/network/NetworkUtils.java
@@ -25,6 +25,9 @@ import static org.zstack.utils.network.IPv6NetworkUtils.isIpv6UnicastAddress;
 public class NetworkUtils {
     private static final CLogger logger = Utils.getLogger(NetworkUtils.class);
 
+    private static final int MAX_DOMAIN_NAME_LENGTH = 253;
+    private static final int MAX_DOMAIN_NAME_LABEL_LENGTH = 63;
+
     private static final Map<String, Integer> validNetmasks = new HashMap<String, Integer>();
 
     private static final Random random = new Random();
@@ -73,6 +76,20 @@ public class NetworkUtils {
         Pattern pattern = Pattern.compile(PATTERN);
         Matcher matcher = pattern.matcher(hostname);
         return matcher.matches();
+    }
+
+    public static boolean isDomainName(String domainName) {
+        if (domainName == null || domainName.length() > MAX_DOMAIN_NAME_LENGTH || !isHostname(domainName)) {
+            return false;
+        }
+
+        for (String label : domainName.split("\\.")) {
+            if (label.length() > MAX_DOMAIN_NAME_LABEL_LENGTH) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     public static boolean isIpv4Address(String ip) {
@@ -972,4 +989,3 @@ public class NetworkUtils {
         return diff > 0 ? 1 : diff == 0 ? 0 : -1;
     }
 }
-

--- a/utils/src/test/java/org/zstack/utils/test/TestNetworkUtils.java
+++ b/utils/src/test/java/org/zstack/utils/test/TestNetworkUtils.java
@@ -4,6 +4,9 @@ import org.junit.Test;
 import org.omg.PortableInterceptor.SYSTEM_EXCEPTION;
 import org.zstack.utils.network.NetworkUtils;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 public class TestNetworkUtils {
     @Test
     public void test() {
@@ -35,5 +38,23 @@ public class TestNetworkUtils {
         System.out.println(String.format("%s %s", hname, NetworkUtils.isHostname(hname)));
         hname = "hostname.zstack.org";
         System.out.println(String.format("%s %s", hname, NetworkUtils.isHostname(hname)));
+    }
+
+    @Test
+    public void testDomainName() {
+        assertTrue(NetworkUtils.isDomainName("db.prod.local"));
+        assertTrue(NetworkUtils.isDomainName("app-1.internal"));
+        assertTrue(NetworkUtils.isDomainName("localhost"));
+
+        assertFalse(NetworkUtils.isDomainName(null));
+        assertFalse(NetworkUtils.isDomainName("*.app.local"));
+        assertFalse(NetworkUtils.isDomainName("db_prod.local"));
+        assertFalse(NetworkUtils.isDomainName("中文.local"));
+        assertFalse(NetworkUtils.isDomainName(".prod.local"));
+        assertFalse(NetworkUtils.isDomainName("prod.local."));
+        assertFalse(NetworkUtils.isDomainName("-db.prod.local"));
+        assertFalse(NetworkUtils.isDomainName("db-.prod.local"));
+        assertFalse(NetworkUtils.isDomainName(new String(new char[64]).replace('\0', 'a') + ".local"));
+        assertFalse(NetworkUtils.isDomainName(new String(new char[254]).replace('\0', 'a')));
     }
 }


### PR DESCRIPTION
## Summary\n- Restore VPC router DNS record SDK and schema on 5.4.7-nexavm.\n- Keep schema creation in V5.4.7.1 after the earlier revert.\n\n## Cherry-pick Source\n- 54cc7f95cba11bd660309970ac72dd82caab0271\n- 5641744e1c0ee9a092e61aabfb1a8be8d98f25ee\n\n## Verification\n- mvn clean install -DskipTests\n- MN upgrade validation\n\n## Jira\nResolves: ZSTAC-85249

sync from gitlab !10076