### PR TITLE
<feature>[license]: manage license server lifecycle

### DIFF
--- a/conf/springConfigXml/externalService.xml
+++ b/conf/springConfigXml/externalService.xml
@@ -18,4 +18,10 @@
             <zstack:extension interface="org.zstack.header.Service"/>
         </zstack:plugin>
     </bean>
+
+    <bean id="ExternalLicenseServer" class="org.zstack.externalservice.licenseserver.LicenseServerExternalService">
+        <zstack:plugin>
+            <zstack:extension interface="org.zstack.header.managementnode.ManagementNodeReadyExtensionPoint"/>
+        </zstack:plugin>
+    </bean>
 </beans>

--- a/externalservice/src/main/java/org/zstack/externalservice/licenseserver/LicenseServerExternalService.java
+++ b/externalservice/src/main/java/org/zstack/externalservice/licenseserver/LicenseServerExternalService.java
@@ -1,0 +1,114 @@
+package org.zstack.externalservice.licenseserver;
+
+import org.zstack.core.Platform;
+import org.zstack.core.CoreGlobalProperty;
+import org.zstack.core.externalservice.AbstractLocalExternalSystemdService;
+import org.zstack.core.externalservice.ExternalService;
+import org.zstack.core.externalservice.ExternalServiceManager;
+import org.zstack.core.externalservice.ExternalServiceCapabilitiesBuilder;
+import org.zstack.header.core.external.service.ExternalServiceCapabilities;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.zstack.header.managementnode.ManagementNodeReadyExtensionPoint;
+import org.zstack.utils.Utils;
+import org.zstack.utils.logging.CLogger;
+
+import java.io.File;
+
+public class LicenseServerExternalService extends AbstractLocalExternalSystemdService implements ManagementNodeReadyExtensionPoint {
+    private static final CLogger logger = Utils.getLogger(LicenseServerExternalService.class);
+
+    public static final String SYSTEMD_SERVICE_NAME = "zstack-license-server.service";
+    public static final String SERVICE_TYPE = "LicenseServer";
+
+    @Autowired
+    private ExternalServiceManager externalServiceManager;
+
+    private final ExternalServiceCapabilities capabilities = ExternalServiceCapabilitiesBuilder
+            .build()
+            .reloadConfig(false);
+
+    @Override
+    public void managementNodeReady() {
+        if (CoreGlobalProperty.UNIT_TEST_ON) {
+            return;
+        }
+
+        if (!isInstalled()) {
+            logger.warn(String.format("[External Service] %s is not installed, skip registering it", getName()));
+            return;
+        }
+
+        try {
+            ExternalService service = externalServiceManager.getService(getName(), () -> this);
+            service.start();
+        } catch (Exception t) {
+            logger.warn(String.format("[External Service] failed to start %s", getName()), t);
+        }
+    }
+
+    @Override
+    protected String[] getCommandLineKeywords() {
+        return new String[] {"zstack-license-server", "--config"};
+    }
+
+    @Override
+    public String getName() {
+        return String.format("license-server-on-machine-%s", Platform.getManagementServerIp());
+    }
+
+    @Override
+    public String getServiceType() {
+        return SERVICE_TYPE;
+    }
+
+    @Override
+    public String getSystemdServiceName() {
+        return SYSTEMD_SERVICE_NAME;
+    }
+
+    @Override
+    public void start() {
+        if (!isInstalled()) {
+            logger.warn(String.format("[External Service] %s is not installed, skip starting it", getName()));
+            return;
+        }
+
+        if (isAlive()) {
+            logger.debug(String.format("[External Service] %s is already running", getName()));
+            return;
+        }
+
+        sysctl("start");
+        logger.debug(String.format("[External Service] started %s", getName()));
+    }
+
+    @Override
+    public void stop() {
+        logger.debug(String.format("[External Service] skip stopping %s, it is managed independently", getName()));
+    }
+
+    @Override
+    public void restart() {
+        start();
+    }
+
+    @Override
+    public boolean isAlive() {
+        return getPID() != null;
+    }
+
+    @Override
+    public ExternalServiceCapabilities getExternalServiceCapabilities() {
+        return capabilities;
+    }
+
+    @Override
+    public void reload() {
+        logger.debug(String.format("[External Service] %s does not support reload config", getName()));
+    }
+
+    private boolean isInstalled() {
+        return new File("/usr/lib/systemd/system/" + SYSTEMD_SERVICE_NAME).exists()
+                || new File("/etc/systemd/system/" + SYSTEMD_SERVICE_NAME).exists();
+    }
+}


### PR DESCRIPTION
## Summary
- register License Server as a local ExternalService on each management node
- start License Server after the management node reaches `managementNodeReady`
- keep `stop()` as a no-op so ZStack does not stop the License Server process
- expose License Server status through `GetExternalServices`
- register License Server manager in existing `springConfigXml/externalService.xml` and avoid adding/overwriting `springConfigXml/licenseServer.xml`

## Validation
- created changes in a dedicated worktree: `/Users/wushan/zstack/zstack-license-server-external-worktree`
- `JAVA_HOME=/Users/wushan/Library/Java/JavaVirtualMachines/corretto-1.8.0_372/Contents/Home mvn -pl externalservice -am -DskipTests compile`
- `git diff --check`
- verified the MR no longer creates `conf/springConfigXml/licenseServer.xml`, so premium's existing `licenseServer.xml` keeps its `LicenseClientUsageGetterImpl` bean

## Notes
- If `zstack-license-server.service` is not installed, management node startup only logs and skips starting License Server.
- License Server reload config is not supported; capability is reported as `reloadConfig=false`.
- The previous version of this MR created a same-name `springConfigXml/licenseServer.xml`; that conflicted with premium and caused `LicenseClientUsageGetter` bean injection failure. This has been fixed by moving the bean into `externalService.xml`.

sync from gitlab !10132