### PR TITLE
Draft: <feature>[core]: Add external service configuration APIs

### DIFF
--- a/conf/db/zsv/V5.1.0__schema.sql
+++ b/conf/db/zsv/V5.1.0__schema.sql
@@ -132,3 +132,16 @@ CREATE TABLE IF NOT EXISTS `zstack`.`LogServerVO` (
     `createDate` timestamp NOT NULL DEFAULT '1999-12-31 23:59:59',
     PRIMARY KEY  (`uuid`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+-- Feature: External Service Configuration
+
+CREATE TABLE IF NOT EXISTS `zstack`.`ExternalServiceConfigurationVO` (
+    `uuid` varchar(32) NOT NULL UNIQUE,
+    `serviceType` varchar(32) NOT NULL,
+    `configuration` text DEFAULT NULL,
+    `description` varchar(2048) DEFAULT NULL,
+    `lastOpDate` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    `createDate` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (`uuid`),
+    UNIQUE KEY `ukExternalServiceConfigurationVOServiceType` (`serviceType`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;

--- a/conf/persistence.xml
+++ b/conf/persistence.xml
@@ -225,5 +225,6 @@
         <class>org.zstack.header.vm.metadata.VmMetadataDirtyVO</class>
         <class>org.zstack.header.vm.metadata.VmMetadataFlushStateVO</class>
         <class>org.zstack.log.server.LogServerVO</class>
+        <class>org.zstack.header.core.external.service.ExternalServiceConfigurationVO</class>
     </persistence-unit>
 </persistence>

--- a/conf/serviceConfig/externalService.xml
+++ b/conf/serviceConfig/externalService.xml
@@ -9,4 +9,21 @@
     <message>
         <name>org.zstack.header.core.external.service.APIReloadExternalServiceMsg</name>
     </message>
+
+    <message>
+        <name>org.zstack.header.core.external.service.APIAddExternalServiceConfigurationMsg</name>
+    </message>
+
+    <message>
+        <name>org.zstack.header.core.external.service.APIQueryExternalServiceConfigurationMsg</name>
+        <serviceId>query</serviceId>
+    </message>
+
+    <message>
+        <name>org.zstack.header.core.external.service.APIUpdateExternalServiceConfigurationMsg</name>
+    </message>
+
+    <message>
+        <name>org.zstack.header.core.external.service.APIDeleteExternalServiceConfigurationMsg</name>
+    </message>
 </service>

--- a/core/src/main/java/org/zstack/core/externalservice/ExternalService.java
+++ b/core/src/main/java/org/zstack/core/externalservice/ExternalService.java
@@ -16,4 +16,12 @@ public interface ExternalService {
     ExternalServiceCapabilities getExternalServiceCapabilities();
 
     void reload();
+
+    default String getServiceType() {
+        return getName();
+    }
+
+    default void externalConfig(String serviceType) {
+        // no-op by default
+    }
 }

--- a/core/src/main/java/org/zstack/core/externalservice/ExternalServiceManagerImpl.java
+++ b/core/src/main/java/org/zstack/core/externalservice/ExternalServiceManagerImpl.java
@@ -1,19 +1,36 @@
 package org.zstack.core.externalservice;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.zstack.core.CoreGlobalProperty;
+import org.zstack.core.GlobalProperty;
+import org.zstack.core.Platform;
+import org.zstack.core.asyncbatch.While;
 import org.zstack.core.cloudbus.CloudBus;
+import org.zstack.core.cloudbus.CloudBusCallBack;
+import org.zstack.core.db.DatabaseFacade;
+import org.zstack.core.db.Q;
+import org.zstack.core.thread.ChainTask;
+import org.zstack.core.thread.SyncTaskChain;
+import org.zstack.core.thread.ThreadFacade;
+import org.zstack.core.workflow.SimpleFlowChain;
 import org.zstack.header.AbstractService;
-import org.zstack.header.core.external.service.APIGetExternalServicesMsg;
-import org.zstack.header.core.external.service.APIGetExternalServicesReply;
-import org.zstack.header.core.external.service.APIReloadExternalServiceEvent;
-import org.zstack.header.core.external.service.APIReloadExternalServiceMsg;
-import org.zstack.header.core.external.service.ExternalServiceInventory;
-import org.zstack.header.core.external.service.ExternalServiceStatus;
+import org.zstack.header.core.Completion;
+import org.zstack.header.core.ReturnValueCompletion;
+import org.zstack.header.core.WhileDoneCompletion;
+import org.zstack.header.core.external.service.*;
+import org.zstack.header.core.workflow.*;
+import org.zstack.header.errorcode.ErrorCode;
+import org.zstack.header.errorcode.ErrorCodeList;
 import org.zstack.header.errorcode.OperationFailureException;
+import org.zstack.header.managementnode.ManagementNodeVO;
+import org.zstack.header.managementnode.ManagementNodeVO_;
 import org.zstack.header.message.APIMessage;
 import org.zstack.header.message.Message;
+import org.zstack.header.message.MessageReply;
 
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Supplier;
@@ -23,6 +40,10 @@ import static org.zstack.core.Platform.operr;
 public class ExternalServiceManagerImpl extends AbstractService implements ExternalServiceManager {
     @Autowired
     public CloudBus bus;
+    @Autowired
+    private DatabaseFacade dbf;
+    @Autowired
+    private ThreadFacade thdf;
 
     private final Map<String, ExternalService> services = new ConcurrentHashMap<>();
 
@@ -71,8 +92,8 @@ public class ExternalServiceManagerImpl extends AbstractService implements Exter
     public void handleMessage(Message msg) {
         if (msg instanceof APIMessage) {
             handleApiMessage((APIMessage) msg);
-        } else {
-            bus.dealWithUnknownMessage(msg);
+        }  else {
+            handleLocalMessage(msg);
         }
     }
 
@@ -81,6 +102,20 @@ public class ExternalServiceManagerImpl extends AbstractService implements Exter
             handle((APIGetExternalServicesMsg) msg);
         } else if (msg instanceof APIReloadExternalServiceMsg) {
             handle((APIReloadExternalServiceMsg) msg);
+        } else if (msg instanceof APIAddExternalServiceConfigurationMsg){
+            handle((APIAddExternalServiceConfigurationMsg) msg);
+        } else if (msg instanceof APIUpdateExternalServiceConfigurationMsg) {
+            handle((APIUpdateExternalServiceConfigurationMsg) msg);
+        } else if (msg instanceof APIDeleteExternalServiceConfigurationMsg) {
+            handle((APIDeleteExternalServiceConfigurationMsg) msg);
+        } else {
+            bus.dealWithUnknownMessage(msg);
+        }
+    }
+
+    private void handleLocalMessage(Message msg) {
+        if (msg instanceof ApplyExternalServiceConfigurationMsg) {
+            handle((ApplyExternalServiceConfigurationMsg) msg);
         } else {
             bus.dealWithUnknownMessage(msg);
         }
@@ -117,10 +152,368 @@ public class ExternalServiceManagerImpl extends AbstractService implements Exter
             inv.setName(name);
             inv.setStatus(service.isAlive() ? ExternalServiceStatus.RUNNING.toString() : ExternalServiceStatus.STOPPED.toString());
             inv.setCapabilities(service.getExternalServiceCapabilities());
+            inv.setServiceType(service.getServiceType());
             reply.getInventories().add(inv);
         });
 
         bus.reply(msg, reply);
+    }
+
+    private void handle(APIAddExternalServiceConfigurationMsg msg ){
+        APIAddExternalServiceConfigurationEvent event = new APIAddExternalServiceConfigurationEvent(msg.getId());
+
+        thdf.chainSubmit(new ChainTask(msg) {
+            @Override
+            public void run(SyncTaskChain chain) {
+                createExternalServiceConfiguration(msg, event, new Completion(chain) {
+                    @Override
+                    public void success() {
+                        bus.publish(event);
+                        chain.next();
+                    }
+
+                    @Override
+                    public void fail(ErrorCode errorCode) {
+                        event.setError(errorCode);
+                        bus.publish(event);
+                        chain.next();
+                    }
+                });
+            }
+
+            @Override
+            public String getSyncSignature() {
+                return String.format("create-update-delete-external-service-configuration-%s", msg.getExternalServiceType());
+            }
+
+            @Override
+            public String getName() {
+                return String.format("create-external-service-configuration-type-%s", msg.getExternalServiceType());
+            }
+        });
+
+    }
+
+    private void createExternalServiceConfiguration(APIAddExternalServiceConfigurationMsg msg, APIAddExternalServiceConfigurationEvent evt, Completion completion) {
+        if (!hasRegisteredServiceType(msg.getExternalServiceType())) {
+            completion.fail(operr("unable to find external service type [%s]", msg.getExternalServiceType()));
+            return;
+        }
+        if (Q.New(ExternalServiceConfigurationVO.class)
+                .eq(ExternalServiceConfigurationVO_.serviceType, msg.getExternalServiceType())
+                .count() > 0) {
+            completion.fail(operr("external service configuration for type [%s] already exists", msg.getExternalServiceType()));
+            return;
+        }
+
+        // create db record
+        ExternalServiceConfigurationVO configurationVO = new ExternalServiceConfigurationVO();
+        configurationVO.setUuid(msg.getResourceUuid() != null ? msg.getResourceUuid() : Platform.getUuid());
+        configurationVO.setServiceType(msg.getExternalServiceType());
+        configurationVO.setConfiguration(msg.getConfiguration());
+        configurationVO.setDescription(msg.getDescription());
+        configurationVO = dbf.persistAndRefresh(configurationVO);
+
+        ExternalServiceConfigurationInventory inv = ExternalServiceConfigurationInventory.valueOf(configurationVO);
+        evt.setInventory(inv);
+        final String uuid = configurationVO.getUuid();
+        final String serviceType = configurationVO.getServiceType();
+
+        applyExternalServiceConfigurationToAllNodes(serviceType, new ReturnValueCompletion<List<ApplyExternalConfigurationResult>>(completion) {
+            @Override
+            public void success(List<ApplyExternalConfigurationResult> returnValue) {
+                inv.setApplyResults(returnValue);
+                evt.setInventory(inv);
+                ErrorCode errorCode = firstFailure(returnValue);
+                if (errorCode != null) {
+                    rollbackCreatedExternalServiceConfiguration(uuid, serviceType, errorCode, completion);
+                    return;
+                }
+                completion.success();
+            }
+
+            @Override
+            public void fail(ErrorCode errorCode) {
+                rollbackCreatedExternalServiceConfiguration(uuid, serviceType, errorCode, completion);
+            }
+        });
+    }
+
+    private void rollbackCreatedExternalServiceConfiguration(String uuid, String serviceType, ErrorCode originalError, Completion completion) {
+        dbf.removeByPrimaryKey(uuid, ExternalServiceConfigurationVO.class);
+        applyExternalServiceConfigurationToAllNodes(serviceType, new ReturnValueCompletion<List<ApplyExternalConfigurationResult>>(completion) {
+            @Override
+            public void success(List<ApplyExternalConfigurationResult> returnValue) {
+                completion.fail(originalError);
+            }
+
+            @Override
+            public void fail(ErrorCode rollbackError) {
+                completion.fail(originalError);
+            }
+        });
+    }
+
+    private void handle(APIUpdateExternalServiceConfigurationMsg msg){
+        APIUpdateExternalServiceConfigurationEvent event = new APIUpdateExternalServiceConfigurationEvent(msg.getId());
+        ExternalServiceConfigurationVO vo = dbf.findByUuid(msg.getUuid(), ExternalServiceConfigurationVO.class);
+        final String syncKey = vo != null ? vo.getServiceType() : msg.getUuid();
+
+        thdf.chainSubmit(new ChainTask(msg) {
+            @Override
+            public void run(SyncTaskChain chain) {
+                updateExternalServiceConfiguration(msg, event, new Completion(chain) {
+                    @Override
+                    public void success() {
+                        bus.publish(event);
+                        chain.next();
+                    }
+
+                    @Override
+                    public void fail(ErrorCode errorCode) {
+                        event.setError(errorCode);
+                        bus.publish(event);
+                        chain.next();
+                    }
+                });
+            }
+
+            @Override
+            public String getSyncSignature() {
+                return String.format("create-update-delete-external-service-configuration-%s", syncKey);
+            }
+
+            @Override
+            public String getName() {
+                return String.format("update-external-service-configuration-%s", msg.getUuid());
+            }
+        });
+    }
+
+    private void updateExternalServiceConfiguration(APIUpdateExternalServiceConfigurationMsg msg, APIUpdateExternalServiceConfigurationEvent evt, Completion completion) {
+        ExternalServiceConfigurationVO vo = dbf.findByUuid(msg.getUuid(), ExternalServiceConfigurationVO.class);
+
+        if (vo == null) {
+            completion.fail(operr("unable to find external service configuration with uuid [%s]", msg.getUuid()));
+            return;
+        }
+
+        if (msg.getDescription() != null) {
+            vo.setDescription(msg.getDescription());
+            vo = dbf.updateAndRefresh(vo);
+        }
+
+        ExternalServiceConfigurationInventory inv = ExternalServiceConfigurationInventory.valueOf(vo);
+        evt.setInventory(inv);
+        completion.success();
+    }
+
+    private void handle(APIDeleteExternalServiceConfigurationMsg msg) {
+        APIDeleteExternalServiceConfigurationEvent event = new APIDeleteExternalServiceConfigurationEvent(msg.getId());
+        ExternalServiceConfigurationVO vo = dbf.findByUuid(msg.getUuid(), ExternalServiceConfigurationVO.class);
+        final String syncKey = vo != null ? vo.getServiceType() : msg.getUuid();
+
+        thdf.chainSubmit(new ChainTask(msg) {
+            @Override
+            public void run(SyncTaskChain chain) {
+                deleteExternalServiceConfiguration(msg, event, new Completion(chain) {
+                    @Override
+                    public void success() {
+                        bus.publish(event);
+                        chain.next();
+                    }
+
+                    @Override
+                    public void fail(ErrorCode errorCode) {
+                        event.setError(errorCode);
+                        bus.publish(event);
+                        chain.next();
+                    }
+                });
+            }
+
+            @Override
+            public String getSyncSignature() {
+                return String.format("create-update-delete-external-service-configuration-%s", syncKey);
+            }
+
+            @Override
+            public String getName() {
+                return String.format("delete-external-service-configuration-%s", msg.getUuid());
+            }
+        });
+    }
+
+    private void deleteExternalServiceConfiguration(APIDeleteExternalServiceConfigurationMsg msg, APIDeleteExternalServiceConfigurationEvent evt, Completion completion) {
+        // delete db record
+        ExternalServiceConfigurationVO vo = dbf.findByUuid(msg.getUuid(), ExternalServiceConfigurationVO.class);
+        String serviceType;
+        if (vo != null) {
+            serviceType = vo.getServiceType();
+            dbf.remove(vo);
+        } else {
+            completion.success();
+            return;
+        }
+
+        applyExternalServiceConfigurationToAllNodes(serviceType, new ReturnValueCompletion<List<ApplyExternalConfigurationResult>>(completion) {
+            @Override
+            public void success(List<ApplyExternalConfigurationResult> returnValue) {
+                evt.setApplyResults(returnValue);
+                ErrorCode errorCode = firstFailure(returnValue);
+                if (errorCode != null) {
+                    rollbackDeletedExternalServiceConfiguration(vo, serviceType, errorCode, completion);
+                    return;
+                }
+                completion.success();
+            }
+
+            @Override
+            public void fail(ErrorCode errorCode) {
+                rollbackDeletedExternalServiceConfiguration(vo, serviceType, errorCode, completion);
+            }
+        });
+    }
+
+    private void rollbackDeletedExternalServiceConfiguration(ExternalServiceConfigurationVO vo, String serviceType,
+            ErrorCode originalError, Completion completion) {
+        dbf.persist(copyExternalServiceConfigurationVO(vo));
+        applyExternalServiceConfigurationToAllNodes(serviceType, new ReturnValueCompletion<List<ApplyExternalConfigurationResult>>(completion) {
+            @Override
+            public void success(List<ApplyExternalConfigurationResult> returnValue) {
+                completion.fail(originalError);
+            }
+
+            @Override
+            public void fail(ErrorCode rollbackError) {
+                completion.fail(originalError);
+            }
+        });
+    }
+
+    private ExternalServiceConfigurationVO copyExternalServiceConfigurationVO(ExternalServiceConfigurationVO vo) {
+        // The original VO may have been removed from Hibernate's persistence context; re-persist a clean instance.
+        ExternalServiceConfigurationVO copy = new ExternalServiceConfigurationVO();
+        copy.setUuid(vo.getUuid());
+        copy.setServiceType(vo.getServiceType());
+        copy.setConfiguration(vo.getConfiguration());
+        copy.setDescription(vo.getDescription());
+        copy.setCreateDate(vo.getCreateDate());
+        copy.setLastOpDate(vo.getLastOpDate());
+        return copy;
+    }
+
+    private ErrorCode firstFailure(List<ApplyExternalConfigurationResult> results) {
+        for (ApplyExternalConfigurationResult result : results) {
+            if (!result.isSuccess()) {
+                return result.getErrorCode() != null ? result.getErrorCode() :
+                        operr("failed to apply external service configuration on management node [%s]", result.getManagementNodeUuid());
+            }
+        }
+        return null;
+    }
+
+    private boolean hasRegisteredServiceType(String serviceType) {
+        for (ExternalService service : services.values()) {
+            if (serviceType.equals(service.getServiceType())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private void applyExternalServiceConfigurationToAllNodes(String serviceType, ReturnValueCompletion<List<ApplyExternalConfigurationResult>> completion) {
+        final List<ApplyExternalConfigurationResult> results = Collections.synchronizedList(new ArrayList<>());
+
+        FlowChain chain = new SimpleFlowChain();
+        chain.setName("apply-external-service-configuration-to-all-nodes");
+        chain.then(new Flow() {
+            String __name__ = "apply-external-service-configuration";
+
+            @Override
+            public void run(FlowTrigger trigger, Map data) {
+                List<String> mnUuids = Q.New(ManagementNodeVO.class).select(ManagementNodeVO_.uuid).listValues();
+
+                new While<>(mnUuids).each((mnUuid, whileCompletion) -> {
+                    ApplyExternalServiceConfigurationMsg amsg = new ApplyExternalServiceConfigurationMsg();
+                    amsg.setServiceType(serviceType);
+                    bus.makeServiceIdByManagementNodeId(amsg, SERVICE_ID, mnUuid);
+                    bus.send(amsg, new CloudBusCallBack(whileCompletion) {
+                        @Override
+                        public void run(MessageReply reply) {
+                            ApplyExternalConfigurationResult result = new ApplyExternalConfigurationResult();
+                            result.setManagementNodeUuid(mnUuid);
+                            results.add(result);
+
+                            if (!reply.isSuccess()) {
+                                result.setErrorCode(reply.getError());
+                                whileCompletion.done();
+                                return;
+                            }
+                            whileCompletion.done();
+                        }
+                    });
+                }).run(new WhileDoneCompletion(trigger) {
+                    @Override
+                    public void done(ErrorCodeList errorCodeList) {
+                        trigger.next();
+                    }
+                });
+            }
+
+            @Override
+            public void rollback(FlowRollback trigger, Map data) {
+                trigger.rollback();
+            }
+        }).done(new FlowDoneHandler(completion) {
+            @Override
+            public void handle(Map data) {
+                completion.success(new ArrayList<>(results));
+            }
+        }).error(new FlowErrorHandler(completion) {
+            @Override
+            public void handle(ErrorCode errCode, Map data) {
+                completion.fail(errCode);
+            }
+        }).start();
+    }
+
+    private void handle(ApplyExternalServiceConfigurationMsg msg) {
+        ApplyExternalServiceConfigurationReply reply = new ApplyExternalServiceConfigurationReply();
+
+        regenerateExternalServiceConfiguration(msg.getServiceType(), new ReturnValueCompletion<String>(msg) {
+            @Override
+            public void success(String returnValue) {
+                reply.setValue(returnValue);
+                reply.setManagementNodeUuid(Platform.getManagementServerId());
+                bus.reply(msg, reply);
+            }
+
+            @Override
+            public void fail(ErrorCode errorCode) {
+                reply.setError(errorCode);
+                bus.reply(msg, reply);
+            }
+        });
+    }
+
+    private void regenerateExternalServiceConfiguration(String serviceType, ReturnValueCompletion<String> completion) {
+        for (ExternalService service : services.values()) {
+            if (serviceType.equals(service.getServiceType())) {
+                try{
+                    service.externalConfig(serviceType);
+                    completion.success(serviceType);
+                } catch (Exception e) {
+                    completion.fail(operr("failed to apply external service configuration for type [%s]: %s", serviceType, e.getMessage()));
+                }
+                return;
+            }
+        }
+        if (CoreGlobalProperty.UNIT_TEST_ON) {
+            completion.success(serviceType);
+            return;
+        }
+        completion.fail(operr("unable to find external service type [%s]", serviceType));
     }
 
     @Override

--- a/header/src/main/java/org/zstack/header/core/external/service/APIAddExternalServiceConfigurationEvent.java
+++ b/header/src/main/java/org/zstack/header/core/external/service/APIAddExternalServiceConfigurationEvent.java
@@ -1,0 +1,34 @@
+package org.zstack.header.core.external.service;
+
+import org.zstack.header.message.APIEvent;
+import org.zstack.header.rest.RestResponse;
+
+/**
+ * @Author: ya.wang
+ * @Date: 1/15/26 12:48 AM
+ */
+@RestResponse(allTo = "inventory")
+public class APIAddExternalServiceConfigurationEvent extends APIEvent {
+
+    private ExternalServiceConfigurationInventory inventory;
+
+    public APIAddExternalServiceConfigurationEvent() {}
+
+    public APIAddExternalServiceConfigurationEvent(String apiId) { super(apiId);}
+
+    public void setInventory(ExternalServiceConfigurationInventory inventory) {this.inventory = inventory;}
+
+    public ExternalServiceConfigurationInventory getInventory() {return inventory;}
+
+    public static APIAddExternalServiceConfigurationEvent __example__() {
+        APIAddExternalServiceConfigurationEvent event = new APIAddExternalServiceConfigurationEvent();
+        ExternalServiceConfigurationInventory inv = new ExternalServiceConfigurationInventory();
+
+        inv.setUuid(uuid());
+        inv.setServiceType("Prometheus2");
+        inv.setConfiguration("{}");
+        event.setInventory(inv);
+
+        return event;
+    }
+}

--- a/header/src/main/java/org/zstack/header/core/external/service/APIAddExternalServiceConfigurationEventDoc_zh_cn.groovy
+++ b/header/src/main/java/org/zstack/header/core/external/service/APIAddExternalServiceConfigurationEventDoc_zh_cn.groovy
@@ -1,0 +1,32 @@
+package org.zstack.header.core.external.service
+
+import org.zstack.header.core.external.service.ExternalServiceConfigurationInventory
+import org.zstack.header.errorcode.ErrorCode
+
+doc {
+
+	title "添加外部服务配置返回"
+
+	ref {
+		name "inventory"
+		path "org.zstack.header.core.external.service.APIAddExternalServiceConfigurationEvent.inventory"
+		desc "外部服务配置详情"
+		type "ExternalServiceConfigurationInventory"
+		since "5.1.0"
+		clz ExternalServiceConfigurationInventory.class
+	}
+	field {
+		name "success"
+		desc "操作是否成功"
+		type "boolean"
+		since "5.1.0"
+	}
+	ref {
+		name "error"
+		path "org.zstack.header.core.external.service.APIAddExternalServiceConfigurationEvent.error"
+		desc "错误码，若不为null，则表示操作失败, 操作成功时该字段为null",false
+		type "ErrorCode"
+		since "5.1.0"
+		clz ErrorCode.class
+	}
+}

--- a/header/src/main/java/org/zstack/header/core/external/service/APIAddExternalServiceConfigurationMsg.java
+++ b/header/src/main/java/org/zstack/header/core/external/service/APIAddExternalServiceConfigurationMsg.java
@@ -1,0 +1,66 @@
+package org.zstack.header.core.external.service;
+
+import org.springframework.http.HttpMethod;
+import org.zstack.header.message.APICreateMessage;
+import org.zstack.header.message.APIEvent;
+import org.zstack.header.message.APIMessage;
+import org.zstack.header.message.APIParam;
+import org.zstack.header.other.APIAuditor;
+import org.zstack.header.rest.RestRequest;
+
+/**
+ * @Author: ya.wang
+ * @Date: 1/15/26 12:43 AM
+ */
+@RestRequest(
+        path = "/external/service/configuration",
+        method = HttpMethod.POST,
+        parameterName = "params",
+        responseClass = APIAddExternalServiceConfigurationEvent.class
+)
+public class APIAddExternalServiceConfigurationMsg extends APICreateMessage implements APIAuditor {
+    @APIParam
+    private String externalServiceType;
+    @APIParam(maxLength = 65535)
+    private String configuration;
+    @APIParam(maxLength = 2048, required = false)
+    private String description;
+
+    public String getExternalServiceType() {
+        return externalServiceType;
+    }
+
+    public void setExternalServiceType(String externalServiceType) {
+        this.externalServiceType = externalServiceType;
+    }
+
+    public String getConfiguration() {
+        return configuration;
+    }
+
+    public void setConfiguration(String configuration) {
+        this.configuration = configuration;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    @Override
+    public Result audit(APIMessage msg, APIEvent rsp) {
+        APIAddExternalServiceConfigurationEvent evt = (APIAddExternalServiceConfigurationEvent) rsp;
+        return new Result(rsp.isSuccess() ? evt.getInventory().getUuid(): "", ExternalServiceConfigurationVO.class);
+    }
+
+    public static APIAddExternalServiceConfigurationMsg __example__() {
+        APIAddExternalServiceConfigurationMsg msg = new APIAddExternalServiceConfigurationMsg();
+        msg.setExternalServiceType("Prometheus2");
+        msg.setConfiguration("{}");
+        msg.setDescription("description");
+        return msg;
+    }
+}

--- a/header/src/main/java/org/zstack/header/core/external/service/APIAddExternalServiceConfigurationMsgDoc_zh_cn.groovy
+++ b/header/src/main/java/org/zstack/header/core/external/service/APIAddExternalServiceConfigurationMsgDoc_zh_cn.groovy
@@ -1,0 +1,94 @@
+package org.zstack.header.core.external.service
+
+import org.zstack.header.core.external.service.APIAddExternalServiceConfigurationEvent
+
+doc {
+	title "新建外部服务配置"
+
+	category "externalService"
+
+	desc """新建外部服务配置"""
+
+	rest {
+		request {
+			url "POST /v1/external/service/configuration"
+
+			header (Authorization: 'OAuth the-session-uuid')
+
+			clz APIAddExternalServiceConfigurationMsg.class
+
+			desc """"""
+
+			params {
+
+				column {
+					name "externalServiceType"
+					enclosedIn "params"
+					desc "外部服务类型, 例如 Prometheus2"
+					location "body"
+					type "String"
+					optional false
+					since "5.1.0"
+				}
+				column {
+					name "configuration"
+					enclosedIn "params"
+					desc "外部服务配置, 使用 json 格式。若配置中包含 remote_write.basic_auth.password 等凭据，系统会按原文保存，并会在查询外部服务配置时原样返回，请仅通过管理员级接口使用"
+					location "body"
+					type "String"
+					optional false
+					since "5.1.0"
+				}
+				column {
+					name "description"
+					enclosedIn "params"
+					desc "资源的详细描述"
+					location "body"
+					type "String"
+					optional true
+					since "5.1.0"
+				}
+				column {
+					name "resourceUuid"
+					enclosedIn "params"
+					desc "资源UUID"
+					location "body"
+					type "String"
+					optional true
+					since "5.1.0"
+				}
+				column {
+					name "tagUuids"
+					enclosedIn "params"
+					desc "标签UUID列表"
+					location "body"
+					type "List"
+					optional true
+					since "5.1.0"
+				}
+				column {
+					name "systemTags"
+					enclosedIn ""
+					desc "系统标签"
+					location "body"
+					type "List"
+					optional true
+					since "5.1.0"
+				}
+				column {
+					name "userTags"
+					enclosedIn ""
+					desc "用户标签"
+					location "body"
+					type "List"
+					optional true
+					since "5.1.0"
+				}
+			}
+		}
+
+		response {
+			clz APIAddExternalServiceConfigurationEvent.class
+		}
+	}
+}

--- a/header/src/main/java/org/zstack/header/core/external/service/APIDeleteExternalServiceConfigurationEvent.java
+++ b/header/src/main/java/org/zstack/header/core/external/service/APIDeleteExternalServiceConfigurationEvent.java
@@ -1,0 +1,33 @@
+package org.zstack.header.core.external.service;
+
+import org.zstack.header.message.APIEvent;
+import org.zstack.header.rest.RestResponse;
+
+import java.util.List;
+
+/**
+ * @Author: ya.wang
+ * @Date: 1/15/26 1:47 AM
+ */
+@RestResponse
+public class APIDeleteExternalServiceConfigurationEvent extends APIEvent {
+    private List<ApplyExternalConfigurationResult> applyResults;
+
+    public APIDeleteExternalServiceConfigurationEvent() {}
+
+    public APIDeleteExternalServiceConfigurationEvent(String apiId) { super(apiId); }
+
+    public List<ApplyExternalConfigurationResult> getApplyResults() {
+        return applyResults;
+    }
+
+    public void setApplyResults(List<ApplyExternalConfigurationResult> applyResults) {
+        this.applyResults = applyResults;
+    }
+
+    public static APIDeleteExternalServiceConfigurationEvent __example__() {
+        APIDeleteExternalServiceConfigurationEvent event = new APIDeleteExternalServiceConfigurationEvent();
+        event.setSuccess(true);
+        return event;
+    }
+}

--- a/header/src/main/java/org/zstack/header/core/external/service/APIDeleteExternalServiceConfigurationEventDoc_zh_cn.groovy
+++ b/header/src/main/java/org/zstack/header/core/external/service/APIDeleteExternalServiceConfigurationEventDoc_zh_cn.groovy
@@ -1,0 +1,23 @@
+package org.zstack.header.core.external.service
+
+import org.zstack.header.errorcode.ErrorCode
+
+doc {
+
+	title "删除外部服务配置返回"
+
+	field {
+		name "success"
+		desc "操作是否成功"
+		type "boolean"
+		since "5.1.0"
+	}
+	ref {
+		name "error"
+		path "org.zstack.header.core.external.service.APIDeleteExternalServiceConfigurationEvent.error"
+		desc "错误码，若不为null，则表示操作失败, 操作成功时该字段为null",false
+		type "ErrorCode"
+		since "5.1.0"
+		clz ErrorCode.class
+	}
+}

--- a/header/src/main/java/org/zstack/header/core/external/service/APIDeleteExternalServiceConfigurationMsg.java
+++ b/header/src/main/java/org/zstack/header/core/external/service/APIDeleteExternalServiceConfigurationMsg.java
@@ -1,0 +1,42 @@
+package org.zstack.header.core.external.service;
+
+import org.springframework.http.HttpMethod;
+import org.zstack.header.message.APIDeleteMessage;
+import org.zstack.header.message.APIEvent;
+import org.zstack.header.message.APIMessage;
+import org.zstack.header.message.APIParam;
+import org.zstack.header.other.APIAuditor;
+import org.zstack.header.rest.RestRequest;
+
+/**
+ * @Author: ya.wang
+ * @Date: 1/15/26 1:44 AM
+ */
+@RestRequest(
+        path = "/external/service/configuration/{uuid}",
+        responseClass = APIDeleteExternalServiceConfigurationEvent.class,
+        method = HttpMethod.DELETE
+)
+public class APIDeleteExternalServiceConfigurationMsg extends APIDeleteMessage implements APIAuditor {
+    @APIParam(resourceType = ExternalServiceConfigurationVO.class, successIfResourceNotExisting = true)
+    private String uuid;
+
+    public String getUuid() {
+        return uuid;
+    }
+
+    public void setUuid(String uuid) {
+        this.uuid = uuid;
+    }
+
+    @Override
+    public Result audit(APIMessage msg, APIEvent rsp) {
+        return new APIAuditor.Result(((APIDeleteExternalServiceConfigurationMsg)msg).getUuid(), ExternalServiceConfigurationVO.class);
+    }
+
+    public static APIDeleteExternalServiceConfigurationMsg __example__() {
+        APIDeleteExternalServiceConfigurationMsg msg = new APIDeleteExternalServiceConfigurationMsg();
+        msg.setUuid(uuid());
+        return msg;
+    }
+}

--- a/header/src/main/java/org/zstack/header/core/external/service/APIDeleteExternalServiceConfigurationMsgDoc_zh_cn.groovy
+++ b/header/src/main/java/org/zstack/header/core/external/service/APIDeleteExternalServiceConfigurationMsgDoc_zh_cn.groovy
@@ -1,0 +1,67 @@
+package org.zstack.header.core.external.service
+
+import org.zstack.header.core.external.service.APIDeleteExternalServiceConfigurationEvent
+
+doc {
+	title "删除外部服务配置"
+
+	category "externalService"
+
+	desc """删除外部服务配置"""
+
+	rest {
+		request {
+			url "DELETE /v1/external/service/configuration/{uuid}"
+
+			header (Authorization: 'OAuth the-session-uuid')
+
+			clz APIDeleteExternalServiceConfigurationMsg.class
+
+			desc """"""
+
+			params {
+
+				column {
+					name "uuid"
+					enclosedIn ""
+					desc "资源的UUID，唯一标示该资源"
+					location "url"
+					type "String"
+					optional false
+					since "5.1.0"
+				}
+				column {
+					name "deleteMode"
+					enclosedIn ""
+					desc "删除模式(Permissive / Enforcing，Permissive)"
+					location "query"
+					type "String"
+					optional true
+					since "5.1.0"
+				}
+				column {
+					name "systemTags"
+					enclosedIn ""
+					desc "系统标签"
+					location "query"
+					type "List"
+					optional true
+					since "5.1.0"
+				}
+				column {
+					name "userTags"
+					enclosedIn ""
+					desc "用户标签"
+					location "query"
+					type "List"
+					optional true
+					since "5.1.0"
+				}
+			}
+		}
+
+		response {
+			clz APIDeleteExternalServiceConfigurationEvent.class
+		}
+	}
+}

--- a/header/src/main/java/org/zstack/header/core/external/service/APIQueryExternalServiceConfigurationMsg.java
+++ b/header/src/main/java/org/zstack/header/core/external/service/APIQueryExternalServiceConfigurationMsg.java
@@ -1,0 +1,24 @@
+package org.zstack.header.core.external.service;
+
+import org.springframework.http.HttpMethod;
+import org.zstack.header.query.APIQueryMessage;
+import org.zstack.header.query.AutoQuery;
+import org.zstack.header.rest.RestRequest;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * @Author: ya.wang
+ * @Date: 1/15/26 1:36 AM
+ */
+@AutoQuery(replyClass = APIQueryExternalServiceConfigurationReply.class, inventoryClass = ExternalServiceConfigurationInventory.class)
+@RestRequest(
+        path = "/external/service/configuration",
+        optionalPaths = {"/external/service/configuration/{uuid}"},
+        method = HttpMethod.GET,
+        responseClass = APIQueryExternalServiceConfigurationReply.class
+)
+public class APIQueryExternalServiceConfigurationMsg extends APIQueryMessage {
+    public static List<String> __example__() {return Collections.singletonList("uuid=" + uuid());}
+}

--- a/header/src/main/java/org/zstack/header/core/external/service/APIQueryExternalServiceConfigurationMsgDoc_zh_cn.groovy
+++ b/header/src/main/java/org/zstack/header/core/external/service/APIQueryExternalServiceConfigurationMsgDoc_zh_cn.groovy
@@ -1,0 +1,31 @@
+package org.zstack.header.core.external.service
+
+import org.zstack.header.core.external.service.APIQueryExternalServiceConfigurationReply
+import org.zstack.header.query.APIQueryMessage
+
+doc {
+	title "查询外部服务配置"
+
+	category "externalService"
+
+	desc """查询外部服务配置"""
+
+	rest {
+		request {
+			url "GET /v1/external/service/configuration"
+			url "GET /v1/external/service/configuration/{uuid}"
+
+			header (Authorization: 'OAuth the-session-uuid')
+
+			clz APIQueryExternalServiceConfigurationMsg.class
+
+			desc """"""
+
+			params APIQueryMessage.class
+		}
+
+		response {
+			clz APIQueryExternalServiceConfigurationReply.class
+		}
+	}
+}

--- a/header/src/main/java/org/zstack/header/core/external/service/APIQueryExternalServiceConfigurationReply.java
+++ b/header/src/main/java/org/zstack/header/core/external/service/APIQueryExternalServiceConfigurationReply.java
@@ -1,0 +1,32 @@
+package org.zstack.header.core.external.service;
+
+import org.zstack.header.query.APIQueryReply;
+import org.zstack.header.rest.RestResponse;
+
+import java.util.List;
+
+import static org.zstack.utils.CollectionDSL.list;
+
+/**
+ * @Author: ya.wang
+ * @Date: 1/15/26 1:39 AM
+ */
+@RestResponse(allTo = "inventories")
+public class APIQueryExternalServiceConfigurationReply extends APIQueryReply {
+    private List<ExternalServiceConfigurationInventory> inventories;
+
+    public List<ExternalServiceConfigurationInventory> getInventories() {return inventories;}
+
+    public void setInventories(List<ExternalServiceConfigurationInventory> inventories) {this.inventories = inventories;}
+
+    public static APIQueryExternalServiceConfigurationReply __example__() {
+        APIQueryExternalServiceConfigurationReply reply = new APIQueryExternalServiceConfigurationReply();
+        ExternalServiceConfigurationInventory inv = new ExternalServiceConfigurationInventory();
+
+        inv.setUuid(uuid());
+        inv.setServiceType("Prometheus2");
+        inv.setConfiguration("{}");
+        reply.setInventories(list(inv));
+        return reply;
+    }
+}

--- a/header/src/main/java/org/zstack/header/core/external/service/APIQueryExternalServiceConfigurationReplyDoc_zh_cn.groovy
+++ b/header/src/main/java/org/zstack/header/core/external/service/APIQueryExternalServiceConfigurationReplyDoc_zh_cn.groovy
@@ -1,0 +1,32 @@
+package org.zstack.header.core.external.service
+
+import org.zstack.header.core.external.service.ExternalServiceConfigurationInventory
+import org.zstack.header.errorcode.ErrorCode
+
+doc {
+
+	title "外部服务配置清单"
+
+	ref {
+		name "inventories"
+		path "org.zstack.header.core.external.service.APIQueryExternalServiceConfigurationReply.inventories"
+		desc "null"
+		type "List"
+		since "5.1.0"
+		clz ExternalServiceConfigurationInventory.class
+	}
+	field {
+		name "success"
+		desc ""
+		type "boolean"
+		since "5.1.0"
+	}
+	ref {
+		name "error"
+		path "org.zstack.header.core.external.service.APIQueryExternalServiceConfigurationReply.error"
+		desc "错误码，若不为null，则表示操作失败, 操作成功时该字段为null",false
+		type "ErrorCode"
+		since "5.1.0"
+		clz ErrorCode.class
+	}
+}

--- a/header/src/main/java/org/zstack/header/core/external/service/APIUpdateExternalServiceConfigurationEvent.java
+++ b/header/src/main/java/org/zstack/header/core/external/service/APIUpdateExternalServiceConfigurationEvent.java
@@ -1,0 +1,30 @@
+package org.zstack.header.core.external.service;
+
+import org.zstack.header.message.APIEvent;
+import org.zstack.header.rest.RestResponse;
+
+/**
+ * @Author: ya.wang
+ * @Date: 1/15/26 1:53 AM
+ */
+@RestResponse(allTo = "inventory")
+public class APIUpdateExternalServiceConfigurationEvent extends APIEvent {
+    private ExternalServiceConfigurationInventory inventory;
+
+    public APIUpdateExternalServiceConfigurationEvent() {}
+
+    public APIUpdateExternalServiceConfigurationEvent(String apiId) { super(apiId); }
+
+    public ExternalServiceConfigurationInventory getInventory() {return inventory;}
+
+    public void setInventory(ExternalServiceConfigurationInventory inventory) {this.inventory = inventory;}
+
+    public static APIUpdateExternalServiceConfigurationEvent __example__() {
+        APIUpdateExternalServiceConfigurationEvent event = new APIUpdateExternalServiceConfigurationEvent();
+        ExternalServiceConfigurationInventory inv = new ExternalServiceConfigurationInventory();
+
+        inv.setUuid(uuid());
+        event.setInventory(inv);
+        return event;
+    }
+}

--- a/header/src/main/java/org/zstack/header/core/external/service/APIUpdateExternalServiceConfigurationEventDoc_zh_cn.groovy
+++ b/header/src/main/java/org/zstack/header/core/external/service/APIUpdateExternalServiceConfigurationEventDoc_zh_cn.groovy
@@ -1,0 +1,32 @@
+package org.zstack.header.core.external.service
+
+import org.zstack.header.core.external.service.ExternalServiceConfigurationInventory
+import org.zstack.header.errorcode.ErrorCode
+
+doc {
+
+	title "更新外部服务配置"
+
+	ref {
+		name "inventory"
+		path "org.zstack.header.core.external.service.APIUpdateExternalServiceConfigurationEvent.inventory"
+		desc "null"
+		type "ExternalServiceConfigurationInventory"
+		since "5.1.0"
+		clz ExternalServiceConfigurationInventory.class
+	}
+	field {
+		name "success"
+		desc ""
+		type "boolean"
+		since "5.1.0"
+	}
+	ref {
+		name "error"
+		path "org.zstack.header.core.external.service.APIUpdateExternalServiceConfigurationEvent.error"
+		desc "错误码，若不为null，则表示操作失败, 操作成功时该字段为null",false
+		type "ErrorCode"
+		since "5.1.0"
+		clz ErrorCode.class
+	}
+}

--- a/header/src/main/java/org/zstack/header/core/external/service/APIUpdateExternalServiceConfigurationMsg.java
+++ b/header/src/main/java/org/zstack/header/core/external/service/APIUpdateExternalServiceConfigurationMsg.java
@@ -1,0 +1,54 @@
+package org.zstack.header.core.external.service;
+
+import org.springframework.http.HttpMethod;
+import org.zstack.header.message.APIEvent;
+import org.zstack.header.message.APIMessage;
+import org.zstack.header.message.APIParam;
+import org.zstack.header.other.APIAuditor;
+import org.zstack.header.rest.RestRequest;
+
+/**
+ * @Author: ya.wang
+ * @Date: 1/15/26 1:49 AM
+ */
+@RestRequest(
+        path = "/external/service/configuration/{uuid}",
+        isAction = true,
+        method = HttpMethod.PUT,
+        responseClass = APIUpdateExternalServiceConfigurationEvent.class
+)
+public class APIUpdateExternalServiceConfigurationMsg extends APIMessage implements APIAuditor {
+    @APIParam(resourceType = ExternalServiceConfigurationVO.class, maxLength = 32, operationTarget = true)
+    private String uuid;
+
+    @APIParam(maxLength = 2048, required = false)
+    private String description;
+
+    public String getUuid() {
+        return uuid;
+    }
+
+    public void setUuid(String uuid) {
+        this.uuid = uuid;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    @Override
+    public Result audit(APIMessage msg, APIEvent rsp) {
+        return new APIAuditor.Result(((APIUpdateExternalServiceConfigurationMsg)msg).getUuid(), ExternalServiceConfigurationVO.class);
+    }
+
+    public static APIUpdateExternalServiceConfigurationMsg __example__() {
+        APIUpdateExternalServiceConfigurationMsg msg = new APIUpdateExternalServiceConfigurationMsg();
+        msg.setUuid(uuid());
+        msg.setDescription("description");
+        return msg;
+    }
+}

--- a/header/src/main/java/org/zstack/header/core/external/service/APIUpdateExternalServiceConfigurationMsgDoc_zh_cn.groovy
+++ b/header/src/main/java/org/zstack/header/core/external/service/APIUpdateExternalServiceConfigurationMsgDoc_zh_cn.groovy
@@ -1,0 +1,67 @@
+package org.zstack.header.core.external.service
+
+import org.zstack.header.core.external.service.APIUpdateExternalServiceConfigurationEvent
+
+doc {
+	title "UpdateExternalServiceConfiguration"
+
+	category "externalService"
+
+	desc """更新外部服务配置"""
+
+	rest {
+		request {
+			url "PUT /v1/external/service/configuration/{uuid}"
+
+			header (Authorization: 'OAuth the-session-uuid')
+
+			clz APIUpdateExternalServiceConfigurationMsg.class
+
+			desc """"""
+
+			params {
+
+				column {
+					name "uuid"
+					enclosedIn "updateExternalServiceConfiguration"
+					desc "资源的UUID，唯一标示该资源"
+					location "url"
+					type "String"
+					optional false
+					since "5.1.0"
+				}
+				column {
+					name "description"
+					enclosedIn "updateExternalServiceConfiguration"
+					desc "资源的详细描述"
+					location "body"
+					type "String"
+					optional true
+					since "5.1.0"
+				}
+				column {
+					name "systemTags"
+					enclosedIn ""
+					desc "系统标签"
+					location "body"
+					type "List"
+					optional true
+					since "5.1.0"
+				}
+				column {
+					name "userTags"
+					enclosedIn ""
+					desc "用户标签"
+					location "body"
+					type "List"
+					optional true
+					since "5.1.0"
+				}
+			}
+		}
+
+		response {
+			clz APIUpdateExternalServiceConfigurationEvent.class
+		}
+	}
+}

--- a/header/src/main/java/org/zstack/header/core/external/service/ApplyExternalConfigurationResult.java
+++ b/header/src/main/java/org/zstack/header/core/external/service/ApplyExternalConfigurationResult.java
@@ -1,0 +1,39 @@
+package org.zstack.header.core.external.service;
+
+import org.zstack.header.errorcode.ErrorCode;
+
+/**
+ * @Author: ya.wang
+ * @Date: 1/15/26 2:50 AM
+ */
+public class ApplyExternalConfigurationResult {
+
+    private String managementNodeUuid;
+    private ErrorCode errorCode;
+    private boolean success = true;
+
+    public String getManagementNodeUuid() {
+        return managementNodeUuid;
+    }
+
+    public void setManagementNodeUuid(String managementNodeUuid) {
+        this.managementNodeUuid = managementNodeUuid;
+    }
+
+    public boolean isSuccess() {
+        return success;
+    }
+
+    public void setSuccess(boolean success) {
+        this.success = success;
+    }
+
+    public ErrorCode getErrorCode() {
+        return errorCode;
+    }
+
+    public void setErrorCode(ErrorCode errorCode) {
+        this.success = false;
+        this.errorCode = errorCode;
+    }
+}

--- a/header/src/main/java/org/zstack/header/core/external/service/ApplyExternalServiceConfigurationMsg.java
+++ b/header/src/main/java/org/zstack/header/core/external/service/ApplyExternalServiceConfigurationMsg.java
@@ -1,0 +1,19 @@
+package org.zstack.header.core.external.service;
+
+import org.zstack.header.message.NeedReplyMessage;
+
+/**
+ * @Author: ya.wang
+ * @Date: 1/15/26 2:59 AM
+ */
+public class ApplyExternalServiceConfigurationMsg extends NeedReplyMessage {
+    private String serviceType;
+
+    public String getServiceType() {
+        return serviceType;
+    }
+
+    public void setServiceType(String serviceType) {
+        this.serviceType = serviceType;
+    }
+}

--- a/header/src/main/java/org/zstack/header/core/external/service/ApplyExternalServiceConfigurationReply.java
+++ b/header/src/main/java/org/zstack/header/core/external/service/ApplyExternalServiceConfigurationReply.java
@@ -1,0 +1,28 @@
+package org.zstack.header.core.external.service;
+
+import org.zstack.header.message.MessageReply;
+
+/**
+ * @Author: ya.wang
+ * @Date: 1/15/26 3:26 AM
+ */
+public class ApplyExternalServiceConfigurationReply extends MessageReply {
+    private String managementNodeUuid;
+    private String value;
+
+    public String getManagementNodeUuid() {
+        return managementNodeUuid;
+    }
+
+    public void setManagementNodeUuid(String managementNodeUuid) {
+        this.managementNodeUuid = managementNodeUuid;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+}

--- a/header/src/main/java/org/zstack/header/core/external/service/ExternalServiceConfigurationInventory.java
+++ b/header/src/main/java/org/zstack/header/core/external/service/ExternalServiceConfigurationInventory.java
@@ -1,0 +1,98 @@
+package org.zstack.header.core.external.service;
+
+import org.zstack.header.search.Inventory;
+
+import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * @Author: ya.wang
+ * @Date: 1/15/26 1:31 AM
+ */
+@Inventory(mappingVOClass = ExternalServiceConfigurationVO.class)
+public class ExternalServiceConfigurationInventory {
+    private String uuid;
+    private String serviceType;
+    private String configuration;
+    private String description;
+    private Timestamp createDate;
+    private Timestamp lastOpDate;
+    private List<ApplyExternalConfigurationResult> applyResults;
+
+    public static ExternalServiceConfigurationInventory valueOf(ExternalServiceConfigurationVO vo) {
+        ExternalServiceConfigurationInventory inv = new ExternalServiceConfigurationInventory();
+        inv.setUuid(vo.getUuid());
+        inv.setDescription(vo.getDescription());
+        inv.setServiceType(vo.getServiceType());
+        inv.setConfiguration(vo.getConfiguration());
+        inv.setCreateDate(vo.getCreateDate());
+        inv.setLastOpDate(vo.getLastOpDate());
+        return inv;
+    }
+
+    public static List<ExternalServiceConfigurationInventory> valueOf(Collection<ExternalServiceConfigurationVO> vos) {
+        List<ExternalServiceConfigurationInventory> invs = new ArrayList<ExternalServiceConfigurationInventory>();
+        for (ExternalServiceConfigurationVO vo : vos) {
+            invs.add(valueOf(vo));
+        }
+        return invs;
+    }
+
+    public Timestamp getLastOpDate() {
+        return lastOpDate;
+    }
+
+    public void setLastOpDate(Timestamp lastOpDate) {
+        this.lastOpDate = lastOpDate;
+    }
+
+    public Timestamp getCreateDate() {
+        return createDate;
+    }
+
+    public void setCreateDate(Timestamp createDate) {
+        this.createDate = createDate;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public String getConfiguration() {
+        return configuration;
+    }
+
+    public void setConfiguration(String configuration) {
+        this.configuration = configuration;
+    }
+
+    public String getServiceType() {
+        return serviceType;
+    }
+
+    public void setServiceType(String serviceType) {
+        this.serviceType = serviceType;
+    }
+
+    public String getUuid() {
+        return uuid;
+    }
+
+    public void setUuid(String uuid) {
+        this.uuid = uuid;
+    }
+
+    public List<ApplyExternalConfigurationResult> getApplyResults() {
+        return applyResults;
+    }
+
+    public void setApplyResults(List<ApplyExternalConfigurationResult> applyResults) {
+        this.applyResults = applyResults;
+    }
+}

--- a/header/src/main/java/org/zstack/header/core/external/service/ExternalServiceConfigurationInventoryDoc_zh_cn.groovy
+++ b/header/src/main/java/org/zstack/header/core/external/service/ExternalServiceConfigurationInventoryDoc_zh_cn.groovy
@@ -1,0 +1,45 @@
+package org.zstack.header.core.external.service
+
+import java.sql.Timestamp
+
+doc {
+
+	title "外部服务配置"
+
+	field {
+		name "uuid"
+		desc "资源的UUID，唯一标示该资源"
+		type "String"
+		since "5.1.0"
+	}
+	field {
+		name "serviceType"
+		desc "外部服务类型, 如 Prometheus2, FluentBitServer"
+		type "String"
+		since "5.1.0"
+	}
+	field {
+		name "configuration"
+		desc "外部服务配置, 使用 json 格式。该字段按原文返回已保存配置；若包含 remote_write.basic_auth.password 等凭据，查询结果会返回明文，请仅通过管理员级接口使用"
+		type "String"
+		since "5.1.0"
+	}
+	field {
+		name "description"
+		desc "资源的详细描述"
+		type "String"
+		since "5.1.0"
+	}
+	field {
+		name "createDate"
+		desc "创建时间"
+		type "Timestamp"
+		since "5.1.0"
+	}
+	field {
+		name "lastOpDate"
+		desc "最后一次修改时间"
+		type "Timestamp"
+		since "5.1.0"
+	}
+}

--- a/header/src/main/java/org/zstack/header/core/external/service/ExternalServiceConfigurationVO.java
+++ b/header/src/main/java/org/zstack/header/core/external/service/ExternalServiceConfigurationVO.java
@@ -1,0 +1,89 @@
+package org.zstack.header.core.external.service;
+
+import org.zstack.header.vo.ResourceVO;
+import org.zstack.header.vo.ToInventory;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.PrePersist;
+import javax.persistence.PreUpdate;
+import javax.persistence.Table;
+import javax.persistence.UniqueConstraint;
+import java.sql.Timestamp;
+
+/**
+ * @Author: ya.wang
+ * @Date: 1/15/26 1:25 AM
+ */
+@Entity
+@Table(uniqueConstraints = {
+        @UniqueConstraint(name = "ukExternalServiceConfigurationVOServiceType", columnNames = {"serviceType"})
+})
+public class ExternalServiceConfigurationVO extends ResourceVO implements ToInventory {
+    @Column
+    private String serviceType;
+    @Column
+    private String configuration;
+    @Column
+    private String description;
+    @Column
+    private Timestamp createDate;
+    @Column
+    private Timestamp lastOpDate;
+
+    public String getServiceType() {
+        return serviceType;
+    }
+
+    @PrePersist
+    private void prePersistExternalServiceConfiguration() {
+        Timestamp now = new Timestamp(System.currentTimeMillis());
+        if (createDate == null) {
+            createDate = now;
+        }
+        if (lastOpDate == null) {
+            lastOpDate = now;
+        }
+    }
+
+    @PreUpdate
+    private void preUpdateExternalServiceConfiguration() {
+        lastOpDate = new Timestamp(System.currentTimeMillis());
+    }
+
+    public void setServiceType(String serviceType) {
+        this.serviceType = serviceType;
+    }
+
+    public String getConfiguration() {
+        return configuration;
+    }
+
+    public void setConfiguration(String configuration) {
+        this.configuration = configuration;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public Timestamp getCreateDate() {
+        return createDate;
+    }
+
+    public void setCreateDate(Timestamp createDate) {
+        this.createDate = createDate;
+    }
+
+    public Timestamp getLastOpDate() {
+        return lastOpDate;
+    }
+
+    public void setLastOpDate(Timestamp lastOpDate) {
+        this.lastOpDate = lastOpDate;
+    }
+}

--- a/header/src/main/java/org/zstack/header/core/external/service/ExternalServiceConfigurationVO_.java
+++ b/header/src/main/java/org/zstack/header/core/external/service/ExternalServiceConfigurationVO_.java
@@ -1,0 +1,18 @@
+package org.zstack.header.core.external.service;
+
+import org.zstack.header.vo.ResourceVO_;
+
+import javax.persistence.metamodel.SingularAttribute;
+import java.sql.Timestamp;
+
+/**
+ * @Author: ya.wang
+ * @Date: 1/15/26 1:30 AM
+ */
+public class ExternalServiceConfigurationVO_ extends ResourceVO_ {
+    public static volatile SingularAttribute<ExternalServiceConfigurationVO, String> serviceType;
+    public static volatile SingularAttribute<ExternalServiceConfigurationVO, String> configuration;
+    public static volatile SingularAttribute<ExternalServiceConfigurationVO, String> description;
+    public static volatile SingularAttribute<ExternalServiceConfigurationVO, Timestamp> createDate;
+    public static volatile SingularAttribute<ExternalServiceConfigurationVO, Timestamp> lastOpDate;
+}

--- a/header/src/main/java/org/zstack/header/core/external/service/ExternalServiceInventory.java
+++ b/header/src/main/java/org/zstack/header/core/external/service/ExternalServiceInventory.java
@@ -4,6 +4,7 @@ public class ExternalServiceInventory {
     private String name;
     private String status;
     private ExternalServiceCapabilities capabilities;
+    private String serviceType;
 
     public String getName() {
         return name;
@@ -29,6 +30,14 @@ public class ExternalServiceInventory {
         this.capabilities = capabilities;
     }
 
+    public String getServiceType() {
+        return serviceType;
+    }
+
+    public void setServiceType(String serviceType) {
+        this.serviceType = serviceType;
+    }
+
     public static ExternalServiceInventory __example__() {
         ExternalServiceInventory inv = new ExternalServiceInventory();
         inv.setName("prometheus");
@@ -36,6 +45,7 @@ public class ExternalServiceInventory {
         ExternalServiceCapabilities cap = new ExternalServiceCapabilities();
         cap.setReloadConfig(true);
         inv.setCapabilities(cap);
+        inv.setServiceType("Prometheus2");
         return inv;
     }
 }

--- a/header/src/main/java/org/zstack/header/core/external/service/PackageInfo.java
+++ b/header/src/main/java/org/zstack/header/core/external/service/PackageInfo.java
@@ -1,0 +1,7 @@
+package org.zstack.header.core.external.service;
+
+import org.zstack.header.rest.SDKPackage;
+
+@SDKPackage(packageName = "org.zstack.sdk.external.service")
+public class PackageInfo {
+}

--- a/sdk/src/main/java/org/zstack/sdk/ExternalServiceCapabilitiesBuilder.java
+++ b/sdk/src/main/java/org/zstack/sdk/ExternalServiceCapabilitiesBuilder.java
@@ -2,7 +2,7 @@ package org.zstack.sdk;
 
 
 
-public class ExternalServiceCapabilitiesBuilder extends org.zstack.sdk.ExternalServiceCapabilities {
+public class ExternalServiceCapabilitiesBuilder extends org.zstack.sdk.external.service.ExternalServiceCapabilities {
 
 
 }

--- a/sdk/src/main/java/org/zstack/sdk/SourceClassMap.java
+++ b/sdk/src/main/java/org/zstack/sdk/SourceClassMap.java
@@ -138,8 +138,10 @@ public class SourceClassMap {
 			put("org.zstack.header.configuration.VmCustomSpecificationStruct", "org.zstack.sdk.VmCustomSpecificationStruct");
 			put("org.zstack.header.console.ConsoleInventory", "org.zstack.sdk.ConsoleInventory");
 			put("org.zstack.header.console.ConsoleProxyAgentInventory", "org.zstack.sdk.ConsoleProxyAgentInventory");
-			put("org.zstack.header.core.external.service.ExternalServiceCapabilities", "org.zstack.sdk.ExternalServiceCapabilities");
-			put("org.zstack.header.core.external.service.ExternalServiceInventory", "org.zstack.sdk.ExternalServiceInventory");
+			put("org.zstack.header.core.external.service.ApplyExternalConfigurationResult", "org.zstack.sdk.external.service.ApplyExternalConfigurationResult");
+			put("org.zstack.header.core.external.service.ExternalServiceCapabilities", "org.zstack.sdk.external.service.ExternalServiceCapabilities");
+			put("org.zstack.header.core.external.service.ExternalServiceConfigurationInventory", "org.zstack.sdk.external.service.ExternalServiceConfigurationInventory");
+			put("org.zstack.header.core.external.service.ExternalServiceInventory", "org.zstack.sdk.external.service.ExternalServiceInventory");
 			put("org.zstack.header.core.progress.ChainInfo", "org.zstack.sdk.ChainInfo");
 			put("org.zstack.header.core.progress.PendingTaskInfo", "org.zstack.sdk.PendingTaskInfo");
 			put("org.zstack.header.core.progress.RunningTaskInfo", "org.zstack.sdk.RunningTaskInfo");
@@ -826,9 +828,7 @@ public class SourceClassMap {
 			put("org.zstack.sdk.ExternalBackupState", "org.zstack.externalbackup.ExternalBackupState");
 			put("org.zstack.sdk.ExternalBackupStorageInventory", "org.zstack.header.storage.addon.backup.ExternalBackupStorageInventory");
 			put("org.zstack.sdk.ExternalPrimaryStorageInventory", "org.zstack.header.storage.addon.primary.ExternalPrimaryStorageInventory");
-			put("org.zstack.sdk.ExternalServiceCapabilities", "org.zstack.header.core.external.service.ExternalServiceCapabilities");
 			put("org.zstack.sdk.ExternalServiceCapabilitiesBuilder", "org.zstack.core.externalservice.ExternalServiceCapabilitiesBuilder");
-			put("org.zstack.sdk.ExternalServiceInventory", "org.zstack.header.core.external.service.ExternalServiceInventory");
 			put("org.zstack.sdk.FaultToleranceVmGroupInventory", "org.zstack.faulttolerance.entity.FaultToleranceVmGroupInventory");
 			put("org.zstack.sdk.FcHbaDeviceInventory", "org.zstack.storage.device.hba.FcHbaDeviceInventory");
 			put("org.zstack.sdk.FiberChannelLunInventory", "org.zstack.storage.device.fibreChannel.FiberChannelLunInventory");
@@ -1257,6 +1257,10 @@ public class SourceClassMap {
 			put("org.zstack.sdk.databasebackup.DatabaseBackupStorageRefInventory", "org.zstack.header.storage.database.backup.DatabaseBackupStorageRefInventory");
 			put("org.zstack.sdk.databasebackup.DatabaseBackupStruct", "org.zstack.header.storage.database.backup.DatabaseBackupStruct");
 			put("org.zstack.sdk.databasebackup.DatabaseType", "org.zstack.header.storage.database.backup.DatabaseType");
+			put("org.zstack.sdk.external.service.ApplyExternalConfigurationResult", "org.zstack.header.core.external.service.ApplyExternalConfigurationResult");
+			put("org.zstack.sdk.external.service.ExternalServiceCapabilities", "org.zstack.header.core.external.service.ExternalServiceCapabilities");
+			put("org.zstack.sdk.external.service.ExternalServiceConfigurationInventory", "org.zstack.header.core.external.service.ExternalServiceConfigurationInventory");
+			put("org.zstack.sdk.external.service.ExternalServiceInventory", "org.zstack.header.core.external.service.ExternalServiceInventory");
 			put("org.zstack.sdk.guesttools.GuestToolsInventory", "org.zstack.guesttools.GuestToolsInventory");
 			put("org.zstack.sdk.guesttools.GuestToolsStateInventory", "org.zstack.guesttools.GuestToolsStateInventory");
 			put("org.zstack.sdk.guesttools.advanced.VmCustomSpecificationInventory", "org.zstack.guesttools.advanced.VmCustomSpecificationInventory");

--- a/sdk/src/main/java/org/zstack/sdk/external/service/AddExternalServiceConfigurationAction.java
+++ b/sdk/src/main/java/org/zstack/sdk/external/service/AddExternalServiceConfigurationAction.java
@@ -1,10 +1,10 @@
-package org.zstack.sdk;
+package org.zstack.sdk.external.service;
 
 import java.util.HashMap;
 import java.util.Map;
 import org.zstack.sdk.*;
 
-public class GetExternalServicesAction extends AbstractAction {
+public class AddExternalServiceConfigurationAction extends AbstractAction {
 
     private static final HashMap<String, Parameter> parameterMap = new HashMap<>();
 
@@ -12,7 +12,7 @@ public class GetExternalServicesAction extends AbstractAction {
 
     public static class Result {
         public ErrorCode error;
-        public org.zstack.sdk.GetExternalServicesResult value;
+        public org.zstack.sdk.external.service.AddExternalServiceConfigurationResult value;
 
         public Result throwExceptionIfError() {
             if (error != null) {
@@ -24,6 +24,21 @@ public class GetExternalServicesAction extends AbstractAction {
             return this;
         }
     }
+
+    @Param(required = true, nonempty = false, nullElements = false, emptyString = true, noTrim = false)
+    public java.lang.String externalServiceType;
+
+    @Param(required = true, maxLength = 65535, nonempty = false, nullElements = false, emptyString = true, noTrim = false)
+    public java.lang.String configuration;
+
+    @Param(required = false, maxLength = 2048, nonempty = false, nullElements = false, emptyString = true, noTrim = false)
+    public java.lang.String description;
+
+    @Param(required = false)
+    public java.lang.String resourceUuid;
+
+    @Param(required = false, nonempty = false, nullElements = false, emptyString = true, noTrim = false)
+    public java.util.List tagUuids;
 
     @Param(required = false)
     public java.util.List systemTags;
@@ -43,6 +58,12 @@ public class GetExternalServicesAction extends AbstractAction {
     @Param(required = false)
     public String requestIp;
 
+    @NonAPIParam
+    public long timeout = -1;
+
+    @NonAPIParam
+    public long pollingInterval = -1;
+
 
     private Result makeResult(ApiResult res) {
         Result ret = new Result();
@@ -51,8 +72,8 @@ public class GetExternalServicesAction extends AbstractAction {
             return ret;
         }
         
-        org.zstack.sdk.GetExternalServicesResult value = res.getResult(org.zstack.sdk.GetExternalServicesResult.class);
-        ret.value = value == null ? new org.zstack.sdk.GetExternalServicesResult() : value; 
+        org.zstack.sdk.external.service.AddExternalServiceConfigurationResult value = res.getResult(org.zstack.sdk.external.service.AddExternalServiceConfigurationResult.class);
+        ret.value = value == null ? new org.zstack.sdk.external.service.AddExternalServiceConfigurationResult() : value; 
 
         return ret;
     }
@@ -81,11 +102,11 @@ public class GetExternalServicesAction extends AbstractAction {
 
     protected RestInfo getRestInfo() {
         RestInfo info = new RestInfo();
-        info.httpMethod = "GET";
-        info.path = "/external/services";
+        info.httpMethod = "POST";
+        info.path = "/external/service/configuration";
         info.needSession = true;
-        info.needPoll = false;
-        info.parameterName = "";
+        info.needPoll = true;
+        info.parameterName = "params";
         return info;
     }
 

--- a/sdk/src/main/java/org/zstack/sdk/external/service/AddExternalServiceConfigurationResult.java
+++ b/sdk/src/main/java/org/zstack/sdk/external/service/AddExternalServiceConfigurationResult.java
@@ -1,0 +1,14 @@
+package org.zstack.sdk.external.service;
+
+import org.zstack.sdk.external.service.ExternalServiceConfigurationInventory;
+
+public class AddExternalServiceConfigurationResult {
+    public ExternalServiceConfigurationInventory inventory;
+    public void setInventory(ExternalServiceConfigurationInventory inventory) {
+        this.inventory = inventory;
+    }
+    public ExternalServiceConfigurationInventory getInventory() {
+        return this.inventory;
+    }
+
+}

--- a/sdk/src/main/java/org/zstack/sdk/external/service/ApplyExternalConfigurationResult.java
+++ b/sdk/src/main/java/org/zstack/sdk/external/service/ApplyExternalConfigurationResult.java
@@ -1,0 +1,31 @@
+package org.zstack.sdk.external.service;
+
+import org.zstack.sdk.ErrorCode;
+
+public class ApplyExternalConfigurationResult  {
+
+    public java.lang.String managementNodeUuid;
+    public void setManagementNodeUuid(java.lang.String managementNodeUuid) {
+        this.managementNodeUuid = managementNodeUuid;
+    }
+    public java.lang.String getManagementNodeUuid() {
+        return this.managementNodeUuid;
+    }
+
+    public ErrorCode errorCode;
+    public void setErrorCode(ErrorCode errorCode) {
+        this.errorCode = errorCode;
+    }
+    public ErrorCode getErrorCode() {
+        return this.errorCode;
+    }
+
+    public boolean success;
+    public void setSuccess(boolean success) {
+        this.success = success;
+    }
+    public boolean getSuccess() {
+        return this.success;
+    }
+
+}

--- a/sdk/src/main/java/org/zstack/sdk/external/service/DeleteExternalServiceConfigurationAction.java
+++ b/sdk/src/main/java/org/zstack/sdk/external/service/DeleteExternalServiceConfigurationAction.java
@@ -1,0 +1,104 @@
+package org.zstack.sdk.external.service;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.zstack.sdk.*;
+
+public class DeleteExternalServiceConfigurationAction extends AbstractAction {
+
+    private static final HashMap<String, Parameter> parameterMap = new HashMap<>();
+
+    private static final HashMap<String, Parameter> nonAPIParameterMap = new HashMap<>();
+
+    public static class Result {
+        public ErrorCode error;
+        public org.zstack.sdk.external.service.DeleteExternalServiceConfigurationResult value;
+
+        public Result throwExceptionIfError() {
+            if (error != null) {
+                throw new ApiException(
+                    String.format("error[code: %s, description: %s, details: %s]", error.code, error.description, error.details)
+                );
+            }
+            
+            return this;
+        }
+    }
+
+    @Param(required = true, nonempty = false, nullElements = false, emptyString = true, noTrim = false)
+    public java.lang.String uuid;
+
+    @Param(required = false)
+    public java.lang.String deleteMode = "Permissive";
+
+    @Param(required = false)
+    public java.util.List systemTags;
+
+    @Param(required = false)
+    public java.util.List userTags;
+
+    @Param(required = false)
+    public String sessionId;
+
+    @Param(required = false)
+    public String accessKeyId;
+
+    @Param(required = false)
+    public String accessKeySecret;
+
+    @Param(required = false)
+    public String requestIp;
+
+    @NonAPIParam
+    public long timeout = -1;
+
+    @NonAPIParam
+    public long pollingInterval = -1;
+
+
+    private Result makeResult(ApiResult res) {
+        Result ret = new Result();
+        if (res.error != null) {
+            ret.error = res.error;
+            return ret;
+        }
+        
+        org.zstack.sdk.external.service.DeleteExternalServiceConfigurationResult value = res.getResult(org.zstack.sdk.external.service.DeleteExternalServiceConfigurationResult.class);
+        ret.value = value == null ? new org.zstack.sdk.external.service.DeleteExternalServiceConfigurationResult() : value; 
+
+        return ret;
+    }
+
+    public Result call() {
+        ApiResult res = ZSClient.call(this);
+        return makeResult(res);
+    }
+
+    public void call(final Completion<Result> completion) {
+        ZSClient.call(this, new InternalCompletion() {
+            @Override
+            public void complete(ApiResult res) {
+                completion.complete(makeResult(res));
+            }
+        });
+    }
+
+    protected Map<String, Parameter> getParameterMap() {
+        return parameterMap;
+    }
+
+    protected Map<String, Parameter> getNonAPIParameterMap() {
+        return nonAPIParameterMap;
+    }
+
+    protected RestInfo getRestInfo() {
+        RestInfo info = new RestInfo();
+        info.httpMethod = "DELETE";
+        info.path = "/external/service/configuration/{uuid}";
+        info.needSession = true;
+        info.needPoll = true;
+        info.parameterName = "";
+        return info;
+    }
+
+}

--- a/sdk/src/main/java/org/zstack/sdk/external/service/DeleteExternalServiceConfigurationResult.java
+++ b/sdk/src/main/java/org/zstack/sdk/external/service/DeleteExternalServiceConfigurationResult.java
@@ -1,0 +1,7 @@
+package org.zstack.sdk.external.service;
+
+
+
+public class DeleteExternalServiceConfigurationResult {
+
+}

--- a/sdk/src/main/java/org/zstack/sdk/external/service/ExternalServiceCapabilities.java
+++ b/sdk/src/main/java/org/zstack/sdk/external/service/ExternalServiceCapabilities.java
@@ -1,4 +1,4 @@
-package org.zstack.sdk;
+package org.zstack.sdk.external.service;
 
 
 

--- a/sdk/src/main/java/org/zstack/sdk/external/service/ExternalServiceConfigurationInventory.java
+++ b/sdk/src/main/java/org/zstack/sdk/external/service/ExternalServiceConfigurationInventory.java
@@ -1,0 +1,63 @@
+package org.zstack.sdk.external.service;
+
+
+
+public class ExternalServiceConfigurationInventory  {
+
+    public java.lang.String uuid;
+    public void setUuid(java.lang.String uuid) {
+        this.uuid = uuid;
+    }
+    public java.lang.String getUuid() {
+        return this.uuid;
+    }
+
+    public java.lang.String serviceType;
+    public void setServiceType(java.lang.String serviceType) {
+        this.serviceType = serviceType;
+    }
+    public java.lang.String getServiceType() {
+        return this.serviceType;
+    }
+
+    public java.lang.String configuration;
+    public void setConfiguration(java.lang.String configuration) {
+        this.configuration = configuration;
+    }
+    public java.lang.String getConfiguration() {
+        return this.configuration;
+    }
+
+    public java.lang.String description;
+    public void setDescription(java.lang.String description) {
+        this.description = description;
+    }
+    public java.lang.String getDescription() {
+        return this.description;
+    }
+
+    public java.sql.Timestamp createDate;
+    public void setCreateDate(java.sql.Timestamp createDate) {
+        this.createDate = createDate;
+    }
+    public java.sql.Timestamp getCreateDate() {
+        return this.createDate;
+    }
+
+    public java.sql.Timestamp lastOpDate;
+    public void setLastOpDate(java.sql.Timestamp lastOpDate) {
+        this.lastOpDate = lastOpDate;
+    }
+    public java.sql.Timestamp getLastOpDate() {
+        return this.lastOpDate;
+    }
+
+    public java.util.List applyResults;
+    public void setApplyResults(java.util.List applyResults) {
+        this.applyResults = applyResults;
+    }
+    public java.util.List getApplyResults() {
+        return this.applyResults;
+    }
+
+}

--- a/sdk/src/main/java/org/zstack/sdk/external/service/ExternalServiceInventory.java
+++ b/sdk/src/main/java/org/zstack/sdk/external/service/ExternalServiceInventory.java
@@ -1,6 +1,6 @@
-package org.zstack.sdk;
+package org.zstack.sdk.external.service;
 
-import org.zstack.sdk.ExternalServiceCapabilities;
+import org.zstack.sdk.external.service.ExternalServiceCapabilities;
 
 public class ExternalServiceInventory  {
 
@@ -26,6 +26,14 @@ public class ExternalServiceInventory  {
     }
     public ExternalServiceCapabilities getCapabilities() {
         return this.capabilities;
+    }
+
+    public java.lang.String serviceType;
+    public void setServiceType(java.lang.String serviceType) {
+        this.serviceType = serviceType;
+    }
+    public java.lang.String getServiceType() {
+        return this.serviceType;
     }
 
 }

--- a/sdk/src/main/java/org/zstack/sdk/external/service/GetExternalServicesAction.java
+++ b/sdk/src/main/java/org/zstack/sdk/external/service/GetExternalServicesAction.java
@@ -1,0 +1,92 @@
+package org.zstack.sdk.external.service;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.zstack.sdk.*;
+
+public class GetExternalServicesAction extends AbstractAction {
+
+    private static final HashMap<String, Parameter> parameterMap = new HashMap<>();
+
+    private static final HashMap<String, Parameter> nonAPIParameterMap = new HashMap<>();
+
+    public static class Result {
+        public ErrorCode error;
+        public org.zstack.sdk.external.service.GetExternalServicesResult value;
+
+        public Result throwExceptionIfError() {
+            if (error != null) {
+                throw new ApiException(
+                    String.format("error[code: %s, description: %s, details: %s]", error.code, error.description, error.details)
+                );
+            }
+            
+            return this;
+        }
+    }
+
+    @Param(required = false)
+    public java.util.List systemTags;
+
+    @Param(required = false)
+    public java.util.List userTags;
+
+    @Param(required = false)
+    public String sessionId;
+
+    @Param(required = false)
+    public String accessKeyId;
+
+    @Param(required = false)
+    public String accessKeySecret;
+
+    @Param(required = false)
+    public String requestIp;
+
+
+    private Result makeResult(ApiResult res) {
+        Result ret = new Result();
+        if (res.error != null) {
+            ret.error = res.error;
+            return ret;
+        }
+        
+        org.zstack.sdk.external.service.GetExternalServicesResult value = res.getResult(org.zstack.sdk.external.service.GetExternalServicesResult.class);
+        ret.value = value == null ? new org.zstack.sdk.external.service.GetExternalServicesResult() : value; 
+
+        return ret;
+    }
+
+    public Result call() {
+        ApiResult res = ZSClient.call(this);
+        return makeResult(res);
+    }
+
+    public void call(final Completion<Result> completion) {
+        ZSClient.call(this, new InternalCompletion() {
+            @Override
+            public void complete(ApiResult res) {
+                completion.complete(makeResult(res));
+            }
+        });
+    }
+
+    protected Map<String, Parameter> getParameterMap() {
+        return parameterMap;
+    }
+
+    protected Map<String, Parameter> getNonAPIParameterMap() {
+        return nonAPIParameterMap;
+    }
+
+    protected RestInfo getRestInfo() {
+        RestInfo info = new RestInfo();
+        info.httpMethod = "GET";
+        info.path = "/external/services";
+        info.needSession = true;
+        info.needPoll = false;
+        info.parameterName = "";
+        return info;
+    }
+
+}

--- a/sdk/src/main/java/org/zstack/sdk/external/service/GetExternalServicesResult.java
+++ b/sdk/src/main/java/org/zstack/sdk/external/service/GetExternalServicesResult.java
@@ -1,4 +1,4 @@
-package org.zstack.sdk;
+package org.zstack.sdk.external.service;
 
 
 

--- a/sdk/src/main/java/org/zstack/sdk/external/service/QueryExternalServiceConfigurationAction.java
+++ b/sdk/src/main/java/org/zstack/sdk/external/service/QueryExternalServiceConfigurationAction.java
@@ -1,0 +1,75 @@
+package org.zstack.sdk.external.service;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.zstack.sdk.*;
+
+public class QueryExternalServiceConfigurationAction extends QueryAction {
+
+    private static final HashMap<String, Parameter> parameterMap = new HashMap<>();
+
+    private static final HashMap<String, Parameter> nonAPIParameterMap = new HashMap<>();
+
+    public static class Result {
+        public ErrorCode error;
+        public org.zstack.sdk.external.service.QueryExternalServiceConfigurationResult value;
+
+        public Result throwExceptionIfError() {
+            if (error != null) {
+                throw new ApiException(
+                    String.format("error[code: %s, description: %s, details: %s]", error.code, error.description, error.details)
+                );
+            }
+            
+            return this;
+        }
+    }
+
+
+
+    private Result makeResult(ApiResult res) {
+        Result ret = new Result();
+        if (res.error != null) {
+            ret.error = res.error;
+            return ret;
+        }
+        
+        org.zstack.sdk.external.service.QueryExternalServiceConfigurationResult value = res.getResult(org.zstack.sdk.external.service.QueryExternalServiceConfigurationResult.class);
+        ret.value = value == null ? new org.zstack.sdk.external.service.QueryExternalServiceConfigurationResult() : value; 
+
+        return ret;
+    }
+
+    public Result call() {
+        ApiResult res = ZSClient.call(this);
+        return makeResult(res);
+    }
+
+    public void call(final Completion<Result> completion) {
+        ZSClient.call(this, new InternalCompletion() {
+            @Override
+            public void complete(ApiResult res) {
+                completion.complete(makeResult(res));
+            }
+        });
+    }
+
+    protected Map<String, Parameter> getParameterMap() {
+        return parameterMap;
+    }
+
+    protected Map<String, Parameter> getNonAPIParameterMap() {
+        return nonAPIParameterMap;
+    }
+
+    protected RestInfo getRestInfo() {
+        RestInfo info = new RestInfo();
+        info.httpMethod = "GET";
+        info.path = "/external/service/configuration";
+        info.needSession = true;
+        info.needPoll = false;
+        info.parameterName = "";
+        return info;
+    }
+
+}

--- a/sdk/src/main/java/org/zstack/sdk/external/service/QueryExternalServiceConfigurationResult.java
+++ b/sdk/src/main/java/org/zstack/sdk/external/service/QueryExternalServiceConfigurationResult.java
@@ -1,0 +1,22 @@
+package org.zstack.sdk.external.service;
+
+
+
+public class QueryExternalServiceConfigurationResult {
+    public java.util.List inventories;
+    public void setInventories(java.util.List inventories) {
+        this.inventories = inventories;
+    }
+    public java.util.List getInventories() {
+        return this.inventories;
+    }
+
+    public java.lang.Long total;
+    public void setTotal(java.lang.Long total) {
+        this.total = total;
+    }
+    public java.lang.Long getTotal() {
+        return this.total;
+    }
+
+}

--- a/sdk/src/main/java/org/zstack/sdk/external/service/ReloadExternalServiceAction.java
+++ b/sdk/src/main/java/org/zstack/sdk/external/service/ReloadExternalServiceAction.java
@@ -1,4 +1,4 @@
-package org.zstack.sdk;
+package org.zstack.sdk.external.service;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -12,7 +12,7 @@ public class ReloadExternalServiceAction extends AbstractAction {
 
     public static class Result {
         public ErrorCode error;
-        public org.zstack.sdk.ReloadExternalServiceResult value;
+        public org.zstack.sdk.external.service.ReloadExternalServiceResult value;
 
         public Result throwExceptionIfError() {
             if (error != null) {
@@ -60,8 +60,8 @@ public class ReloadExternalServiceAction extends AbstractAction {
             return ret;
         }
         
-        org.zstack.sdk.ReloadExternalServiceResult value = res.getResult(org.zstack.sdk.ReloadExternalServiceResult.class);
-        ret.value = value == null ? new org.zstack.sdk.ReloadExternalServiceResult() : value; 
+        org.zstack.sdk.external.service.ReloadExternalServiceResult value = res.getResult(org.zstack.sdk.external.service.ReloadExternalServiceResult.class);
+        ret.value = value == null ? new org.zstack.sdk.external.service.ReloadExternalServiceResult() : value; 
 
         return ret;
     }

--- a/sdk/src/main/java/org/zstack/sdk/external/service/ReloadExternalServiceResult.java
+++ b/sdk/src/main/java/org/zstack/sdk/external/service/ReloadExternalServiceResult.java
@@ -1,4 +1,4 @@
-package org.zstack.sdk;
+package org.zstack.sdk.external.service;
 
 
 

--- a/sdk/src/main/java/org/zstack/sdk/external/service/UpdateExternalServiceConfigurationAction.java
+++ b/sdk/src/main/java/org/zstack/sdk/external/service/UpdateExternalServiceConfigurationAction.java
@@ -1,0 +1,104 @@
+package org.zstack.sdk.external.service;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.zstack.sdk.*;
+
+public class UpdateExternalServiceConfigurationAction extends AbstractAction {
+
+    private static final HashMap<String, Parameter> parameterMap = new HashMap<>();
+
+    private static final HashMap<String, Parameter> nonAPIParameterMap = new HashMap<>();
+
+    public static class Result {
+        public ErrorCode error;
+        public org.zstack.sdk.external.service.UpdateExternalServiceConfigurationResult value;
+
+        public Result throwExceptionIfError() {
+            if (error != null) {
+                throw new ApiException(
+                    String.format("error[code: %s, description: %s, details: %s]", error.code, error.description, error.details)
+                );
+            }
+            
+            return this;
+        }
+    }
+
+    @Param(required = true, maxLength = 32, nonempty = false, nullElements = false, emptyString = true, noTrim = false)
+    public java.lang.String uuid;
+
+    @Param(required = false, maxLength = 2048, nonempty = false, nullElements = false, emptyString = true, noTrim = false)
+    public java.lang.String description;
+
+    @Param(required = false)
+    public java.util.List systemTags;
+
+    @Param(required = false)
+    public java.util.List userTags;
+
+    @Param(required = false)
+    public String sessionId;
+
+    @Param(required = false)
+    public String accessKeyId;
+
+    @Param(required = false)
+    public String accessKeySecret;
+
+    @Param(required = false)
+    public String requestIp;
+
+    @NonAPIParam
+    public long timeout = -1;
+
+    @NonAPIParam
+    public long pollingInterval = -1;
+
+
+    private Result makeResult(ApiResult res) {
+        Result ret = new Result();
+        if (res.error != null) {
+            ret.error = res.error;
+            return ret;
+        }
+        
+        org.zstack.sdk.external.service.UpdateExternalServiceConfigurationResult value = res.getResult(org.zstack.sdk.external.service.UpdateExternalServiceConfigurationResult.class);
+        ret.value = value == null ? new org.zstack.sdk.external.service.UpdateExternalServiceConfigurationResult() : value; 
+
+        return ret;
+    }
+
+    public Result call() {
+        ApiResult res = ZSClient.call(this);
+        return makeResult(res);
+    }
+
+    public void call(final Completion<Result> completion) {
+        ZSClient.call(this, new InternalCompletion() {
+            @Override
+            public void complete(ApiResult res) {
+                completion.complete(makeResult(res));
+            }
+        });
+    }
+
+    protected Map<String, Parameter> getParameterMap() {
+        return parameterMap;
+    }
+
+    protected Map<String, Parameter> getNonAPIParameterMap() {
+        return nonAPIParameterMap;
+    }
+
+    protected RestInfo getRestInfo() {
+        RestInfo info = new RestInfo();
+        info.httpMethod = "PUT";
+        info.path = "/external/service/configuration/{uuid}";
+        info.needSession = true;
+        info.needPoll = true;
+        info.parameterName = "updateExternalServiceConfiguration";
+        return info;
+    }
+
+}

--- a/sdk/src/main/java/org/zstack/sdk/external/service/UpdateExternalServiceConfigurationResult.java
+++ b/sdk/src/main/java/org/zstack/sdk/external/service/UpdateExternalServiceConfigurationResult.java
@@ -1,0 +1,14 @@
+package org.zstack.sdk.external.service;
+
+import org.zstack.sdk.external.service.ExternalServiceConfigurationInventory;
+
+public class UpdateExternalServiceConfigurationResult {
+    public ExternalServiceConfigurationInventory inventory;
+    public void setInventory(ExternalServiceConfigurationInventory inventory) {
+        this.inventory = inventory;
+    }
+    public ExternalServiceConfigurationInventory getInventory() {
+        return this.inventory;
+    }
+
+}

--- a/testlib/src/main/java/org/zstack/testlib/ApiHelper.groovy
+++ b/testlib/src/main/java/org/zstack/testlib/ApiHelper.groovy
@@ -15433,6 +15433,108 @@ abstract class ApiHelper {
         }
     }
 
+    def addExternalServiceConfiguration(@DelegatesTo(strategy = Closure.OWNER_FIRST, value = org.zstack.sdk.AddExternalServiceConfigurationAction.class) Closure c) {
+        def a = new org.zstack.sdk.AddExternalServiceConfigurationAction()
+        a.sessionId = Test.currentEnvSpec?.session?.uuid
+        c.resolveStrategy = Closure.OWNER_FIRST
+        c.delegate = a
+        c()
+
+        if (System.getProperty("apipath") != null) {
+            if (a.apiId == null) {
+                a.apiId = Platform.uuid
+            }
+
+            def tracker = new ApiPathTracker(a.apiId)
+            def out = errorOut(a.call())
+            def path = tracker.getApiPath()
+            if (!path.isEmpty()) {
+                Test.apiPaths[a.class.name] = path.join(" --->\n")
+            }
+
+            return out
+        } else {
+            return errorOut(a.call())
+        }
+    }
+
+    def queryExternalServiceConfiguration(@DelegatesTo(strategy = Closure.OWNER_FIRST, value = org.zstack.sdk.QueryExternalServiceConfigurationAction.class) Closure c) {
+        def a = new org.zstack.sdk.QueryExternalServiceConfigurationAction()
+        a.sessionId = Test.currentEnvSpec?.session?.uuid
+        c.resolveStrategy = Closure.OWNER_FIRST
+        c.delegate = a
+        c()
+
+        a.conditions = a.conditions.collect { it.toString() }
+
+        if (System.getProperty("apipath") != null) {
+            if (a.apiId == null) {
+                a.apiId = Platform.uuid
+            }
+
+            def tracker = new ApiPathTracker(a.apiId)
+            def out = errorOut(a.call())
+            def path = tracker.getApiPath()
+            if (!path.isEmpty()) {
+                Test.apiPaths[a.class.name] = path.join(" --->\n")
+            }
+
+            return out
+        } else {
+            return errorOut(a.call())
+        }
+    }
+
+    def updateExternalServiceConfiguration(@DelegatesTo(strategy = Closure.OWNER_FIRST, value = org.zstack.sdk.UpdateExternalServiceConfigurationAction.class) Closure c) {
+        def a = new org.zstack.sdk.UpdateExternalServiceConfigurationAction()
+        a.sessionId = Test.currentEnvSpec?.session?.uuid
+        c.resolveStrategy = Closure.OWNER_FIRST
+        c.delegate = a
+        c()
+
+        if (System.getProperty("apipath") != null) {
+            if (a.apiId == null) {
+                a.apiId = Platform.uuid
+            }
+
+            def tracker = new ApiPathTracker(a.apiId)
+            def out = errorOut(a.call())
+            def path = tracker.getApiPath()
+            if (!path.isEmpty()) {
+                Test.apiPaths[a.class.name] = path.join(" --->\n")
+            }
+
+            return out
+        } else {
+            return errorOut(a.call())
+        }
+    }
+
+    def deleteExternalServiceConfiguration(@DelegatesTo(strategy = Closure.OWNER_FIRST, value = org.zstack.sdk.DeleteExternalServiceConfigurationAction.class) Closure c) {
+        def a = new org.zstack.sdk.DeleteExternalServiceConfigurationAction()
+        a.sessionId = Test.currentEnvSpec?.session?.uuid
+        c.resolveStrategy = Closure.OWNER_FIRST
+        c.delegate = a
+        c()
+
+        if (System.getProperty("apipath") != null) {
+            if (a.apiId == null) {
+                a.apiId = Platform.uuid
+            }
+
+            def tracker = new ApiPathTracker(a.apiId)
+            def out = errorOut(a.call())
+            def path = tracker.getApiPath()
+            if (!path.isEmpty()) {
+                Test.apiPaths[a.class.name] = path.join(" --->\n")
+            }
+
+            return out
+        } else {
+            return errorOut(a.call())
+        }
+    }
+
 
     def getFactoryModeState(@DelegatesTo(strategy = Closure.OWNER_FIRST, value = org.zstack.sdk.GetFactoryModeStateAction.class) Closure c) {
         def a = new org.zstack.sdk.GetFactoryModeStateAction()


### PR DESCRIPTION
- Add ExternalServiceConfigurationVO schema, inventory, query API, and add/update/delete APIs
- Apply configuration changes to matching external services across management nodes
- Expose serviceType in external service inventory for configuration routing
- Generate SDK actions/results and testlib helpers for external service configuration operations
- Register persistence and external service API metadata

DBImpact
APIImpact

Resolves: ZSV-12395

Change-Id: I6a6b76626770736871716563676b6a7a74736966

sync from gitlab !10144