### PR TITLE
ZSTAC-85711 pass vm uuid to flat dhcp

### DIFF
--- a/plugin/flatNetworkProvider/src/main/java/org/zstack/network/service/flat/FlatDhcpBackend.java
+++ b/plugin/flatNetworkProvider/src/main/java/org/zstack/network/service/flat/FlatDhcpBackend.java
@@ -1836,6 +1836,7 @@ public class FlatDhcpBackend extends AbstractService implements NetworkServiceDh
         public List<HostRouteInfo> hostRoutes;
         public String nicType;
         public String vlanId;
+        public String vmUuid;
     }
 
     public static class ApplyDhcpCmd extends KVMAgentCommands.AgentCommand {
@@ -2063,6 +2064,7 @@ public class FlatDhcpBackend extends AbstractService implements NetworkServiceDh
                 info.mtu = arg.getMtu();
                 info.hostRoutes = getL3NetworkHostRoute(arg.getL3Network().getUuid());
                 info.vmMultiGateway = multiGateway;
+                info.vmUuid = arg.getVmUuid();
                 if ((arg.getIpVersion() == IPv6Constants.DUAL_STACK  || arg.getIpVersion() == IPv6Constants.IPv6)
                         && !IPv6Constants.SLAAC.equals(arg.getRaMode())) {
                     info.ip6 = arg.getIp6();

--- a/test/src/test/groovy/org/zstack/test/integration/network/l3network/ipv6/IPv6DhcpCase.groovy
+++ b/test/src/test/groovy/org/zstack/test/integration/network/l3network/ipv6/IPv6DhcpCase.groovy
@@ -112,6 +112,7 @@ class IPv6DhcpCase extends SubCase {
         assert dhcpInfo.endIp == ipr.getEndIp()
         assert dhcpInfo.ipVersion == IPv6Constants.IPv6
         assert dhcpInfo.enableRa
+        assert dhcpInfo.vmUuid == vm.uuid
         assert pcmds.size() == 1
         FlatDhcpBackend.PrepareDhcpCmd pcmd = pcmds.get(0)
         assert pcmd.ipVersion == IPv6Constants.IPv6
@@ -198,6 +199,7 @@ class IPv6DhcpCase extends SubCase {
                 assert dhcpInfo.ip == ip4.ip
                 assert dhcpInfo.gateway == ip4.gateway
             }
+            assert dhcpInfo.vmUuid == vm.uuid
         }
 
         pcmds = Collections.synchronizedList(new ArrayList())
@@ -242,9 +244,9 @@ class IPv6DhcpCase extends SubCase {
                 assert dhcpInfo.ip == ip4.ip
                 assert dhcpInfo.gateway == ip4.gateway
             }
+            assert dhcpInfo.vmUuid == vm.uuid
         }
     }
 
 
 }
-


### PR DESCRIPTION
Root cause:
- Cloud already records vmUuid in DhcpStruct, but FlatDhcpBackend.DhcpInfo did not carry it.
- The kvmagent batchApply DHCP payload therefore lost vmUuid, so kvmagent could not generate DHCPv6 DUID-UUID static leases.

Fix:
- Add vmUuid to FlatDhcpBackend.DhcpInfo and populate it from DhcpStruct.
- Extend IPv6DhcpCase assertions to cover create/reboot/reconnect DHCP apply payloads.

Verification:
- git diff --check: PASS
- mvn -pl plugin/flatNetworkProvider -am -DskipTests compile: PASS

sync from gitlab !10155