### PR TITLE
<fix>[kvm]: disable arm VM PMU by default

### DIFF
--- a/compute/src/main/java/org/zstack/compute/vm/VmGlobalConfig.java
+++ b/compute/src/main/java/org/zstack/compute/vm/VmGlobalConfig.java
@@ -49,6 +49,10 @@ public class VmGlobalConfig {
     public static GlobalConfig KVM_HIDDEN_STATE = new GlobalConfig(CATEGORY, "kvmHiddenState");
     @GlobalConfigValidation(validValues = {"true", "false"})
     public static GlobalConfig VM_PORT_OFF = new GlobalConfig(CATEGORY, "vmPortOff");
+    @GlobalConfigDef(defaultValue = "false", type = Boolean.class, description = "enable PMU for VM, disabled by default on aarch64 to avoid Kunpeng-920 kernel panic")
+    @GlobalConfigValidation(validValues = {"true", "false"})
+    @BindResourceConfig(value = {VmInstanceVO.class, ClusterVO.class})
+    public static GlobalConfig VM_PMU = new GlobalConfig(CATEGORY, "vm.pmu");
     @GlobalConfigValidation(validValues = {"true", "false"})
     @BindResourceConfig(value = {VmInstanceVO.class, ClusterVO.class})
     public static GlobalConfig EMULATE_HYPERV = new GlobalConfig(CATEGORY, "emulateHyperV");

--- a/plugin/kvm/src/main/java/org/zstack/kvm/KVMAgentCommands.java
+++ b/plugin/kvm/src/main/java/org/zstack/kvm/KVMAgentCommands.java
@@ -1709,6 +1709,7 @@ public class KVMAgentCommands {
         private boolean coloSecondary;
         private boolean consoleLogToFile;
         private boolean acpi;
+        private boolean pmu = true;
 
         // TODO: only for test
         private boolean useColoBinary;
@@ -2166,6 +2167,14 @@ public class KVMAgentCommands {
 
         public void setAcpi(boolean acpi) {
             this.acpi = acpi;
+        }
+
+        public boolean isPmu() {
+            return pmu;
+        }
+
+        public void setPmu(boolean pmu) {
+            this.pmu = pmu;
         }
 
         public boolean isHypervClock() {

--- a/plugin/kvm/src/main/java/org/zstack/kvm/KVMHost.java
+++ b/plugin/kvm/src/main/java/org/zstack/kvm/KVMHost.java
@@ -3255,6 +3255,10 @@ public class KVMHost extends HostBase implements Host {
         if (spec.isCreatePaused()) {
             cmd.setCreatePaused(true);
         }
+        if (ImageArchitecture.aarch64.toString().equals(architecture)) {
+            Boolean pmuEnabled = rcf.getResourceConfigValue(VmGlobalConfig.VM_PMU, spec.getVmInventory().getUuid(), Boolean.class);
+            cmd.setPmu(Boolean.TRUE.equals(pmuEnabled));
+        }
         String vmArchPlatformRelease = String.format("%s_%s_%s", spec.getVmInventory().getArchitecture(), spec.getVmInventory().getPlatform(), spec.getVmInventory().getGuestOsType());
         if (allGuestOsCharacter.containsKey(vmArchPlatformRelease)) {
             cmd.setAcpi(allGuestOsCharacter.get(vmArchPlatformRelease).getAcpi() != null && allGuestOsCharacter.get(vmArchPlatformRelease).getAcpi());

--- a/test/src/test/groovy/org/zstack/test/integration/kvm/vm/VmPmuConfigCase.groovy
+++ b/test/src/test/groovy/org/zstack/test/integration/kvm/vm/VmPmuConfigCase.groovy
@@ -1,0 +1,212 @@
+package org.zstack.test.integration.kvm.vm
+
+import org.springframework.http.HttpEntity
+import org.zstack.compute.vm.VmGlobalConfig
+import org.zstack.header.image.ImageArchitecture
+import org.zstack.kvm.KVMAgentCommands
+import org.zstack.kvm.KVMConstant
+import org.zstack.resourceconfig.ResourceConfigFacade
+import org.zstack.sdk.GlobalConfigInventory
+import org.zstack.sdk.ImageInventory
+import org.zstack.sdk.InstanceOfferingInventory
+import org.zstack.sdk.L3NetworkInventory
+import org.zstack.sdk.VmInstanceInventory
+import org.zstack.test.integration.kvm.KvmTest
+import org.zstack.testlib.EnvSpec
+import org.zstack.testlib.SubCase
+import org.zstack.utils.data.SizeUnit
+import org.zstack.utils.gson.JSONObjectUtil
+
+class VmPmuConfigCase extends SubCase {
+    EnvSpec env
+
+    @Override
+    void clean() {
+        env.delete()
+    }
+
+    @Override
+    void setup() {
+        useSpring(KvmTest.springSpec)
+    }
+
+    @Override
+    void environment() {
+        env = env {
+            instanceOffering {
+                name = "instanceOffering"
+                memory = SizeUnit.GIGABYTE.toByte(2)
+                cpu = 1
+            }
+
+            sftpBackupStorage {
+                name = "sftp"
+                url = "/sftp"
+                username = "root"
+                password = "password"
+                hostname = "localhost"
+
+                image {
+                    name = "image_x86"
+                    architecture = ImageArchitecture.x86_64.toString()
+                    url = "http://zstack.org/download/test.qcow2"
+                }
+
+                image {
+                    name = "image_arm64"
+                    architecture = ImageArchitecture.aarch64.toString()
+                    url = "http://zstack.org/download/test-arm.qcow2"
+                }
+            }
+
+            zone {
+                name = "zone"
+                description = "test"
+
+                cluster {
+                    name = "cluster_x86"
+                    hypervisorType = "KVM"
+                    architecture = ImageArchitecture.x86_64.toString()
+
+                    kvm {
+                        name = "kvm_x86"
+                        managementIp = "localhost"
+                        username = "root"
+                        password = "password"
+                    }
+
+                    attachPrimaryStorage("local")
+                    attachL2Network("l2")
+                }
+
+                cluster {
+                    name = "cluster_arm64"
+                    hypervisorType = "KVM"
+                    architecture = ImageArchitecture.aarch64.toString()
+
+                    kvm {
+                        name = "kvm_arm64"
+                        managementIp = "127.0.0.3"
+                        username = "root"
+                        password = "password"
+                    }
+
+                    attachPrimaryStorage("local")
+                    attachL2Network("l2")
+                }
+
+                attachBackupStorage("sftp")
+
+                localPrimaryStorage {
+                    name = "local"
+                    url = "/local_ps"
+                    availableCapacity = SizeUnit.GIGABYTE.toByte(100)
+                    totalCapacity = SizeUnit.GIGABYTE.toByte(100)
+                }
+
+                l2NoVlanNetwork {
+                    name = "l2"
+                    physicalInterface = "eth0"
+
+                    l3Network {
+                        name = "l3"
+
+                        ip {
+                            startIp = "192.168.100.10"
+                            endIp = "192.168.100.100"
+                            netmask = "255.255.255.0"
+                            gateway = "192.168.100.1"
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @Override
+    void test() {
+        env.create {
+            testPmuGlobalConfigExists()
+            testPmuDefaultOnX86()
+            testPmuDefaultOffOnAarch64()
+            testPmuResourceConfigOverrideOnAarch64()
+        }
+    }
+
+    void testPmuGlobalConfigExists() {
+        List<GlobalConfigInventory> configs = queryGlobalConfig {
+            conditions = ["category=${VmGlobalConfig.CATEGORY}", "name=${VmGlobalConfig.VM_PMU.name}"]
+        }
+
+        assert configs.size() == 1
+        assert configs[0].defaultValue == "false"
+    }
+
+    void testPmuDefaultOnX86() {
+        KVMAgentCommands.StartVmCmd cmd = createVmAndCaptureStartCmd("test-pmu-x86", "image_x86")
+        assert cmd.pmu
+    }
+
+    void testPmuDefaultOffOnAarch64() {
+        KVMAgentCommands.StartVmCmd cmd = createVmAndCaptureStartCmd("test-pmu-arm", "image_arm64")
+        assert !cmd.pmu
+    }
+
+    void testPmuResourceConfigOverrideOnAarch64() {
+        ImageInventory image = env.inventoryByName("image_arm64") as ImageInventory
+        L3NetworkInventory l3 = env.inventoryByName("l3") as L3NetworkInventory
+        InstanceOfferingInventory instanceOffering = env.inventoryByName("instanceOffering") as InstanceOfferingInventory
+
+        VmInstanceInventory vm = createVmInstance {
+            name = "test-pmu-arm-override"
+            imageUuid = image.uuid
+            l3NetworkUuids = [l3.uuid]
+            instanceOfferingUuid = instanceOffering.uuid
+        } as VmInstanceInventory
+
+        updateResourceConfig {
+            category = VmGlobalConfig.CATEGORY
+            name = VmGlobalConfig.VM_PMU.name
+            value = "true"
+            resourceUuid = vm.uuid
+        }
+
+        ResourceConfigFacade rcf = bean(ResourceConfigFacade.class)
+        assert rcf.getResourceConfigValue(VmGlobalConfig.VM_PMU, vm.uuid, Boolean.class)
+
+        KVMAgentCommands.StartVmCmd cmd = null
+        env.afterSimulator(KVMConstant.KVM_START_VM_PATH) { rsp, HttpEntity<String> e ->
+            cmd = JSONObjectUtil.toObject(e.body, KVMAgentCommands.StartVmCmd.class)
+            return rsp
+        }
+
+        rebootVmInstance {
+            uuid = vm.uuid
+        }
+
+        assert cmd != null
+        assert cmd.pmu
+    }
+
+    KVMAgentCommands.StartVmCmd createVmAndCaptureStartCmd(String name, String imageName) {
+        ImageInventory image = env.inventoryByName(imageName) as ImageInventory
+        L3NetworkInventory l3 = env.inventoryByName("l3") as L3NetworkInventory
+        InstanceOfferingInventory instanceOffering = env.inventoryByName("instanceOffering") as InstanceOfferingInventory
+
+        KVMAgentCommands.StartVmCmd cmd = null
+        env.afterSimulator(KVMConstant.KVM_START_VM_PATH) { rsp, HttpEntity<String> e ->
+            cmd = JSONObjectUtil.toObject(e.body, KVMAgentCommands.StartVmCmd.class)
+            return rsp
+        }
+
+        createVmInstance {
+            name = name
+            imageUuid = image.uuid
+            l3NetworkUuids = [l3.uuid]
+            instanceOfferingUuid = instanceOffering.uuid
+        }
+
+        assert cmd != null
+        return cmd
+    }
+}


### PR DESCRIPTION
## 背景

ZSTAC-85874 是 ZSTAC-76375 在 4.4.52-sm 的 clone。Kunpeng-920 V200 7270Z/5230Z 上 openEuler 24.03 aarch64 Guest 会读取 PMMIR_EL1，4.19 Host KVM 不支持该寄存器虚拟化，导致 Guest panic/控制台黑屏。

## 修改

- 新增 `VmGlobalConfig.VM_PMU`，默认 `false`，支持 VM/Cluster 资源级覆盖。
- `StartVmCmd` 新增 `pmu` 字段，字段默认 `true`，保持旧 payload 行为。
- `KVMHost.startVm` 仅在目标 Host 架构为 `aarch64` 时读取 `vm.pmu`，默认下发 `pmu=false`；显式配置为 `true` 时可重新启用。
- 新增 `VmPmuConfigCase` 覆盖全局配置存在性、x86 默认不受影响、aarch64 默认关闭、aarch64 VM 级覆盖。

## 验证

- PASS: `git diff --check`
- BLOCKED: `mvn compile -pl compute,plugin/kvm -am -Dmaven.test.skip` 在本地 Java 17 环境下进入改动模块前失败，原因是 4.4.52-sm `utils` 依赖 JDK8 自带 `javax.xml.bind`。
- BLOCKED: `mvn -f test/pom.xml -Dtest=org.zstack.test.integration.kvm.vm.VmPmuConfigCase test` 因本地未安装 4.4.0 reactor artifacts 失败。

Resolves: ZSTAC-85874

sync from gitlab !10158