### PR TITLE
<fix>[storage,localstorage]: backport ZSTAC-85572/85581 to 4.8.38

### DIFF
--- a/plugin/localstorage/src/main/java/org/zstack/storage/primary/local/LocalStorageDesignatedAllocateCapacityFlow.java
+++ b/plugin/localstorage/src/main/java/org/zstack/storage/primary/local/LocalStorageDesignatedAllocateCapacityFlow.java
@@ -95,6 +95,7 @@ public class LocalStorageDesignatedAllocateCapacityFlow implements Flow {
                         if (msg == rootVolumeAllocationMsg) {
                             vspec.setSize(ar.getSize());
                             vspec.setPrimaryStorageInventory(ar.getPrimaryStorageInventory());
+                            vspec.setDiskOfferingUuid(msg.getDiskOfferingUuid());
                             vspec.setType(VolumeType.Root.toString());
                         } else {
                             vspec.setSize(ar.getSize());

--- a/storage/src/main/java/org/zstack/storage/snapshot/VolumeSnapshotTreeBase.java
+++ b/storage/src/main/java/org/zstack/storage/snapshot/VolumeSnapshotTreeBase.java
@@ -61,7 +61,6 @@ import org.zstack.header.volume.*;
 import org.zstack.longjob.LongJobUtils;
 import org.zstack.storage.primary.PrimaryStorageCapacityUpdater;
 import org.zstack.storage.primary.PrimaryStorageGlobalProperty;
-import org.zstack.storage.snapshot.group.VolumeSnapshotGroupOperationValidator;
 import org.zstack.storage.snapshot.reference.VolumeSnapshotReferenceUtils;
 import org.zstack.storage.volume.FireSnapShotCanonicalEvent;
 import org.zstack.tag.TagManager;
@@ -2318,8 +2317,11 @@ public class VolumeSnapshotTreeBase {
                             logger.debug(String.format("reset latest snapshot of tree[uuid:%s] to snapshot[uuid:%s]",
                                     currentRoot.getTreeUuid(), currentRoot.getParentUuid()));
                         }
+
+                        VolumeSnapshotReferenceUtils.updateReferenceAfterMarkSnapshotAsVolume(currentRoot);
                     }
                 }.execute();
+
                 cleanup();
 
                 bus.reply(msg, reply);

--- a/storage/src/main/java/org/zstack/storage/snapshot/reference/VolumeSnapshotReferenceUtils.java
+++ b/storage/src/main/java/org/zstack/storage/snapshot/reference/VolumeSnapshotReferenceUtils.java
@@ -339,6 +339,22 @@ public class VolumeSnapshotReferenceUtils {
         }
     }
 
+    public static void updateReferenceAfterMarkSnapshotAsVolume(VolumeSnapshotVO snapshot) {
+        if (VolumeSnapshotConstant.STORAGE_SNAPSHOT_TYPE.toString().equals(snapshot.getType())) {
+            return;
+        }
+
+        VolumeSnapshotReferenceVO ref = getVolumeBackingRef(snapshot.getVolumeUuid());
+        if (ref != null && snapshot.getPrimaryStorageInstallPath().equals(ref.getReferenceInstallUrl())) {
+            SQL.New(VolumeSnapshotReferenceVO.class).eq(VolumeSnapshotReferenceVO_.id, ref.getId())
+                    .set(VolumeSnapshotReferenceVO_.referenceUuid, snapshot.getVolumeUuid())
+                    .set(VolumeSnapshotReferenceVO_.referenceType, VolumeVO.class.getSimpleName())
+                    .update();
+            logger.debug(String.format("update volume snapshot reference[referVolumeSnapshotUuid:%s, referVolumeUuid:%s] after mark snapshot as volume",
+                    snapshot.getUuid(), snapshot.getVolumeUuid()));
+        }
+    }
+
     public static void cleanTemporaryImageReference(List<ImageInventory> images) {
         if (!PrimaryStorageGlobalProperty.USE_SNAPSHOT_AS_INCREMENTAL_CACHE || CollectionUtils.isEmpty(images)) {
             return;


### PR DESCRIPTION
## Backport to 4.8.38 — cross-repo group `@@3` (zstack-utility + zstack + premium, must merge together)

Cherry-picked from 5.5.x:
- **ZSTAC-85572** `f70f6403bb` `<fix>[storage]: update reference after mark snapshot as volume` — double-nfs vm restart fail (import-order conflict resolved)
- **ZSTAC-85581** `eb1c5fd057` `<fix>[localstorage]: set diskoffering uuid on LocalStorageDesignatedAllocateCapacityFlow` — core half of root-volume qos fix

⚠️ **ZSTAC-85581 spans core + premium** — must merge together with the premium `@@3` MR (`a827e9d02c` adapted).

Full premium build green locally. Cases run by CI.

sync from gitlab !10161