### PR TITLE
<fix>[kvm]: drain stale http calls on agent restart

### DIFF
--- a/core/src/main/java/org/zstack/core/rest/RESTFacadeImpl.java
+++ b/core/src/main/java/org/zstack/core/rest/RESTFacadeImpl.java
@@ -25,6 +25,7 @@ import org.zstack.core.thread.ThreadFacade;
 import org.zstack.core.thread.ThreadFacadeImpl.TimeoutTaskReceipt;
 import org.zstack.core.timeout.ApiTimeoutManager;
 import org.zstack.core.validation.ValidationFacade;
+import org.zstack.header.Constants;
 import org.zstack.header.core.Completion;
 import org.zstack.header.core.ReturnValueCompletion;
 import org.zstack.header.errorcode.ErrorCode;
@@ -80,6 +81,10 @@ public class RESTFacadeImpl implements RESTFacade {
         void fail(ErrorCode err);
 
         void success(HttpEntity<String> responseEntity);
+
+        String getResourceUuid();
+
+        long getSentAtMillis();
     }
 
     private interface HttpCallHandlerWrapper {
@@ -341,6 +346,9 @@ public class RESTFacadeImpl implements RESTFacade {
 
         HttpEntity<String> req = new HttpEntity<String>(body, requestHeaders);
 
+        final long sentAtMillis = System.currentTimeMillis();
+        final String resourceUuid = (headers == null) ? null : headers.get(Constants.AGENT_HTTP_HEADER_RESOURCE_UUID);
+
         AsyncHttpWrapper wrapper = new AsyncHttpWrapper() {
             final AtomicBoolean called = new AtomicBoolean(false);
 
@@ -435,6 +443,16 @@ public class RESTFacadeImpl implements RESTFacade {
             public void success(HttpEntity<String> responseEntity) {
                 completion.success(responseEntity);
             }
+
+            @Override
+            public String getResourceUuid() {
+                return resourceUuid;
+            }
+
+            @Override
+            public long getSentAtMillis() {
+                return sentAtMillis;
+            }
         };
 
         try {
@@ -468,6 +486,29 @@ public class RESTFacadeImpl implements RESTFacade {
     public void asyncJsonPost(String url, String body, AsyncRESTCallback callback) {
         Long timeout = timeoutMgr.getTimeout();
         asyncJsonPost(url, body, callback, TimeUnit.MILLISECONDS, timeout);
+    }
+
+    @Override
+    public int failPendingCallsForResourceBefore(String resourceUuid, long cutoffMillis, ErrorCode err) {
+        if (resourceUuid == null) {
+            return 0;
+        }
+        int drained = 0;
+        for (AsyncHttpWrapper w : wrappers.values()) {
+            if (!resourceUuid.equals(w.getResourceUuid())) {
+                continue;
+            }
+            if (w.getSentAtMillis() >= cutoffMillis) {
+                continue;
+            }
+            try {
+                w.fail(err);
+                drained++;
+            } catch (Throwable t) {
+                logger.warn(String.format("fail injection threw for resource[uuid:%s]: %s", resourceUuid, t.getMessage()), t);
+            }
+        }
+        return drained;
     }
 
     @Override

--- a/header/src/main/java/org/zstack/header/rest/RESTFacade.java
+++ b/header/src/main/java/org/zstack/header/rest/RESTFacade.java
@@ -11,6 +11,7 @@ import org.springframework.http.converter.HttpMessageConverter;
 import org.springframework.http.converter.StringHttpMessageConverter;
 import org.springframework.web.client.RestTemplate;
 import org.zstack.header.core.Completion;
+import org.zstack.header.errorcode.ErrorCode;
 
 import javax.net.ssl.SSLContext;
 import javax.servlet.http.HttpServletRequest;
@@ -35,6 +36,8 @@ public interface RESTFacade {
     void asyncJsonPost(String url, String body, AsyncRESTCallback callback);
     void asyncJsonDelete(String url, String body, Map<String, String> headers, AsyncRESTCallback callback, TimeUnit unit, long timeout);
     void asyncJsonGet(String url, String body, Map<String, String> headers, AsyncRESTCallback callback, TimeUnit unit, long timeout);
+
+    int failPendingCallsForResourceBefore(String resourceUuid, long cutoffMillis, ErrorCode err);
 
     <T> T syncJsonPost(String url, Object body, Class<T> returnClass);
 

--- a/plugin/kvm/src/main/java/org/zstack/kvm/KVMAgentCommands.java
+++ b/plugin/kvm/src/main/java/org/zstack/kvm/KVMAgentCommands.java
@@ -337,6 +337,8 @@ public class KVMAgentCommands {
     public static class ConnectResponse extends AgentResponse {
         private String libvirtVersion;
         private String qemuVersion;
+        private boolean firstConnect;
+        private long agentStartTimeMillis;
 
         public String getLibvirtVersion() {
             return libvirtVersion;
@@ -352,6 +354,22 @@ public class KVMAgentCommands {
 
         public void setQemuVersion(String qemuVersion) {
             this.qemuVersion = qemuVersion;
+        }
+
+        public boolean isFirstConnect() {
+            return firstConnect;
+        }
+
+        public void setFirstConnect(boolean firstConnect) {
+            this.firstConnect = firstConnect;
+        }
+
+        public long getAgentStartTimeMillis() {
+            return agentStartTimeMillis;
+        }
+
+        public void setAgentStartTimeMillis(long agentStartTimeMillis) {
+            this.agentStartTimeMillis = agentStartTimeMillis;
         }
     }
 

--- a/plugin/kvm/src/main/java/org/zstack/kvm/KVMHost.java
+++ b/plugin/kvm/src/main/java/org/zstack/kvm/KVMHost.java
@@ -5036,6 +5036,16 @@ public class KVMHost extends HostBase implements Host {
                 errCode = operr("unable to connect to kvm host[uuid:%s, ip:%s, url:%s], because %s",
                         self.getUuid(), self.getManagementIp(), connectPath, rsp.getError());
             } else {
+                if (rsp.isFirstConnect()) {
+                    long cutoffMillis = rsp.getAgentStartTimeMillis() - TimeUnit.SECONDS.toMillis(60);
+                    int drained = restf.failPendingCallsForResourceBefore(self.getUuid(), cutoffMillis,
+                            operr("kvmagent on host[uuid:%s] restarted at %s, pending HTTP call sent before %s aborted",
+                                    self.getUuid(), rsp.getAgentStartTimeMillis(), cutoffMillis));
+                    if (drained > 0) {
+                        logger.info(String.format("kvmagent on host[uuid:%s] restarted at %d, drained %d pending HTTP call(s)",
+                                self.getUuid(), rsp.getAgentStartTimeMillis(), drained));
+                    }
+                }
                 VersionComparator libvirtVersion = new VersionComparator(rsp.getLibvirtVersion());
                 VersionComparator qemuVersion = new VersionComparator(rsp.getQemuVersion());
                 boolean liveSnapshot = libvirtVersion.compare(KVMConstant.MIN_LIBVIRT_LIVESNAPSHOT_VERSION) >= 0

--- a/test/src/test/groovy/org/zstack/test/integration/kvm/host/HostAgentRestartDrainCase.groovy
+++ b/test/src/test/groovy/org/zstack/test/integration/kvm/host/HostAgentRestartDrainCase.groovy
@@ -1,0 +1,117 @@
+package org.zstack.test.integration.kvm.host
+
+import org.springframework.http.HttpEntity
+import org.zstack.header.Constants
+import org.zstack.header.errorcode.ErrorCode
+import org.zstack.header.errorcode.SysErrors
+import org.zstack.header.rest.JsonAsyncRESTCallback
+import org.zstack.header.rest.RESTFacade
+import org.zstack.kvm.KVMAgentCommands
+import org.zstack.kvm.KVMConstant
+import org.zstack.sdk.HostInventory
+import org.zstack.test.integration.kvm.Env
+import org.zstack.test.integration.kvm.KvmTest
+import org.zstack.testlib.EnvSpec
+import org.zstack.testlib.SubCase
+
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
+
+class HostAgentRestartDrainCase extends SubCase {
+    EnvSpec env
+    HostInventory host
+    RESTFacade restf
+
+    static class StuckCall {
+        CountDownLatch entered = new CountDownLatch(1)
+        CountDownLatch release = new CountDownLatch(1)
+        CountDownLatch done = new CountDownLatch(1)
+        AtomicReference<ErrorCode> received = new AtomicReference<>()
+    }
+
+    @Override
+    void setup() {
+        useSpring(KvmTest.springSpec)
+    }
+
+    @Override
+    void environment() {
+        env = Env.noVmEnv()
+    }
+
+    @Override
+    void test() {
+        env.create {
+            host = env.inventoryByName("kvm")
+            restf = bean(RESTFacade.class)
+            testFirstConnectDrainsStaleCalls()
+            testNoFirstConnectKeepsStaleCalls()
+            testDifferentResourceUuidIsolated()
+        }
+    }
+
+    @Override
+    void clean() {
+        env.delete()
+    }
+
+    private StuckCall sendStuckCall(String resourceUuid) {
+        StuckCall h = new StuckCall()
+        def stuckPath = "/test/stuck/${UUID.randomUUID()}"
+        env.simulator(stuckPath) {
+            h.entered.countDown()
+            h.release.await(120, TimeUnit.SECONDS)
+            return new KVMAgentCommands.AgentResponse()
+        }
+
+        Map<String, String> headers = [(Constants.AGENT_HTTP_HEADER_RESOURCE_UUID): resourceUuid]
+        restf.asyncJsonPost(restf.makeUrl(stuckPath), "{}", headers, new JsonAsyncRESTCallback<String>(null) {
+            @Override void fail(ErrorCode err) { h.received.set(err); h.done.countDown() }
+            @Override void success(String ret) { h.done.countDown() }
+            @Override Class<String> getReturnClass() { return String.class }
+        }, TimeUnit.MINUTES, 30)
+        assert h.entered.await(5, TimeUnit.SECONDS)
+        return h
+    }
+
+    private void overrideConnectResponse(boolean firstConnect, long agentStartTimeMillis) {
+        env.afterSimulator(KVMConstant.KVM_CONNECT_PATH) { KVMAgentCommands.ConnectResponse rsp, HttpEntity<String> e ->
+            rsp.firstConnect = firstConnect
+            rsp.agentStartTimeMillis = agentStartTimeMillis
+            return rsp
+        }
+    }
+
+    void testFirstConnectDrainsStaleCalls() {
+        StuckCall h = sendStuckCall(host.uuid)
+        overrideConnectResponse(true, System.currentTimeMillis() + 70_000L)
+        reconnectHost {
+            uuid = host.uuid
+        }
+        assert h.done.await(5, TimeUnit.SECONDS)
+        assert h.received.get() != null
+        assert h.received.get().code == SysErrors.OPERATION_ERROR.toString()
+        h.release.countDown()
+    }
+
+    void testNoFirstConnectKeepsStaleCalls() {
+        StuckCall h = sendStuckCall(host.uuid)
+        overrideConnectResponse(false, System.currentTimeMillis() + 70_000L)
+        reconnectHost {
+            uuid = host.uuid
+        }
+        assert !h.done.await(500, TimeUnit.MILLISECONDS)
+        h.release.countDown()
+    }
+
+    void testDifferentResourceUuidIsolated() {
+        StuckCall h = sendStuckCall("unrelated-resource-uuid")
+        overrideConnectResponse(true, System.currentTimeMillis() + 70_000L)
+        reconnectHost {
+            uuid = host.uuid
+        }
+        assert !h.done.await(500, TimeUnit.MILLISECONDS)
+        h.release.countDown()
+    }
+}


### PR DESCRIPTION
Resolves: ZSTAC-58310

Backport for ZSTAC-65590 (4.8.38 clone of ZSTAC-58310).

(cherry picked from commit b569092d72, MR !9904, 5.5.22)

Adaptation for 4.8.38: structured error-code subsystem (conf/i18n/globalErrorCodeMapping + CloudOperationsErrorCode, ORG_ZSTACK_CORE_REST_10013) does not exist on this branch — dropped the error-code constant, KVMHost uses plain operr(fmt, args); added missing `import org.zstack.header.Constants` in RESTFacadeImpl (5.5.22 already had it as context).

Companion zstack-utility MR on same branch name (@@2 group).

sync from gitlab !10186