### PR TITLE
<fix>[ldap]: add more global properties for ldap context source

### DIFF
--- a/plugin/ldap/src/main/java/org/zstack/ldap/LdapGlobalProperty.java
+++ b/plugin/ldap/src/main/java/org/zstack/ldap/LdapGlobalProperty.java
@@ -13,4 +13,10 @@ public class LdapGlobalProperty {
 
     @GlobalProperty(name = "Ldap.addServer.readTimeout", defaultValue = "5000")
     public static int LDAP_ADD_SERVER_READ_TIMEOUT;
+
+    @GlobalProperty(name = "Ldap.referral", defaultValue = "follow")
+    public static String LDAP_REFERRAL;
+
+    @GlobalProperty(name = "Ldap.connect.pool", defaultValue = "false")
+    public static boolean LDAP_CONNECT_POOL;
 }

--- a/plugin/ldap/src/main/java/org/zstack/ldap/LdapUtil.java
+++ b/plugin/ldap/src/main/java/org/zstack/ldap/LdapUtil.java
@@ -1,6 +1,7 @@
 package org.zstack.ldap;
 
 import org.apache.commons.lang.StringUtils;
+import org.apache.logging.log4j.util.Strings;
 import org.springframework.ldap.NamingException;
 import org.springframework.ldap.control.PagedResultsDirContextProcessor;
 import org.springframework.ldap.core.DirContextOperations;
@@ -167,8 +168,11 @@ public class LdapUtil {
             }
         }
         ldapContextSource.setCacheEnvironmentProperties(false);
-        ldapContextSource.setPooled(false);
-        ldapContextSource.setReferral("follow");
+        ldapContextSource.setPooled(LdapGlobalProperty.LDAP_CONNECT_POOL);
+
+        if (!Strings.isEmpty(LdapGlobalProperty.LDAP_REFERRAL)) {
+            ldapContextSource.setReferral(LdapGlobalProperty.LDAP_REFERRAL);
+        }
 
         if (baseEnvironmentProperties != null && !baseEnvironmentProperties.isEmpty()) {
             ldapContextSource.setBaseEnvironmentProperties(baseEnvironmentProperties);

--- a/test/src/test/groovy/org/zstack/test/unittest/ldap/TestLdapSearchCase.java
+++ b/test/src/test/groovy/org/zstack/test/unittest/ldap/TestLdapSearchCase.java
@@ -1,0 +1,78 @@
+package org.zstack.test.unittest.ldap;
+
+import com.unboundid.ldap.sdk.*;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.zapodot.junit.ldap.EmbeddedLdapRule;
+import org.zapodot.junit.ldap.EmbeddedLdapRuleBuilder;
+
+import java.util.Arrays;
+
+public class TestLdapSearchCase {
+    public static String DOMAIN_DSN = "dc=example,dc=com";
+
+    static {
+        System.setProperty("com.unboundid.ldap.sdk.debug.enabled", "true");
+        System.setProperty("com.unboundid.ldap.sdk.debug.level", "FINEST");
+        System.setProperty("com.unboundid.ldap.sdk.LDAPConnectionOptions.followReferrals", "true");
+    }
+
+    @ClassRule
+    public static EmbeddedLdapRule embeddedLdapRule = EmbeddedLdapRuleBuilder
+            .newInstance()
+            .usingDomainDsn("dc=example,dc=com")
+            .importingLdifs("users-import.ldif")
+            .bindingToPort(10389)
+            .build();
+
+    @Test
+    public void testLdapWithIgnore() {
+        try (LDAPConnection ldapConnection = embeddedLdapRule.unsharedLdapConnection()) {
+            ldapConnection.getConnectionOptions().setFollowReferrals(false);
+            SearchResult searchResult = ldapConnection.search(
+                    DOMAIN_DSN,
+                    SearchScope.SUB,
+                    "(objectclass=*)");
+
+            System.out.printf("Found %d entries%n", searchResult.getEntryCount());
+            for (SearchResultEntry entry : searchResult.getSearchEntries()) {
+                System.out.println(entry.getDN());
+                for (Attribute attribute : entry.getAttributes()) {
+                    System.out.printf("  %s: %s%n", attribute.getName(), attribute.getValue());
+                }
+            }
+
+            System.out.println("Found referral URLs:" + Arrays.toString(searchResult.getReferralURLs()));
+            assert searchResult.getEntryCount() == 6;
+        } catch (Exception e) {
+            assert false : "Unexpected error during testLdapWithIgnore";
+        }
+    }
+
+    @Test
+    public void testLdapWithReferral() throws LDAPException {
+        try (LDAPConnection ldapConnection = embeddedLdapRule.unsharedLdapConnection()) {
+            ldapConnection.getConnectionOptions().setFollowReferrals(true);
+            SearchResult searchResult = ldapConnection.search(
+                    DOMAIN_DSN,
+                    SearchScope.SUB,
+                    "(objectclass=*)");
+
+            System.out.printf("Found %d entries%n", searchResult.getEntryCount());
+            for (SearchResultEntry entry : searchResult.getSearchEntries()) {
+                System.out.println(entry.getDN());
+                for (Attribute attribute : entry.getAttributes()) {
+                    System.out.printf("  %s: %s%n", attribute.getName(), attribute.getValue());
+                }
+            }
+
+            System.out.println("Found referral URLs:" + Arrays.toString(searchResult.getReferralURLs()));
+            assert searchResult.getReferenceCount() == 1024;
+        } catch (StackOverflowError e) {
+            System.out.print("stack over flow expected");
+            return;
+        }
+
+        assert false : "Unexpected here";
+    }
+}

--- a/test/src/test/resources/users-import.ldif
+++ b/test/src/test/resources/users-import.ldif
@@ -43,3 +43,10 @@ cn: John Steinbeck
 sn: Steinbeck
 uid: jsteinbeck
 userPassword: password
+
+dn: ou=referral test,dc=example,dc=com
+objectClass: extensibleObject
+objectClass: referral
+objectClass: top
+objectClass: person
+ref: ldap://localhost:10389/dc=example,dc=com


### PR DESCRIPTION
## Backport ZSTAC-81454 to 4.8.38

Cherry-pick of LDAP fix from 原单 ZSTAC-66029, picked from the 4.8.36 cherry-pick MRs (zstack !9084 / premium !12819).

Original commits: 4451fde0ca, c455b0ab7e (from zstackio/zstack !9084, source ZSTAC-81454@@2)
Local cherry-pick HEAD: aa75cce4fc

### Changes
```
 .../java/org/zstack/ldap/LdapGlobalProperty.java   |  6 ++
 .../src/main/java/org/zstack/ldap/LdapUtil.java    |  8 ++-
 .../test/unittest/ldap/TestLdapSearchCase.java     | 78 ++++++++++++++++++++++
 test/src/test/resources/users-import.ldif          |  9 ++-
 4 files changed, 98 insertions(+), 3 deletions(-)
```

### Related MRs
- premium MR: to be linked (sibling backport, branch bugfix/ZSTAC-81454@@2)

Related: ZSTAC-81454

sync from gitlab !10192