### PR TITLE
<fix>[volume-cache]: ZSTAC-85778 fix volume cache final delete

### DIFF
--- a/header/src/main/java/org/zstack/header/volume/VolumeBeforeFinalDeleteExtensionPoint.java
+++ b/header/src/main/java/org/zstack/header/volume/VolumeBeforeFinalDeleteExtensionPoint.java
@@ -1,0 +1,7 @@
+package org.zstack.header.volume;
+
+import org.zstack.header.core.Completion;
+
+public interface VolumeBeforeFinalDeleteExtensionPoint {
+    void volumeBeforeFinalDelete(VolumeInventory volume, boolean bestEffort, Completion completion);
+}

--- a/storage/src/main/java/org/zstack/storage/volume/VolumeBase.java
+++ b/storage/src/main/java/org/zstack/storage/volume/VolumeBase.java
@@ -976,6 +976,30 @@ public class VolumeBase extends AbstractVolume implements Volume {
                         }
                     });
                 }
+
+                flow(new Flow() {
+                    String __name__ = "before-final-delete-volume-extension";
+
+                    @Override
+                    public void run(FlowTrigger trigger, Map data) {
+                        callVolumeBeforeFinalDeleteExtensionPoint(inv, false, new Completion(trigger) {
+                            @Override
+                            public void success() {
+                                trigger.next();
+                            }
+
+                            @Override
+                            public void fail(ErrorCode errorCode) {
+                                trigger.fail(errorCode);
+                            }
+                        });
+                    }
+
+                    @Override
+                    public void rollback(FlowRollback trigger, Map data) {
+                        trigger.rollback();
+                    }
+                });
             }
         }).done(new FlowDoneHandler(completion) {
             @Override
@@ -1327,6 +1351,32 @@ public class VolumeBase extends AbstractVolume implements Volume {
                     }
                 });
 
+                if (deletionPolicy == VolumeDeletionPolicy.Direct || deletionPolicy == VolumeDeletionPolicy.DBOnly) {
+                    flow(new Flow() {
+                        String __name__ = "before-final-delete-volume-extension";
+
+                        @Override
+                        public void run(FlowTrigger trigger, Map data) {
+                            callVolumeBeforeFinalDeleteExtensionPoint(getSelfInventory(), msg.isForceDelete(), new Completion(trigger) {
+                                @Override
+                                public void success() {
+                                    trigger.next();
+                                }
+
+                                @Override
+                                public void fail(ErrorCode errorCode) {
+                                    trigger.fail(errorCode);
+                                }
+                            });
+                        }
+
+                        @Override
+                        public void rollback(FlowRollback trigger, Map data) {
+                            trigger.rollback();
+                        }
+                    });
+                }
+
 
                 done(new FlowDoneHandler(msg) {
                     @Override
@@ -1539,6 +1589,33 @@ public class VolumeBase extends AbstractVolume implements Volume {
     private void callVolumeJustBeforeDeleteFromDbExtensionPoint() {
         VolumeInventory inv = getSelfInventory();
         CollectionUtils.safeForEach(pluginRgty.getExtensionList(VolumeJustBeforeDeleteFromDbExtensionPoint.class), p -> p.volumeJustBeforeDeleteFromDb(inv));
+    }
+
+    private void callVolumeBeforeFinalDeleteExtensionPoint(VolumeInventory inv, boolean bestEffort, Completion completion) {
+        ErrorCodeList errList = new ErrorCodeList();
+        new While<>(pluginRgty.getExtensionList(VolumeBeforeFinalDeleteExtensionPoint.class)).each((ext, c) ->
+                ext.volumeBeforeFinalDelete(inv, bestEffort, new Completion(c) {
+                    @Override
+                    public void success() {
+                        c.done();
+                    }
+
+                    @Override
+                    public void fail(ErrorCode errorCode) {
+                        errList.getCauses().add(errorCode);
+                        c.done();
+                    }
+                })).run(new WhileDoneCompletion(completion) {
+            @Override
+            public void done(ErrorCodeList errorCodeList) {
+                if (!errList.getCauses().isEmpty()) {
+                    completion.fail(errList.getCauses().get(0));
+                    return;
+                }
+
+                completion.success();
+            }
+        });
     }
 
     private void handle(final VolumeDeletionMsg msg) {


### PR DESCRIPTION
## Summary
Volume cache now follows the owning volume's final-deletion lifecycle. Recoverable volume deletion keeps cache data, while direct final deletion, expunge, and recycle-bin cleanup run the cache delete path before removing the volume record.

## Changes
- Add a fail-capable `VolumeBeforeFinalDeleteExtensionPoint`.
- Invoke the final-delete hook from direct/DBOnly volume deletion and volume expunge before `VolumeVO` is removed.

## Testing
- [x] `git -C zstack diff --check upstream/feature-5.5.6-local-cache..HEAD`
- [x] `git -C zstack rev-list HEAD..upstream/feature-5.5.6-local-cache --count` -> `0`
- [x] Latest commit includes `Change-Id: Id850d40f3ee737d7c7987673e11d3fe2b4a79f6a`
- [x] `openspec validate zstac-85778-volume-cache-lifecycle`
- [x] `premium/mevoco` compilation reached `BUILD SUCCESS` in earlier local validation
- [ ] `scripts/backend-build-container/container-run test-premium --package premium/mevoco VolumeCacheCase` blocked before running the case by environment fd exhaustion: `Too many open files in system` while compiling unrelated `VipQosAcquireVipCase.groovy`

Related premium MR: http://dev.zstack.io:9080/zstackio/premium/-/merge_requests/14254

Resolves: ZSTAC-85778

sync from gitlab !10195