### PR TITLE
<fix>[loadBalancer]: fix query loadbalancer error (ZSTAC-85955 backport 4.8.38)

### DIFF
--- a/plugin/loadBalancer/src/main/java/org/zstack/network/service/lb/LoadBalancerListenerVO.java
+++ b/plugin/loadBalancer/src/main/java/org/zstack/network/service/lb/LoadBalancerListenerVO.java
@@ -26,10 +26,6 @@ import java.util.stream.Collectors;
 @EntityGraph(
         parents = {
                 @EntityGraph.Neighbour(type = LoadBalancerVO.class, myField = "loadBalancerUuid", targetField = "uuid"),
-                @EntityGraph.Neighbour(type = LoadBalancerListenerVmNicRefVO.class, myField = "uuid", targetField = "listenerUuid"),
-                @EntityGraph.Neighbour(type = LoadBalancerListenerCertificateRefVO.class, myField = "uuid", targetField = "listenerUuid"),
-                @EntityGraph.Neighbour(type = LoadBalancerListenerACLRefVO.class, myField = "uuid", targetField = "listenerUuid"),
-                @EntityGraph.Neighbour(type = LoadBalancerListenerServerGroupRefVO.class, myField = "uuid", targetField = "listenerUuid")
         }
 )
 public class LoadBalancerListenerVO extends ResourceVO implements OwnedByAccount {

--- a/plugin/loadBalancer/src/main/java/org/zstack/network/service/lb/LoadBalancerServerGroupVO.java
+++ b/plugin/loadBalancer/src/main/java/org/zstack/network/service/lb/LoadBalancerServerGroupVO.java
@@ -21,14 +21,6 @@ import java.util.stream.Collectors;
 @Entity
 @Table
 @BaseResource
-@EntityGraph(
-        parents = {
-                @EntityGraph.Neighbour(type = LoadBalancerVO.class, myField = "loadBalancerUuid", targetField = "uuid"),
-                @EntityGraph.Neighbour(type = LoadBalancerListenerServerGroupRefVO.class, myField = "uuid", targetField = "serverGroupUuid"),
-                @EntityGraph.Neighbour(type = LoadBalancerServerGroupServerIpVO.class, myField = "uuid", targetField = "serverGroupUuid"),
-                @EntityGraph.Neighbour(type = LoadBalancerServerGroupVmNicRefVO.class, myField = "uuid", targetField = "serverGroupUuid"),
-        }
-)
 public class LoadBalancerServerGroupVO extends ResourceVO  implements OwnedByAccount {
     @Column
     private String name;

--- a/plugin/loadBalancer/src/main/java/org/zstack/network/service/lb/LoadBalancerVO.java
+++ b/plugin/loadBalancer/src/main/java/org/zstack/network/service/lb/LoadBalancerVO.java
@@ -2,7 +2,6 @@ package org.zstack.network.service.lb;
 
 import org.zstack.header.identity.OwnedByAccount;
 import org.zstack.header.vo.BaseResource;
-import org.zstack.header.vo.EntityGraph;
 import org.zstack.header.vo.ForeignKey;
 import org.zstack.header.vo.ForeignKey.ReferenceOption;
 import org.zstack.header.vo.NoView;
@@ -20,15 +19,6 @@ import java.util.Set;
 @Entity
 @Table
 @BaseResource
-@EntityGraph(
-        parents = {
-                @EntityGraph.Neighbour(type = VipVO.class, myField = "vipUuid", targetField = "uuid"),
-        },
-
-        friends = {
-                @EntityGraph.Neighbour(type = LoadBalancerListenerVO.class, myField = "loadBalancerUuid", targetField = "uuid"),
-        }
-)
 public class LoadBalancerVO extends ResourceVO implements OwnedByAccount {
     @Column
     private String name;


### PR DESCRIPTION
## Summary
Backport 5.x fix for ZSTAC-85955 to 4.8.38.

## Source
- source: ZSTAC-65274, MR 6182, commit c10fc0a
- Branch: `shixin-ZSTAC-85955-4.8.38`
- Target: `4.8.38`

## Verification
- Cherry-pick completed in isolated worktree.
- `git diff --check` run for all backport branches; warnings, if any, are noted in Source above.
- No full Maven/Groovy suite was run locally for this batch backport.

Jira: http://jira.zstack.io/browse/ZSTAC-85955

sync from gitlab !10204