### PR TITLE
<fix>[network]: update sdk and doc for l2Network api (ZSTAC-85724 backport 4.8.38)

### DIFF
--- a/header/src/main/java/org/zstack/header/network/l2/APICreateL2NoVlanNetworkMsgDoc_zh_cn.groovy
+++ b/header/src/main/java/org/zstack/header/network/l2/APICreateL2NoVlanNetworkMsgDoc_zh_cn.groovy
@@ -74,6 +74,7 @@ doc {
 					type "String"
 					optional true
 					since "4.1.0"
+					values ("LinuxBridge","OvsDpdk","MacVlan")
 				}
 				column {
 					name "resourceUuid"

--- a/header/src/main/java/org/zstack/header/network/l2/APICreateL2VlanNetworkEvent.java
+++ b/header/src/main/java/org/zstack/header/network/l2/APICreateL2VlanNetworkEvent.java
@@ -1,6 +1,5 @@
 package org.zstack.header.network.l2;
 
-import org.zstack.header.message.APIEvent;
 import org.zstack.header.rest.RestResponse;
 
 /**
@@ -26,12 +25,7 @@ import org.zstack.header.rest.RestResponse;
  * @since 0.1.0
  */
 @RestResponse(allTo = "inventory")
-public class APICreateL2VlanNetworkEvent extends APIEvent {
-    /**
-     * @desc see :ref:`L2VlanNetworkInventory`
-     */
-    private L2VlanNetworkInventory inventory;
-
+public class APICreateL2VlanNetworkEvent extends APICreateL2NetworkEvent {
     public APICreateL2VlanNetworkEvent(String apiId) {
         super(apiId);
     }
@@ -40,14 +34,6 @@ public class APICreateL2VlanNetworkEvent extends APIEvent {
         super(null);
     }
 
-    public L2VlanNetworkInventory getInventory() {
-        return inventory;
-    }
-
-    public void setInventory(L2VlanNetworkInventory inventory) {
-        this.inventory = inventory;
-    }
- 
     public static APICreateL2VlanNetworkEvent __example__() {
         APICreateL2VlanNetworkEvent event = new APICreateL2VlanNetworkEvent();
         L2VlanNetworkInventory net = new L2VlanNetworkInventory();

--- a/header/src/main/java/org/zstack/header/network/l2/APICreateL2VlanNetworkMsg.java
+++ b/header/src/main/java/org/zstack/header/network/l2/APICreateL2VlanNetworkMsg.java
@@ -1,8 +1,6 @@
 package org.zstack.header.network.l2;
 
 import org.springframework.http.HttpMethod;
-import org.zstack.header.message.APIEvent;
-import org.zstack.header.message.APIMessage;
 import org.zstack.header.message.APIParam;
 import org.zstack.header.rest.RestRequest;
 import org.zstack.header.tag.TagResourceType;
@@ -69,7 +67,7 @@ public class APICreateL2VlanNetworkMsg extends APICreateL2NetworkMsg {
     public String getType() {
         return L2NetworkConstant.L2_VLAN_NETWORK_TYPE;
     }
- 
+
     public static APICreateL2VlanNetworkMsg __example__() {
         APICreateL2VlanNetworkMsg msg = new APICreateL2VlanNetworkMsg();
 
@@ -80,10 +78,5 @@ public class APICreateL2VlanNetworkMsg extends APICreateL2NetworkMsg {
         msg.setPhysicalInterface("eth0");
 
         return msg;
-    }
-
-    @Override
-    public Result audit(APIMessage msg, APIEvent rsp) {
-        return new Result(rsp.isSuccess() ? ((APICreateL2VlanNetworkEvent)rsp).getInventory().getUuid() : "", L2NetworkVO.class);
     }
 }

--- a/header/src/main/java/org/zstack/header/network/l2/APICreateL2VlanNetworkMsgDoc_zh_cn.groovy
+++ b/header/src/main/java/org/zstack/header/network/l2/APICreateL2VlanNetworkMsgDoc_zh_cn.groovy
@@ -3,11 +3,11 @@ package org.zstack.header.network.l2
 import org.zstack.header.network.l2.APICreateL2VlanNetworkEvent
 
 doc {
-    title "创建Vlan二层网络(CreateL2VlanNetwork)"
+    title "创建二层Vlan网络(CreateL2VlanNetwork)"
 
     category "二层网络"
 
-    desc """创建Vlan二层网络"""
+    desc """创建二层Vlan网络"""
 
     rest {
         request {
@@ -83,6 +83,7 @@ doc {
 					type "String"
 					optional true
 					since "4.1.0"
+					values ("LinuxBridge","OvsDpdk","MacVlan")
 				}
 				column {
 					name "resourceUuid"

--- a/header/src/main/java/org/zstack/header/network/l2/APIGetVSwitchTypesReplyDoc_zh_cn.groovy
+++ b/header/src/main/java/org/zstack/header/network/l2/APIGetVSwitchTypesReplyDoc_zh_cn.groovy
@@ -4,7 +4,7 @@ import org.zstack.header.errorcode.ErrorCode
 
 doc {
 
-    title "虚拟交换机清单"
+    title "虚拟交换机类型清单"
 
     ref {
         name "error"

--- a/header/src/main/java/org/zstack/header/network/l2/L2NetworkInventoryDoc_zh_cn.groovy
+++ b/header/src/main/java/org/zstack/header/network/l2/L2NetworkInventoryDoc_zh_cn.groovy
@@ -5,7 +5,7 @@ import java.sql.Timestamp
 
 doc {
 
-	title "在这里输入结构的名称"
+	title "二层网络清单"
 
 	field {
 		name "uuid"
@@ -33,13 +33,13 @@ doc {
 	}
 	field {
 		name "physicalInterface"
-		desc ""
+		desc "物理网卡"
 		type "String"
 		since "0.6"
 	}
 	field {
 		name "type"
-		desc ""
+		desc "二层网络类型"
 		type "String"
 		since "0.6"
 	}
@@ -57,7 +57,7 @@ doc {
 	}
 	field {
 		name "attachedClusterUuids"
-		desc ""
+		desc "挂载集群的UUID列表"
 		type "List"
 		since "0.6"
 	}

--- a/header/src/main/java/org/zstack/header/network/l2/L2VlanNetworkInventoryDoc_zh_cn.groovy
+++ b/header/src/main/java/org/zstack/header/network/l2/L2VlanNetworkInventoryDoc_zh_cn.groovy
@@ -6,11 +6,11 @@ import java.sql.Timestamp
 
 doc {
 
-	title "在这里输入结构的名称"
+	title "二层Vlan网络清单"
 
 	field {
 		name "vlan"
-		desc ""
+		desc "Vlan号"
 		type "Integer"
 		since "0.6"
 	}
@@ -40,13 +40,13 @@ doc {
 	}
 	field {
 		name "physicalInterface"
-		desc ""
+		desc "物理网卡"
 		type "String"
 		since "0.6"
 	}
 	field {
 		name "type"
-		desc ""
+		desc "二层网络类型"
 		type "String"
 		since "0.6"
 	}
@@ -64,7 +64,7 @@ doc {
 	}
 	field {
 		name "attachedClusterUuids"
-		desc ""
+		desc "挂载集群的UUID列表"
 		type "List"
 		since "0.6"
 	}

--- a/plugin/sdnController/src/main/java/org/zstack/sdnController/header/APICreateL2HardwareVxlanNetworkEvent.java
+++ b/plugin/sdnController/src/main/java/org/zstack/sdnController/header/APICreateL2HardwareVxlanNetworkEvent.java
@@ -1,30 +1,17 @@
 package org.zstack.sdnController.header;
 
-import org.zstack.header.message.APIEvent;
+import org.zstack.header.network.l2.APICreateL2NetworkEvent;
 import org.zstack.header.rest.RestResponse;
 import org.zstack.network.l2.vxlan.vxlanNetwork.L2VxlanNetworkInventory;
 
 @RestResponse(allTo = "inventory")
-public class APICreateL2HardwareVxlanNetworkEvent extends APIEvent {
-    /**
-     * @desc see :ref:`L2VlanNetworkInventory`
-     */
-    private L2VxlanNetworkInventory inventory;
-
+public class APICreateL2HardwareVxlanNetworkEvent extends APICreateL2NetworkEvent {
     public APICreateL2HardwareVxlanNetworkEvent(String apiId) {
         super(apiId);
     }
 
-    public L2VxlanNetworkInventory getInventory() {
-        return inventory;
-    }
-
     public APICreateL2HardwareVxlanNetworkEvent() {
         super(null);
-    }
-
-    public void setInventory(L2VxlanNetworkInventory inventory) {
-        this.inventory = inventory;
     }
 
     public static APICreateL2HardwareVxlanNetworkEvent __example__() {

--- a/plugin/sdnController/src/main/java/org/zstack/sdnController/header/APICreateL2HardwareVxlanNetworkMsg.java
+++ b/plugin/sdnController/src/main/java/org/zstack/sdnController/header/APICreateL2HardwareVxlanNetworkMsg.java
@@ -2,9 +2,10 @@ package org.zstack.sdnController.header;
 
 import org.springframework.http.HttpMethod;
 import org.zstack.header.identity.Action;
-import org.zstack.header.message.*;
+import org.zstack.header.message.APIParam;
+import org.zstack.header.message.OverriddenApiParam;
+import org.zstack.header.message.OverriddenApiParams;
 import org.zstack.header.network.l2.APICreateL2NetworkMsg;
-import org.zstack.header.network.l2.L2NetworkVO;
 import org.zstack.header.rest.RestRequest;
 import org.zstack.header.zone.ZoneVO;
 import org.zstack.network.l2.vxlan.vxlanNetworkPool.VxlanNetworkPoolConstant;
@@ -58,10 +59,5 @@ public class APICreateL2HardwareVxlanNetworkMsg extends APICreateL2NetworkMsg {
         msg.setPoolUuid(uuid());
 
         return msg;
-    }
-
-    @Override
-    public Result audit(APIMessage msg, APIEvent rsp) {
-        return new Result(rsp.isSuccess() ? ((APICreateL2HardwareVxlanNetworkEvent) rsp).getInventory().getUuid() : "", L2NetworkVO.class);
     }
 }

--- a/plugin/sdnController/src/main/java/org/zstack/sdnController/header/APICreateL2HardwareVxlanNetworkMsgDoc_zh_cn.groovy
+++ b/plugin/sdnController/src/main/java/org/zstack/sdnController/header/APICreateL2HardwareVxlanNetworkMsgDoc_zh_cn.groovy
@@ -24,7 +24,7 @@ doc {
 				column {
 					name "vni"
 					enclosedIn "params"
-					desc ""
+					desc "Vni号"
 					location "body"
 					type "Integer"
 					optional true
@@ -33,7 +33,7 @@ doc {
 				column {
 					name "poolUuid"
 					enclosedIn "params"
-					desc ""
+					desc "VXLAN资源池UUID"
 					location "body"
 					type "String"
 					optional false
@@ -69,7 +69,7 @@ doc {
 				column {
 					name "physicalInterface"
 					enclosedIn "params"
-					desc ""
+					desc "物理网卡"
 					location "body"
 					type "String"
 					optional false
@@ -78,7 +78,7 @@ doc {
 				column {
 					name "type"
 					enclosedIn "params"
-					desc ""
+					desc "二层网络类型"
 					location "body"
 					type "String"
 					optional true
@@ -87,7 +87,7 @@ doc {
 				column {
 					name "resourceUuid"
 					enclosedIn "params"
-					desc ""
+					desc "资源UUID。若指定，二层网络会使用该字段值作为UUID"
 					location "body"
 					type "String"
 					optional true
@@ -105,7 +105,7 @@ doc {
 				column {
 					name "systemTags"
 					enclosedIn ""
-					desc ""
+					desc "系统标签"
 					location "body"
 					type "List"
 					optional true
@@ -114,7 +114,7 @@ doc {
 				column {
 					name "userTags"
 					enclosedIn ""
-					desc ""
+					desc "用户标签"
 					location "body"
 					type "List"
 					optional true
@@ -128,7 +128,7 @@ doc {
 					type "String"
 					optional true
 					since "0.6"
-					values ("LinuxBridge","OvsDpdk")
+					values ("LinuxBridge","OvsDpdk","MacVlan")
 				}
 			}
         }

--- a/plugin/sdnController/src/main/java/org/zstack/sdnController/header/APICreateL2HardwareVxlanNetworkPoolEvent.java
+++ b/plugin/sdnController/src/main/java/org/zstack/sdnController/header/APICreateL2HardwareVxlanNetworkPoolEvent.java
@@ -1,29 +1,19 @@
 package org.zstack.sdnController.header;
 
-import org.zstack.header.message.APIEvent;
+import org.zstack.header.network.l2.APICreateL2NetworkEvent;
 import org.zstack.header.rest.RestResponse;
 
 /**
  * Created by shixin.ruan on 09/30/2019.
  */
 @RestResponse(allTo = "inventory")
-public class APICreateL2HardwareVxlanNetworkPoolEvent extends APIEvent {
-    private HardwareL2VxlanNetworkPoolInventory inventory;
-
+public class APICreateL2HardwareVxlanNetworkPoolEvent extends APICreateL2NetworkEvent {
     public APICreateL2HardwareVxlanNetworkPoolEvent(String apiId) {
         super(apiId);
     }
 
-    public HardwareL2VxlanNetworkPoolInventory getInventory() {
-        return inventory;
-    }
-
     public APICreateL2HardwareVxlanNetworkPoolEvent() {
         super(null);
-    }
-
-    public void setInventory(HardwareL2VxlanNetworkPoolInventory inventory) {
-        this.inventory = inventory;
     }
 
     public static APICreateL2HardwareVxlanNetworkPoolEvent __example__() {

--- a/plugin/sdnController/src/main/java/org/zstack/sdnController/header/APICreateL2HardwareVxlanNetworkPoolMsg.java
+++ b/plugin/sdnController/src/main/java/org/zstack/sdnController/header/APICreateL2HardwareVxlanNetworkPoolMsg.java
@@ -1,11 +1,8 @@
 package org.zstack.sdnController.header;
 
 import org.springframework.http.HttpMethod;
-import org.zstack.header.message.APIEvent;
-import org.zstack.header.message.APIMessage;
 import org.zstack.header.message.APIParam;
 import org.zstack.header.network.l2.APICreateL2NetworkMsg;
-import org.zstack.header.network.l2.L2NetworkVO;
 import org.zstack.header.rest.RestRequest;
 
 @RestRequest(
@@ -41,10 +38,5 @@ public class APICreateL2HardwareVxlanNetworkPoolMsg extends APICreateL2NetworkMs
         msg.setPhysicalInterface("bond0");
 
         return msg;
-    }
-
-    @Override
-    public Result audit(APIMessage msg, APIEvent rsp) {
-        return new Result(rsp.isSuccess() ? ((APICreateL2HardwareVxlanNetworkPoolEvent) rsp).getInventory().getUuid() : "", L2NetworkVO.class);
     }
 }

--- a/plugin/sdnController/src/main/java/org/zstack/sdnController/header/APICreateL2HardwareVxlanNetworkPoolMsgDoc_zh_cn.groovy
+++ b/plugin/sdnController/src/main/java/org/zstack/sdnController/header/APICreateL2HardwareVxlanNetworkPoolMsgDoc_zh_cn.groovy
@@ -24,7 +24,7 @@ doc {
 				column {
 					name "sdnControllerUuid"
 					enclosedIn "params"
-					desc ""
+					desc "SDN控制器UUID"
 					location "body"
 					type "String"
 					optional false
@@ -60,7 +60,7 @@ doc {
 				column {
 					name "physicalInterface"
 					enclosedIn "params"
-					desc ""
+					desc "物理网卡"
 					location "body"
 					type "String"
 					optional false
@@ -69,7 +69,7 @@ doc {
 				column {
 					name "type"
 					enclosedIn "params"
-					desc ""
+					desc "二层网络类型"
 					location "body"
 					type "String"
 					optional true
@@ -78,7 +78,7 @@ doc {
 				column {
 					name "resourceUuid"
 					enclosedIn "params"
-					desc ""
+					desc "资源UUID。若指定，二层网络会使用该字段值作为UUID"
 					location "body"
 					type "String"
 					optional true
@@ -96,7 +96,7 @@ doc {
 				column {
 					name "systemTags"
 					enclosedIn ""
-					desc ""
+					desc "系统标签"
 					location "body"
 					type "List"
 					optional true
@@ -105,7 +105,7 @@ doc {
 				column {
 					name "userTags"
 					enclosedIn ""
-					desc ""
+					desc "用户标签"
 					location "body"
 					type "List"
 					optional true
@@ -119,7 +119,7 @@ doc {
 					type "String"
 					optional true
 					since "4.1.2"
-					values ("LinuxBridge","OvsDpdk")
+					values ("LinuxBridge","OvsDpdk","MacVlan")
 				}
 			}
         }

--- a/plugin/sdnController/src/main/java/org/zstack/sdnController/header/HardwareL2VxlanNetworkPoolInventoryDoc_zh_cn.groovy
+++ b/plugin/sdnController/src/main/java/org/zstack/sdnController/header/HardwareL2VxlanNetworkPoolInventoryDoc_zh_cn.groovy
@@ -12,7 +12,7 @@ doc {
 
 	field {
 		name "sdnControllerUuid"
-		desc ""
+		desc "SDN控制器UUID"
 		type "String"
 		since "3.7"
 	}
@@ -42,7 +42,7 @@ doc {
 	}
 	field {
 		name "attachedCidrs"
-		desc ""
+		desc "已加载CIDR映射表"
 		type "Map"
 		since "3.7"
 	}
@@ -72,13 +72,13 @@ doc {
 	}
 	field {
 		name "physicalInterface"
-		desc ""
+		desc "物理网卡"
 		type "String"
 		since "3.7"
 	}
 	field {
 		name "type"
-		desc ""
+		desc "二层网络类型"
 		type "String"
 		since "3.7"
 	}
@@ -96,7 +96,7 @@ doc {
 	}
 	field {
 		name "attachedClusterUuids"
-		desc ""
+		desc "挂载集群的UUID列表"
 		type "List"
 		since "3.7"
 	}

--- a/plugin/sftpBackupStorage/src/main/java/org/zstack/storage/backup/sftp/APIAddSftpBackupStorageEvent.java
+++ b/plugin/sftpBackupStorage/src/main/java/org/zstack/storage/backup/sftp/APIAddSftpBackupStorageEvent.java
@@ -8,21 +8,11 @@ public class APIAddSftpBackupStorageEvent extends APIAddBackupStorageEvent {
     public APIAddSftpBackupStorageEvent(String apiId) {
         super(apiId);
     }
-    
+
     public APIAddSftpBackupStorageEvent() {
         super(null);
     }
 
-    private SftpBackupStorageInventory inventory;
-
-    public SftpBackupStorageInventory getInventory() {
-        return inventory;
-    }
-
-    public void setInventory(SftpBackupStorageInventory inventory) {
-        this.inventory = inventory;
-    }
- 
     public static APIAddSftpBackupStorageEvent __example__() {
         APIAddSftpBackupStorageEvent event = new APIAddSftpBackupStorageEvent();
         SftpBackupStorageInventory ssInventory = new SftpBackupStorageInventory();

--- a/plugin/vxlan/src/main/java/org/zstack/network/l2/vxlan/vtep/APICreateVxlanVtepEventDoc_zh_cn.groovy
+++ b/plugin/vxlan/src/main/java/org/zstack/network/l2/vxlan/vtep/APICreateVxlanVtepEventDoc_zh_cn.groovy
@@ -5,7 +5,7 @@ import org.zstack.network.l2.vxlan.vtep.VtepInventory
 
 doc {
 
-	title "vxlan隧道端点清单"
+	title "VXLAN隧道端点清单"
 
 	field {
 		name "success"

--- a/plugin/vxlan/src/main/java/org/zstack/network/l2/vxlan/vtep/APICreateVxlanVtepMsgDoc_zh_cn.groovy
+++ b/plugin/vxlan/src/main/java/org/zstack/network/l2/vxlan/vtep/APICreateVxlanVtepMsgDoc_zh_cn.groovy
@@ -3,11 +3,11 @@ package org.zstack.network.l2.vxlan.vtep
 import org.zstack.network.l2.vxlan.vtep.APICreateVxlanVtepEvent
 
 doc {
-    title "CreateVxlanVtep"
+    title "创建VXLAN隧道端点(CreateVxlanVtep)"
 
     category "network.l2"
 
-    desc """创建vxlan隧道端点"""
+    desc """创建VXLAN隧道端点"""
 
     rest {
         request {
@@ -33,7 +33,7 @@ doc {
 				column {
 					name "poolUuid"
 					enclosedIn "params"
-					desc ""
+					desc "VXLAN资源池UUID"
 					location "body"
 					type "String"
 					optional false
@@ -42,7 +42,7 @@ doc {
 				column {
 					name "vtepIp"
 					enclosedIn "params"
-					desc ""
+					desc "隧道端点IP地址"
 					location "body"
 					type "String"
 					optional true
@@ -51,7 +51,7 @@ doc {
 				column {
 					name "resourceUuid"
 					enclosedIn "params"
-					desc ""
+					desc "资源UUID"
 					location "body"
 					type "String"
 					optional true
@@ -60,7 +60,7 @@ doc {
 				column {
 					name "systemTags"
 					enclosedIn ""
-					desc ""
+					desc "系统标签"
 					location "body"
 					type "List"
 					optional true
@@ -69,7 +69,7 @@ doc {
 				column {
 					name "userTags"
 					enclosedIn ""
-					desc ""
+					desc "用户标签"
 					location "body"
 					type "List"
 					optional true

--- a/plugin/vxlan/src/main/java/org/zstack/network/l2/vxlan/vtep/APIQueryVtepMsgDoc_zh_cn.groovy
+++ b/plugin/vxlan/src/main/java/org/zstack/network/l2/vxlan/vtep/APIQueryVtepMsgDoc_zh_cn.groovy
@@ -4,11 +4,11 @@ import org.zstack.network.l2.vxlan.vtep.APIQueryVtepReply
 import org.zstack.header.query.APIQueryMessage
 
 doc {
-    title "QueryVtep"
+    title "查询VXLAN隧道端点(QueryVtep)"
 
     category "network.l2"
 
-    desc """在这里填写API描述"""
+    desc """查询隧道端点"""
 
     rest {
         request {

--- a/plugin/vxlan/src/main/java/org/zstack/network/l2/vxlan/vtep/APIQueryVtepReplyDoc_zh_cn.groovy
+++ b/plugin/vxlan/src/main/java/org/zstack/network/l2/vxlan/vtep/APIQueryVtepReplyDoc_zh_cn.groovy
@@ -5,7 +5,7 @@ import org.zstack.network.l2.vxlan.vtep.VtepInventory
 
 doc {
 
-	title "在这里输入结构的名称"
+	title "VXLAN隧道端点清单"
 
 	field {
 		name "success"

--- a/plugin/vxlan/src/main/java/org/zstack/network/l2/vxlan/vtep/RemoteVtepInventoryDoc_zh_cn.groovy
+++ b/plugin/vxlan/src/main/java/org/zstack/network/l2/vxlan/vtep/RemoteVtepInventoryDoc_zh_cn.groovy
@@ -5,7 +5,7 @@ import java.sql.Timestamp
 
 doc {
 
-	title "vxlan网络外部vtep地址"
+	title "远端VXLAN隧道端点清单"
 
 	field {
 		name "uuid"
@@ -15,19 +15,19 @@ doc {
 	}
 	field {
 		name "vtepIp"
-		desc ""
+		desc "隧道端点IP地址"
 		type "String"
 		since "4.7.11"
 	}
 	field {
 		name "port"
-		desc ""
+		desc "端口"
 		type "Integer"
 		since "4.7.11"
 	}
 	field {
 		name "type"
-		desc ""
+		desc "类型"
 		type "String"
 		since "4.7.11"
 	}
@@ -45,7 +45,7 @@ doc {
 	}
 	field {
 		name "poolUuid"
-		desc ""
+		desc "VXLAN资源池UUID"
 		type "String"
 		since "4.7.11"
 	}

--- a/plugin/vxlan/src/main/java/org/zstack/network/l2/vxlan/vtep/VtepInventoryDoc_zh_cn.groovy
+++ b/plugin/vxlan/src/main/java/org/zstack/network/l2/vxlan/vtep/VtepInventoryDoc_zh_cn.groovy
@@ -6,7 +6,7 @@ import java.sql.Timestamp
 
 doc {
 
-	title "在这里输入结构的名称"
+	title "VXLAN隧道端点清单"
 
 	field {
 		name "uuid"
@@ -22,19 +22,19 @@ doc {
 	}
 	field {
 		name "vtepIp"
-		desc ""
+		desc "隧道端点IP地址"
 		type "String"
 		since "0.6"
 	}
 	field {
 		name "port"
-		desc ""
+		desc "端口"
 		type "Integer"
 		since "0.6"
 	}
 	field {
 		name "type"
-		desc ""
+		desc "类型"
 		type "String"
 		since "0.6"
 	}
@@ -52,7 +52,7 @@ doc {
 	}
 	field {
 		name "poolUuid"
-		desc ""
+		desc "VXLAN资源池UUID"
 		type "String"
 		since "0.6"
 	}

--- a/plugin/vxlan/src/main/java/org/zstack/network/l2/vxlan/vxlanNetwork/APICreateL2VxlanNetworkEvent.java
+++ b/plugin/vxlan/src/main/java/org/zstack/network/l2/vxlan/vxlanNetwork/APICreateL2VxlanNetworkEvent.java
@@ -1,29 +1,16 @@
 package org.zstack.network.l2.vxlan.vxlanNetwork;
 
-import org.zstack.header.message.APIEvent;
+import org.zstack.header.network.l2.APICreateL2NetworkEvent;
 import org.zstack.header.rest.RestResponse;
 
 @RestResponse(allTo = "inventory")
-public class APICreateL2VxlanNetworkEvent extends APIEvent {
-    /**
-     * @desc see :ref:`L2VlanNetworkInventory`
-     */
-    private L2VxlanNetworkInventory inventory;
-
+public class APICreateL2VxlanNetworkEvent extends APICreateL2NetworkEvent {
     public APICreateL2VxlanNetworkEvent(String apiId) {
         super(apiId);
     }
 
-    public L2VxlanNetworkInventory getInventory() {
-        return inventory;
-    }
-
     public APICreateL2VxlanNetworkEvent() {
         super(null);
-    }
-
-    public void setInventory(L2VxlanNetworkInventory inventory) {
-        this.inventory = inventory;
     }
 
     public static APICreateL2VxlanNetworkEvent __example__() {

--- a/plugin/vxlan/src/main/java/org/zstack/network/l2/vxlan/vxlanNetwork/APICreateL2VxlanNetworkEventDoc_zh_cn.groovy
+++ b/plugin/vxlan/src/main/java/org/zstack/network/l2/vxlan/vxlanNetwork/APICreateL2VxlanNetworkEventDoc_zh_cn.groovy
@@ -5,7 +5,7 @@ import org.zstack.network.l2.vxlan.vxlanNetwork.L2VxlanNetworkInventory
 
 doc {
 
-	title "VXLAN网路清单"
+	title "二层VXLAN网路清单"
 
 	field {
 		name "success"

--- a/plugin/vxlan/src/main/java/org/zstack/network/l2/vxlan/vxlanNetwork/APICreateL2VxlanNetworkMsg.java
+++ b/plugin/vxlan/src/main/java/org/zstack/network/l2/vxlan/vxlanNetwork/APICreateL2VxlanNetworkMsg.java
@@ -2,9 +2,10 @@ package org.zstack.network.l2.vxlan.vxlanNetwork;
 
 import org.springframework.http.HttpMethod;
 import org.zstack.header.identity.Action;
-import org.zstack.header.message.*;
+import org.zstack.header.message.APIParam;
+import org.zstack.header.message.OverriddenApiParam;
+import org.zstack.header.message.OverriddenApiParams;
 import org.zstack.header.network.l2.APICreateL2NetworkMsg;
-import org.zstack.header.network.l2.L2NetworkVO;
 import org.zstack.header.rest.RestRequest;
 import org.zstack.header.zone.ZoneVO;
 import org.zstack.network.l2.vxlan.vxlanNetworkPool.VxlanNetworkPoolConstant;
@@ -59,10 +60,5 @@ public class APICreateL2VxlanNetworkMsg extends APICreateL2NetworkMsg {
         msg.setPoolUuid(uuid());
 
         return msg;
-    }
-
-    @Override
-    public Result audit(APIMessage msg, APIEvent rsp) {
-        return new Result(rsp.isSuccess() ? ((APICreateL2VxlanNetworkEvent) rsp).getInventory().getUuid() : "", L2NetworkVO.class);
     }
 }

--- a/plugin/vxlan/src/main/java/org/zstack/network/l2/vxlan/vxlanNetwork/APICreateL2VxlanNetworkMsgDoc_zh_cn.groovy
+++ b/plugin/vxlan/src/main/java/org/zstack/network/l2/vxlan/vxlanNetwork/APICreateL2VxlanNetworkMsgDoc_zh_cn.groovy
@@ -3,11 +3,11 @@ package org.zstack.network.l2.vxlan.vxlanNetwork
 import org.zstack.network.l2.vxlan.vxlanNetwork.APICreateL2VxlanNetworkEvent
 
 doc {
-    title "创建VXLAN网络(CreateL2VxlanNetwork)"
+    title "创建二层VXLAN网络(CreateL2VxlanNetwork)"
 
     category "network.l2"
 
-    desc """创建VXLAN网络"""
+    desc """创建二层VXLAN网络"""
 
     rest {
         request {
@@ -24,7 +24,7 @@ doc {
 				column {
 					name "vni"
 					enclosedIn "params"
-					desc ""
+					desc "Vni号"
 					location "body"
 					type "Integer"
 					optional true
@@ -33,7 +33,7 @@ doc {
 				column {
 					name "poolUuid"
 					enclosedIn "params"
-					desc ""
+					desc "VXLAN资源池UUID"
 					location "body"
 					type "String"
 					optional false
@@ -69,7 +69,7 @@ doc {
 				column {
 					name "physicalInterface"
 					enclosedIn "params"
-					desc ""
+					desc "物理网卡"
 					location "body"
 					type "String"
 					optional false
@@ -78,7 +78,7 @@ doc {
 				column {
 					name "type"
 					enclosedIn "params"
-					desc ""
+					desc "二层网络类型"
 					location "body"
 					type "String"
 					optional true
@@ -87,7 +87,7 @@ doc {
 				column {
 					name "resourceUuid"
 					enclosedIn "params"
-					desc ""
+					desc "资源UUID。若指定，二层网络会使用该字段值作为UUID"
 					location "body"
 					type "String"
 					optional true
@@ -96,7 +96,7 @@ doc {
 				column {
 					name "systemTags"
 					enclosedIn ""
-					desc ""
+					desc "系统标签"
 					location "body"
 					type "List"
 					optional true
@@ -105,7 +105,7 @@ doc {
 				column {
 					name "userTags"
 					enclosedIn ""
-					desc ""
+					desc "用户标签"
 					location "body"
 					type "List"
 					optional true
@@ -119,7 +119,7 @@ doc {
 					type "String"
 					optional true
 					since "0.6"
-					values ("LinuxBridge","OvsDpdk")
+					values ("LinuxBridge","OvsDpdk","MacVlan")
 				}
 				column {
 					name "tagUuids"

--- a/plugin/vxlan/src/main/java/org/zstack/network/l2/vxlan/vxlanNetwork/APIQueryL2VxlanNetworkMsgDoc_zh_cn.groovy
+++ b/plugin/vxlan/src/main/java/org/zstack/network/l2/vxlan/vxlanNetwork/APIQueryL2VxlanNetworkMsgDoc_zh_cn.groovy
@@ -4,11 +4,11 @@ import org.zstack.network.l2.vxlan.vxlanNetwork.APIQueryL2VxlanNetworkReply
 import org.zstack.header.query.APIQueryMessage
 
 doc {
-    title "QueryL2VxlanNetwork"
+    title "查询二层VXLAN网络(QueryL2VxlanNetwork)"
 
     category "network.l2"
 
-    desc """在这里填写API描述"""
+    desc """查询二层VXLAN网络"""
 
     rest {
         request {

--- a/plugin/vxlan/src/main/java/org/zstack/network/l2/vxlan/vxlanNetwork/APIQueryL2VxlanNetworkReplyDoc_zh_cn.groovy
+++ b/plugin/vxlan/src/main/java/org/zstack/network/l2/vxlan/vxlanNetwork/APIQueryL2VxlanNetworkReplyDoc_zh_cn.groovy
@@ -5,7 +5,7 @@ import org.zstack.network.l2.vxlan.vxlanNetwork.L2VxlanNetworkInventory
 
 doc {
 
-	title "在这里输入结构的名称"
+	title "二层VXLAN网络清单列表"
 
 	field {
 		name "success"

--- a/plugin/vxlan/src/main/java/org/zstack/network/l2/vxlan/vxlanNetwork/L2VxlanNetworkInventoryDoc_zh_cn.groovy
+++ b/plugin/vxlan/src/main/java/org/zstack/network/l2/vxlan/vxlanNetwork/L2VxlanNetworkInventoryDoc_zh_cn.groovy
@@ -6,17 +6,17 @@ import java.sql.Timestamp
 
 doc {
 
-	title "在这里输入结构的名称"
+	title "二层VXLAN网络清单"
 
 	field {
 		name "vni"
-		desc ""
+		desc "Vni号"
 		type "Integer"
 		since "0.6"
 	}
 	field {
 		name "poolUuid"
-		desc ""
+		desc "VXLAN资源池UUID"
 		type "String"
 		since "0.6"
 	}
@@ -46,13 +46,13 @@ doc {
 	}
 	field {
 		name "physicalInterface"
-		desc ""
+		desc "物理网卡"
 		type "String"
 		since "0.6"
 	}
 	field {
 		name "type"
-		desc ""
+		desc "二层网络类型"
 		type "String"
 		since "0.6"
 	}
@@ -70,7 +70,7 @@ doc {
 	}
 	field {
 		name "attachedClusterUuids"
-		desc ""
+		desc "挂载集群的UUID列表"
 		type "List"
 		since "0.6"
 	}

--- a/plugin/vxlan/src/main/java/org/zstack/network/l2/vxlan/vxlanNetworkPool/APICreateL2VxlanNetworkPoolEvent.java
+++ b/plugin/vxlan/src/main/java/org/zstack/network/l2/vxlan/vxlanNetworkPool/APICreateL2VxlanNetworkPoolEvent.java
@@ -1,29 +1,19 @@
 package org.zstack.network.l2.vxlan.vxlanNetworkPool;
 
-import org.zstack.header.message.APIEvent;
+import org.zstack.header.network.l2.APICreateL2NetworkEvent;
 import org.zstack.header.rest.RestResponse;
 
 /**
  * Created by weiwang on 03/03/2017.
  */
 @RestResponse(allTo = "inventory")
-public class APICreateL2VxlanNetworkPoolEvent extends APIEvent {
-    private L2VxlanNetworkPoolInventory inventory;
-
+public class APICreateL2VxlanNetworkPoolEvent extends APICreateL2NetworkEvent {
     public APICreateL2VxlanNetworkPoolEvent(String apiId) {
         super(apiId);
     }
 
-    public L2VxlanNetworkPoolInventory getInventory() {
-        return inventory;
-    }
-
     public APICreateL2VxlanNetworkPoolEvent() {
         super(null);
-    }
-
-    public void setInventory(L2VxlanNetworkPoolInventory inventory) {
-        this.inventory = inventory;
     }
 
     public static APICreateL2VxlanNetworkPoolEvent __example__() {

--- a/plugin/vxlan/src/main/java/org/zstack/network/l2/vxlan/vxlanNetworkPool/APICreateL2VxlanNetworkPoolMsg.java
+++ b/plugin/vxlan/src/main/java/org/zstack/network/l2/vxlan/vxlanNetworkPool/APICreateL2VxlanNetworkPoolMsg.java
@@ -1,9 +1,10 @@
 package org.zstack.network.l2.vxlan.vxlanNetworkPool;
 
 import org.springframework.http.HttpMethod;
-import org.zstack.header.message.*;
+import org.zstack.header.message.APIParam;
+import org.zstack.header.message.OverriddenApiParam;
+import org.zstack.header.message.OverriddenApiParams;
 import org.zstack.header.network.l2.APICreateL2NetworkMsg;
-import org.zstack.header.network.l2.L2NetworkVO;
 import org.zstack.header.rest.RestRequest;
 
 @OverriddenApiParams({
@@ -30,10 +31,5 @@ public class APICreateL2VxlanNetworkPoolMsg extends APICreateL2NetworkMsg {
         msg.setZoneUuid(uuid());
 
         return msg;
-    }
-
-    @Override
-    public Result audit(APIMessage msg, APIEvent rsp) {
-        return new Result(rsp.isSuccess() ? ((APICreateL2VxlanNetworkPoolEvent) rsp).getInventory().getUuid() : "", L2NetworkVO.class);
     }
 }

--- a/plugin/vxlan/src/main/java/org/zstack/network/l2/vxlan/vxlanNetworkPool/APICreateL2VxlanNetworkPoolMsgDoc_zh_cn.groovy
+++ b/plugin/vxlan/src/main/java/org/zstack/network/l2/vxlan/vxlanNetworkPool/APICreateL2VxlanNetworkPoolMsgDoc_zh_cn.groovy
@@ -51,7 +51,7 @@ doc {
 				column {
 					name "physicalInterface"
 					enclosedIn "params"
-					desc ""
+					desc "物理网卡"
 					location "body"
 					type "String"
 					optional false
@@ -60,7 +60,7 @@ doc {
 				column {
 					name "type"
 					enclosedIn "params"
-					desc ""
+					desc "二层网络类型"
 					location "body"
 					type "String"
 					optional true
@@ -69,7 +69,7 @@ doc {
 				column {
 					name "resourceUuid"
 					enclosedIn "params"
-					desc ""
+					desc "资源UUID。若指定，二层网络会使用该字段值作为UUID"
 					location "body"
 					type "String"
 					optional true
@@ -78,7 +78,7 @@ doc {
 				column {
 					name "systemTags"
 					enclosedIn ""
-					desc ""
+					desc "系统标签"
 					location "body"
 					type "List"
 					optional true
@@ -87,7 +87,7 @@ doc {
 				column {
 					name "userTags"
 					enclosedIn ""
-					desc ""
+					desc "用户标签"
 					location "body"
 					type "List"
 					optional true
@@ -101,7 +101,7 @@ doc {
 					type "String"
 					optional true
 					since "4.1.2"
-					values ("LinuxBridge","OvsDpdk")
+					values ("LinuxBridge","OvsDpdk","MacVlan")
 				}
 				column {
 					name "tagUuids"

--- a/plugin/vxlan/src/main/java/org/zstack/network/l2/vxlan/vxlanNetworkPool/APICreateVniRangeEventDoc_zh_cn.groovy
+++ b/plugin/vxlan/src/main/java/org/zstack/network/l2/vxlan/vxlanNetworkPool/APICreateVniRangeEventDoc_zh_cn.groovy
@@ -5,7 +5,7 @@ import org.zstack.network.l2.vxlan.vxlanNetworkPool.VniRangeInventory
 
 doc {
 
-	title "在这里输入结构的名称"
+	title "VNI范围清单"
 
 	field {
 		name "success"

--- a/plugin/vxlan/src/main/java/org/zstack/network/l2/vxlan/vxlanNetworkPool/APICreateVniRangeMsgDoc_zh_cn.groovy
+++ b/plugin/vxlan/src/main/java/org/zstack/network/l2/vxlan/vxlanNetworkPool/APICreateVniRangeMsgDoc_zh_cn.groovy
@@ -3,11 +3,11 @@ package org.zstack.network.l2.vxlan.vxlanNetworkPool
 import org.zstack.network.l2.vxlan.vxlanNetworkPool.APICreateVniRangeEvent
 
 doc {
-    title "CreateVniRange"
+    title "创建VNI范围(CreateVniRange)d"
 
     category "network.l2"
 
-    desc """在这里填写API描述"""
+    desc """创建VNI范围"""
 
     rest {
         request {
@@ -42,7 +42,7 @@ doc {
 				column {
 					name "startVni"
 					enclosedIn "params"
-					desc ""
+					desc "起始VNI"
 					location "body"
 					type "Integer"
 					optional false
@@ -51,7 +51,7 @@ doc {
 				column {
 					name "endVni"
 					enclosedIn "params"
-					desc ""
+					desc "结束VNI"
 					location "body"
 					type "Integer"
 					optional false
@@ -69,7 +69,7 @@ doc {
 				column {
 					name "resourceUuid"
 					enclosedIn "params"
-					desc ""
+					desc "资源UUID"
 					location "body"
 					type "String"
 					optional true
@@ -78,7 +78,7 @@ doc {
 				column {
 					name "systemTags"
 					enclosedIn ""
-					desc ""
+					desc "系统标签"
 					location "body"
 					type "List"
 					optional true
@@ -87,7 +87,7 @@ doc {
 				column {
 					name "userTags"
 					enclosedIn ""
-					desc ""
+					desc "用户标签"
 					location "body"
 					type "List"
 					optional true

--- a/plugin/vxlan/src/main/java/org/zstack/network/l2/vxlan/vxlanNetworkPool/APICreateVxlanPoolRemoteVtepEventDoc_zh_cn.groovy
+++ b/plugin/vxlan/src/main/java/org/zstack/network/l2/vxlan/vxlanNetworkPool/APICreateVxlanPoolRemoteVtepEventDoc_zh_cn.groovy
@@ -5,7 +5,7 @@ import org.zstack.header.errorcode.ErrorCode
 
 doc {
 
-	title "创建remote vxlan隧道端点清单"
+	title "远端VXLAN隧道端点清单"
 
 	ref {
 		name "inventory"

--- a/plugin/vxlan/src/main/java/org/zstack/network/l2/vxlan/vxlanNetworkPool/APICreateVxlanPoolRemoteVtepMsgDoc_zh_cn.groovy
+++ b/plugin/vxlan/src/main/java/org/zstack/network/l2/vxlan/vxlanNetworkPool/APICreateVxlanPoolRemoteVtepMsgDoc_zh_cn.groovy
@@ -3,11 +3,11 @@ package org.zstack.network.l2.vxlan.vxlanNetworkPool
 import org.zstack.network.l2.vxlan.vxlanNetworkPool.APICreateVxlanPoolRemoteVtepEvent
 
 doc {
-    title "CreateVxlanPoolRemoteVtep"
+    title "创建远端VXLAN隧道端点(CreateVxlanPoolRemoteVtep)"
 
     category "network.l2"
 
-    desc """在这里填写API描述"""
+    desc """创建远端VXLAN隧道端点"""
 
     rest {
         request {
@@ -42,7 +42,7 @@ doc {
 				column {
 					name "remoteVtepIp"
 					enclosedIn "params"
-					desc ""
+					desc "远端隧道端点IP地址"
 					location "body"
 					type "String"
 					optional false

--- a/plugin/vxlan/src/main/java/org/zstack/network/l2/vxlan/vxlanNetworkPool/APIDeleteVniRangeEventDoc_zh_cn.groovy
+++ b/plugin/vxlan/src/main/java/org/zstack/network/l2/vxlan/vxlanNetworkPool/APIDeleteVniRangeEventDoc_zh_cn.groovy
@@ -4,7 +4,7 @@ import org.zstack.header.errorcode.ErrorCode
 
 doc {
 
-	title "在这里输入结构的名称"
+	title "操作返回结果"
 
 	field {
 		name "success"

--- a/plugin/vxlan/src/main/java/org/zstack/network/l2/vxlan/vxlanNetworkPool/APIDeleteVniRangeMsgDoc_zh_cn.groovy
+++ b/plugin/vxlan/src/main/java/org/zstack/network/l2/vxlan/vxlanNetworkPool/APIDeleteVniRangeMsgDoc_zh_cn.groovy
@@ -3,11 +3,11 @@ package org.zstack.network.l2.vxlan.vxlanNetworkPool
 import org.zstack.network.l2.vxlan.vxlanNetworkPool.APIDeleteVniRangeEvent
 
 doc {
-    title "DeleteVniRange"
+    title "删除VNI范围(DeleteVniRange)"
 
     category "network.l2"
 
-    desc """在这里填写API描述"""
+    desc """删除VNI范围"""
 
     rest {
         request {
@@ -33,7 +33,7 @@ doc {
 				column {
 					name "deleteMode"
 					enclosedIn ""
-					desc ""
+					desc "删除模式"
 					location "body"
 					type "String"
 					optional true
@@ -42,7 +42,7 @@ doc {
 				column {
 					name "systemTags"
 					enclosedIn ""
-					desc ""
+					desc "系统标签"
 					location "body"
 					type "List"
 					optional true
@@ -51,7 +51,7 @@ doc {
 				column {
 					name "userTags"
 					enclosedIn ""
-					desc ""
+					desc "用户标签"
 					location "body"
 					type "List"
 					optional true

--- a/plugin/vxlan/src/main/java/org/zstack/network/l2/vxlan/vxlanNetworkPool/APIDeleteVxlanPoolRemoteVtepEventDoc_zh_cn.groovy
+++ b/plugin/vxlan/src/main/java/org/zstack/network/l2/vxlan/vxlanNetworkPool/APIDeleteVxlanPoolRemoteVtepEventDoc_zh_cn.groovy
@@ -4,7 +4,7 @@ import org.zstack.header.errorcode.ErrorCode
 
 doc {
 
-	title "删除remote vxlan隧道端点清单"
+	title "操作范围结果"
 
 	field {
 		name "success"

--- a/plugin/vxlan/src/main/java/org/zstack/network/l2/vxlan/vxlanNetworkPool/APIDeleteVxlanPoolRemoteVtepMsgDoc_zh_cn.groovy
+++ b/plugin/vxlan/src/main/java/org/zstack/network/l2/vxlan/vxlanNetworkPool/APIDeleteVxlanPoolRemoteVtepMsgDoc_zh_cn.groovy
@@ -3,11 +3,11 @@ package org.zstack.network.l2.vxlan.vxlanNetworkPool
 import org.zstack.network.l2.vxlan.vxlanNetworkPool.APIDeleteVxlanPoolRemoteVtepEvent
 
 doc {
-    title "DeleteVxlanPoolRemoteVtep"
+    title "删除远端VXLAN隧道端点(DeleteVxlanPoolRemoteVtep)"
 
     category "network.l2"
 
-    desc """在这里填写API描述"""
+    desc """删除远端VXLAN隧道端点"""
 
     rest {
         request {
@@ -42,7 +42,7 @@ doc {
 				column {
 					name "remoteVtepIp"
 					enclosedIn ""
-					desc ""
+					desc "远端隧道端点IP地址"
 					location "body"
 					type "String"
 					optional false

--- a/plugin/vxlan/src/main/java/org/zstack/network/l2/vxlan/vxlanNetworkPool/APIQueryL2VxlanNetworkPoolMsgDoc_zh_cn.groovy
+++ b/plugin/vxlan/src/main/java/org/zstack/network/l2/vxlan/vxlanNetworkPool/APIQueryL2VxlanNetworkPoolMsgDoc_zh_cn.groovy
@@ -4,11 +4,11 @@ import org.zstack.network.l2.vxlan.vxlanNetworkPool.APIQueryL2VxlanNetworkPoolRe
 import org.zstack.header.query.APIQueryMessage
 
 doc {
-    title "QueryL2VxlanNetworkPool"
+    title "查询VXLAN资源池(QueryL2VxlanNetworkPool)"
 
     category "network.l2"
 
-    desc """在这里填写API描述"""
+    desc """查询VXLAN资源池"""
 
     rest {
         request {

--- a/plugin/vxlan/src/main/java/org/zstack/network/l2/vxlan/vxlanNetworkPool/APIQueryL2VxlanNetworkPoolReplyDoc_zh_cn.groovy
+++ b/plugin/vxlan/src/main/java/org/zstack/network/l2/vxlan/vxlanNetworkPool/APIQueryL2VxlanNetworkPoolReplyDoc_zh_cn.groovy
@@ -5,7 +5,7 @@ import org.zstack.network.l2.vxlan.vxlanNetworkPool.L2VxlanNetworkPoolInventory
 
 doc {
 
-	title "在这里输入结构的名称"
+	title "VXLAN资源池清单列表"
 
 	field {
 		name "success"

--- a/plugin/vxlan/src/main/java/org/zstack/network/l2/vxlan/vxlanNetworkPool/APIQueryVniRangeMsgDoc_zh_cn.groovy
+++ b/plugin/vxlan/src/main/java/org/zstack/network/l2/vxlan/vxlanNetworkPool/APIQueryVniRangeMsgDoc_zh_cn.groovy
@@ -4,11 +4,11 @@ import org.zstack.network.l2.vxlan.vxlanNetworkPool.APIQueryVniRangeReply
 import org.zstack.header.query.APIQueryMessage
 
 doc {
-    title "QueryVniRange"
+    title "查询VNI范围(QueryVniRange)"
 
     category "network.l2"
 
-    desc """在这里填写API描述"""
+    desc """查询VNI范围"""
 
     rest {
         request {

--- a/plugin/vxlan/src/main/java/org/zstack/network/l2/vxlan/vxlanNetworkPool/APIQueryVniRangeReplyDoc_zh_cn.groovy
+++ b/plugin/vxlan/src/main/java/org/zstack/network/l2/vxlan/vxlanNetworkPool/APIQueryVniRangeReplyDoc_zh_cn.groovy
@@ -5,7 +5,7 @@ import org.zstack.network.l2.vxlan.vxlanNetworkPool.VniRangeInventory
 
 doc {
 
-	title "在这里输入结构的名称"
+	title "VNI范围清单列表"
 
 	field {
 		name "success"

--- a/plugin/vxlan/src/main/java/org/zstack/network/l2/vxlan/vxlanNetworkPool/APIUpdateVniRangeEventDoc_zh_cn.groovy
+++ b/plugin/vxlan/src/main/java/org/zstack/network/l2/vxlan/vxlanNetworkPool/APIUpdateVniRangeEventDoc_zh_cn.groovy
@@ -4,7 +4,7 @@ import org.zstack.header.errorcode.ErrorCode
 
 doc {
 
-	title "修改 Vni Range"
+	title "操作返回结果"
 
 	field {
 		name "success"

--- a/plugin/vxlan/src/main/java/org/zstack/network/l2/vxlan/vxlanNetworkPool/APIUpdateVniRangeMsgDoc_zh_cn.groovy
+++ b/plugin/vxlan/src/main/java/org/zstack/network/l2/vxlan/vxlanNetworkPool/APIUpdateVniRangeMsgDoc_zh_cn.groovy
@@ -3,11 +3,11 @@ package org.zstack.network.l2.vxlan.vxlanNetworkPool
 import org.zstack.network.l2.vxlan.vxlanNetworkPool.APIUpdateVniRangeEvent
 
 doc {
-    title "UpdateVniRange"
+    title "修改VNI范围(UpdateVniRange)"
 
     category "network.l2"
 
-    desc """修改 Vni Range"""
+    desc """修改VNI范围"""
 
     rest {
         request {
@@ -33,7 +33,7 @@ doc {
 				column {
 					name "name"
 					enclosedIn "updateVniRange"
-					desc ""
+					desc "资源名称"
 					location "body"
 					type "String"
 					optional false
@@ -42,7 +42,7 @@ doc {
 				column {
 					name "systemTags"
 					enclosedIn ""
-					desc ""
+					desc "系统标签"
 					location "body"
 					type "List"
 					optional true
@@ -51,7 +51,7 @@ doc {
 				column {
 					name "userTags"
 					enclosedIn ""
-					desc ""
+					desc "用户标签"
 					location "body"
 					type "List"
 					optional true

--- a/plugin/vxlan/src/main/java/org/zstack/network/l2/vxlan/vxlanNetworkPool/L2VxlanNetworkPoolInventoryDoc_zh_cn.groovy
+++ b/plugin/vxlan/src/main/java/org/zstack/network/l2/vxlan/vxlanNetworkPool/L2VxlanNetworkPoolInventoryDoc_zh_cn.groovy
@@ -8,7 +8,7 @@ import java.sql.Timestamp
 
 doc {
 
-	title "在这里输入结构的名称"
+	title "VXLAN资源池清单"
 
 	ref {
 		name "attachedVtepRefs"
@@ -36,7 +36,7 @@ doc {
 	}
 	field {
 		name "attachedCidrs"
-		desc ""
+		desc "已加载CIDR映射表"
 		type "Map"
 		since "0.6"
 	}
@@ -66,13 +66,13 @@ doc {
 	}
 	field {
 		name "physicalInterface"
-		desc ""
+		desc "物理网卡"
 		type "String"
 		since "0.6"
 	}
 	field {
 		name "type"
-		desc ""
+		desc "二层网络类型"
 		type "String"
 		since "0.6"
 	}
@@ -90,7 +90,7 @@ doc {
 	}
 	field {
 		name "attachedClusterUuids"
-		desc ""
+		desc "挂载集群的UUID列表"
 		type "List"
 		since "0.6"
 	}

--- a/plugin/vxlan/src/main/java/org/zstack/network/l2/vxlan/vxlanNetworkPool/VniRangeInventoryDoc_zh_cn.groovy
+++ b/plugin/vxlan/src/main/java/org/zstack/network/l2/vxlan/vxlanNetworkPool/VniRangeInventoryDoc_zh_cn.groovy
@@ -7,7 +7,7 @@ import java.sql.Timestamp
 
 doc {
 
-	title "在这里输入结构的名称"
+	title "vni范围清单"
 
 	field {
 		name "uuid"
@@ -29,13 +29,13 @@ doc {
 	}
 	field {
 		name "startVni"
-		desc ""
+		desc "起始VNI"
 		type "Integer"
 		since "0.6"
 	}
 	field {
 		name "endVni"
-		desc ""
+		desc "结束VNI"
 		type "Integer"
 		since "0.6"
 	}

--- a/rest/src/main/resources/scripts/SdkDataStructureGenerator.groovy
+++ b/rest/src/main/resources/scripts/SdkDataStructureGenerator.groovy
@@ -239,7 +239,7 @@ ${output.join("\n")}
         }
 
         if (!at.allTo().isEmpty()) {
-            Field f = responseClass.getDeclaredField(at.allTo())
+            Field f = getFieldRecursively(responseClass, at.allTo())
             addToFields(at.allTo(), f)
         } else {
             if (at.fieldsTo().length == 1 && at.fieldsTo()[0] == "all") {
@@ -304,6 +304,20 @@ ${output.join("\n")}
 }
 """
         sdkFileMap[responseClass] = file
+    }
+
+    static Field getFieldRecursively(Class<?> clazz, String fieldName) {
+        try {
+            return clazz.getDeclaredField(fieldName)
+        } catch (NoSuchFieldException e) {
+            Class<?> superClass = clazz.getSuperclass()
+
+            if (superClass != null && superClass != Object.class) {
+                return getFieldRecursively(superClass, fieldName)
+            } else {
+                throw e
+            }
+        }
     }
 
     def makeFieldText(String fname, Field field) {

--- a/sdk/src/main/java/org/zstack/sdk/AddSftpBackupStorageResult.java
+++ b/sdk/src/main/java/org/zstack/sdk/AddSftpBackupStorageResult.java
@@ -1,13 +1,13 @@
 package org.zstack.sdk;
 
-import org.zstack.sdk.SftpBackupStorageInventory;
+import org.zstack.sdk.BackupStorageInventory;
 
 public class AddSftpBackupStorageResult {
-    public SftpBackupStorageInventory inventory;
-    public void setInventory(SftpBackupStorageInventory inventory) {
+    public BackupStorageInventory inventory;
+    public void setInventory(BackupStorageInventory inventory) {
         this.inventory = inventory;
     }
-    public SftpBackupStorageInventory getInventory() {
+    public BackupStorageInventory getInventory() {
         return this.inventory;
     }
 

--- a/sdk/src/main/java/org/zstack/sdk/CreateL2HardwareVxlanNetworkPoolResult.java
+++ b/sdk/src/main/java/org/zstack/sdk/CreateL2HardwareVxlanNetworkPoolResult.java
@@ -1,13 +1,13 @@
 package org.zstack.sdk;
 
-import org.zstack.sdk.HardwareL2VxlanNetworkPoolInventory;
+import org.zstack.sdk.L2NetworkInventory;
 
 public class CreateL2HardwareVxlanNetworkPoolResult {
-    public HardwareL2VxlanNetworkPoolInventory inventory;
-    public void setInventory(HardwareL2VxlanNetworkPoolInventory inventory) {
+    public L2NetworkInventory inventory;
+    public void setInventory(L2NetworkInventory inventory) {
         this.inventory = inventory;
     }
-    public HardwareL2VxlanNetworkPoolInventory getInventory() {
+    public L2NetworkInventory getInventory() {
         return this.inventory;
     }
 

--- a/sdk/src/main/java/org/zstack/sdk/CreateL2HardwareVxlanNetworkResult.java
+++ b/sdk/src/main/java/org/zstack/sdk/CreateL2HardwareVxlanNetworkResult.java
@@ -1,13 +1,13 @@
 package org.zstack.sdk;
 
-import org.zstack.sdk.L2VxlanNetworkInventory;
+import org.zstack.sdk.L2NetworkInventory;
 
 public class CreateL2HardwareVxlanNetworkResult {
-    public L2VxlanNetworkInventory inventory;
-    public void setInventory(L2VxlanNetworkInventory inventory) {
+    public L2NetworkInventory inventory;
+    public void setInventory(L2NetworkInventory inventory) {
         this.inventory = inventory;
     }
-    public L2VxlanNetworkInventory getInventory() {
+    public L2NetworkInventory getInventory() {
         return this.inventory;
     }
 

--- a/sdk/src/main/java/org/zstack/sdk/CreateL2PortGroupResult.java
+++ b/sdk/src/main/java/org/zstack/sdk/CreateL2PortGroupResult.java
@@ -1,13 +1,13 @@
 package org.zstack.sdk;
 
-import org.zstack.sdk.L2PortGroupNetworkInventory;
+import org.zstack.sdk.L2NetworkInventory;
 
 public class CreateL2PortGroupResult {
-    public L2PortGroupNetworkInventory inventory;
-    public void setInventory(L2PortGroupNetworkInventory inventory) {
+    public L2NetworkInventory inventory;
+    public void setInventory(L2NetworkInventory inventory) {
         this.inventory = inventory;
     }
-    public L2PortGroupNetworkInventory getInventory() {
+    public L2NetworkInventory getInventory() {
         return this.inventory;
     }
 

--- a/sdk/src/main/java/org/zstack/sdk/CreateL2VirtualSwitchResult.java
+++ b/sdk/src/main/java/org/zstack/sdk/CreateL2VirtualSwitchResult.java
@@ -1,13 +1,13 @@
 package org.zstack.sdk;
 
-import org.zstack.sdk.L2VirtualSwitchNetworkInventory;
+import org.zstack.sdk.L2NetworkInventory;
 
 public class CreateL2VirtualSwitchResult {
-    public L2VirtualSwitchNetworkInventory inventory;
-    public void setInventory(L2VirtualSwitchNetworkInventory inventory) {
+    public L2NetworkInventory inventory;
+    public void setInventory(L2NetworkInventory inventory) {
         this.inventory = inventory;
     }
-    public L2VirtualSwitchNetworkInventory getInventory() {
+    public L2NetworkInventory getInventory() {
         return this.inventory;
     }
 

--- a/sdk/src/main/java/org/zstack/sdk/CreateL2VlanNetworkResult.java
+++ b/sdk/src/main/java/org/zstack/sdk/CreateL2VlanNetworkResult.java
@@ -1,13 +1,13 @@
 package org.zstack.sdk;
 
-import org.zstack.sdk.L2VlanNetworkInventory;
+import org.zstack.sdk.L2NetworkInventory;
 
 public class CreateL2VlanNetworkResult {
-    public L2VlanNetworkInventory inventory;
-    public void setInventory(L2VlanNetworkInventory inventory) {
+    public L2NetworkInventory inventory;
+    public void setInventory(L2NetworkInventory inventory) {
         this.inventory = inventory;
     }
-    public L2VlanNetworkInventory getInventory() {
+    public L2NetworkInventory getInventory() {
         return this.inventory;
     }
 

--- a/sdk/src/main/java/org/zstack/sdk/CreateL2VxlanNetworkPoolResult.java
+++ b/sdk/src/main/java/org/zstack/sdk/CreateL2VxlanNetworkPoolResult.java
@@ -1,13 +1,13 @@
 package org.zstack.sdk;
 
-import org.zstack.sdk.L2VxlanNetworkPoolInventory;
+import org.zstack.sdk.L2NetworkInventory;
 
 public class CreateL2VxlanNetworkPoolResult {
-    public L2VxlanNetworkPoolInventory inventory;
-    public void setInventory(L2VxlanNetworkPoolInventory inventory) {
+    public L2NetworkInventory inventory;
+    public void setInventory(L2NetworkInventory inventory) {
         this.inventory = inventory;
     }
-    public L2VxlanNetworkPoolInventory getInventory() {
+    public L2NetworkInventory getInventory() {
         return this.inventory;
     }
 

--- a/sdk/src/main/java/org/zstack/sdk/CreateL2VxlanNetworkResult.java
+++ b/sdk/src/main/java/org/zstack/sdk/CreateL2VxlanNetworkResult.java
@@ -1,13 +1,13 @@
 package org.zstack.sdk;
 
-import org.zstack.sdk.L2VxlanNetworkInventory;
+import org.zstack.sdk.L2NetworkInventory;
 
 public class CreateL2VxlanNetworkResult {
-    public L2VxlanNetworkInventory inventory;
-    public void setInventory(L2VxlanNetworkInventory inventory) {
+    public L2NetworkInventory inventory;
+    public void setInventory(L2NetworkInventory inventory) {
         this.inventory = inventory;
     }
-    public L2VxlanNetworkInventory getInventory() {
+    public L2NetworkInventory getInventory() {
         return this.inventory;
     }
 


### PR DESCRIPTION
## Summary
Backport 5.x fix for ZSTAC-85724 to 4.8.38.

## Source
- source: ZSTAC-62824, MR 5706, commit 0a23f98f; diff-check has CRLF warning in SdkDataStructureGenerator.groovy from source patch
- Branch: `shixin-ZSTAC-85724-4.8.38@@2`
- Target: `4.8.38`

## Verification
- Cherry-pick completed in isolated worktree.
- `git diff --check` run for all backport branches; warnings, if any, are noted in Source above.
- No full Maven/Groovy suite was run locally for this batch backport.

Jira: http://jira.zstack.io/browse/ZSTAC-85724

sync from gitlab !10206