### PR TITLE
[ZSTAC-86007][4.8.38] backport VPC alarm fix

### DIFF
--- a/plugin/applianceVm/src/main/java/org/zstack/appliancevm/ApplianceVmBase.java
+++ b/plugin/applianceVm/src/main/java/org/zstack/appliancevm/ApplianceVmBase.java
@@ -430,10 +430,6 @@ public abstract class ApplianceVmBase extends VmInstanceBase implements Applianc
             @Override
             public void run(FlowTrigger trigger, Map data) {
                 changeApplianceVmStatus(ApplianceVmStatus.Disconnected);
-                if (originStatus.equals(ApplianceVmStatus.Connected)) {
-                    fireDisconnectedCanonicalEvent(operr("appliance vm %s stopped",
-                            getSelf().getUuid()));
-                }
                 trigger.next();
             }
 
@@ -468,7 +464,7 @@ public abstract class ApplianceVmBase extends VmInstanceBase implements Applianc
         data.setHealthy(false);
         data.setReason(err);
 
-        evtf.fire(ApplianceVmCanonicalEvents.SERVICE_UNHEALTHY_PATH, data);
+        evtf.fire(ApplianceVmCanonicalEvents.SERVICE_HEALTHY_PATH, data);
     }
 
     protected void fireServicehealthyCanonicalEvent() {
@@ -498,7 +494,7 @@ public abstract class ApplianceVmBase extends VmInstanceBase implements Applianc
             ApplianceVmStatus originStatus = getSelf().getStatus();
 
             public void run(FlowTrigger trigger, Map data) {
-                changeApplianceVmStatus(ApplianceVmStatus.Disconnected);
+                changeApplianceVmStatus(ApplianceVmStatus.Destroying);
                 trigger.next();
             }
 
@@ -560,21 +556,12 @@ public abstract class ApplianceVmBase extends VmInstanceBase implements Applianc
 
             @Override
             public void run(FlowTrigger trigger, Map data) {
-                changeApplianceVmStatus(ApplianceVmStatus.Connecting);
-                if (originStatus.equals(ApplianceVmStatus.Connected)) {
-                    fireDisconnectedCanonicalEvent(operr("appliance vm %s reboot",
-                            getSelf().getUuid()));
-                }
+                changeApplianceVmStatus(ApplianceVmStatus.Disconnected);
                 trigger.next();
             }
 
             @Override
             public void rollback(FlowRollback trigger, Map data) {
-                changeApplianceVmStatus(ApplianceVmStatus.Disconnected);
-                if (originStatus.equals(ApplianceVmStatus.Connected)) {
-                    fireDisconnectedCanonicalEvent(operr("appliance vm %s reboot failed",
-                            getSelf().getUuid()));
-                }
                 trigger.rollback();
             }
         });
@@ -640,10 +627,6 @@ public abstract class ApplianceVmBase extends VmInstanceBase implements Applianc
             @Override
             public void rollback(FlowRollback trigger, Map data) {
                 changeApplianceVmStatus(ApplianceVmStatus.Disconnected);
-                if (originStatus.equals(ApplianceVmStatus.Connected)) {
-                    fireDisconnectedCanonicalEvent(operr("appliance vm %s start failed",
-                            getSelf().getUuid()));
-                }
                 trigger.rollback();
             }
         });
@@ -708,21 +691,12 @@ public abstract class ApplianceVmBase extends VmInstanceBase implements Applianc
 
             @Override
             public void run(FlowTrigger trigger, Map data) {
-                changeApplianceVmStatus(ApplianceVmStatus.Connecting);
-                if (originStatus.equals(ApplianceVmStatus.Connected)) {
-                    fireDisconnectedCanonicalEvent(operr("appliance vm %s reboot",
-                            getSelf().getUuid()));
-                }
+                changeApplianceVmStatus(ApplianceVmStatus.Disconnected);
                 trigger.next();
             }
 
             @Override
             public void rollback(FlowRollback trigger, Map data) {
-                changeApplianceVmStatus(ApplianceVmStatus.Disconnected);
-                if (originStatus.equals(ApplianceVmStatus.Connected)) {
-                    fireDisconnectedCanonicalEvent(operr("appliance vm %s reboot failed",
-                            getSelf().getUuid()));
-                }
                 trigger.rollback();
             }
         });
@@ -781,10 +755,6 @@ public abstract class ApplianceVmBase extends VmInstanceBase implements Applianc
             @Override
             public void rollback(FlowRollback trigger, Map data) {
                 changeApplianceVmStatus(ApplianceVmStatus.Disconnected);
-                if (originStatus.equals(ApplianceVmStatus.Connected)) {
-                    fireDisconnectedCanonicalEvent(operr("appliance vm %s start failed",
-                            getSelf().getUuid()));
-                }
                 trigger.rollback();
             }
         });

--- a/plugin/applianceVm/src/main/java/org/zstack/appliancevm/ApplianceVmStatus.java
+++ b/plugin/applianceVm/src/main/java/org/zstack/appliancevm/ApplianceVmStatus.java
@@ -5,5 +5,6 @@ package org.zstack.appliancevm;
 public enum ApplianceVmStatus {
     Connecting,
     Connected,
-    Disconnected
+    Disconnected,
+    Destroying
 }

--- a/plugin/virtualRouterProvider/src/main/java/org/zstack/network/service/virtualrouter/VirtualRouter.java
+++ b/plugin/virtualRouterProvider/src/main/java/org/zstack/network/service/virtualrouter/VirtualRouter.java
@@ -463,7 +463,7 @@ public class VirtualRouter extends ApplianceVmBase {
                         if (replies.size() == steps.size()) {
                             changeApplianceVmStatus(ApplianceVmStatus.Disconnected);
                         }
-                        
+
                         bus.reply(msg, replies.get(0));
                         chain.next();
                     }
@@ -913,10 +913,6 @@ public class VirtualRouter extends ApplianceVmBase {
         }).error(new FlowErrorHandler(completion) {
             @Override
             public void handle(ErrorCode errCode, Map data) {
-                if (oldStatus == ApplianceVmStatus.Connected) {
-                    fireDisconnectedCanonicalEvent(errCode);
-                }
-
                 completion.fail(errCode);
             }
         }).start();


### PR DESCRIPTION
Backport VPC alarm part split from ZSTAC-72876 to 4.8.38. This excludes SLB group alarm changes because that part depends on 5.x SLB group code. Validated by ./runMavenProfile premium, VpcEventCase, and VpcVrouterLifeCycleCase.

sync from gitlab !10212