### PR TITLE
<feature>[vm]: support inline metadata register

### DIFF
--- a/compute/src/main/java/org/zstack/compute/vm/VmInstanceApiInterceptor.java
+++ b/compute/src/main/java/org/zstack/compute/vm/VmInstanceApiInterceptor.java
@@ -40,6 +40,7 @@ import org.zstack.header.vm.cdrom.*;
 import org.zstack.header.vm.APIRegisterVmInstanceFromMetadataMsg;
 import org.zstack.header.vm.devices.VmInstanceResourceMetadataGroupVO;
 import org.zstack.header.vm.devices.VmInstanceResourceMetadataGroupVO_;
+import org.zstack.header.vm.metadata.VmInstanceMetadataDTO;
 import org.zstack.header.vm.metadata.VmMetadataPathBuildExtensionPoint;
 import org.zstack.header.volume.*;
 import org.zstack.network.l2.L2NetworkHostUtils;
@@ -55,6 +56,7 @@ import org.zstack.utils.network.NicIpAddressInfo;
 
 import javax.persistence.Tuple;
 import javax.persistence.TypedQuery;
+import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -1333,12 +1335,13 @@ public class VmInstanceApiInterceptor implements ApiMessageInterceptor {
     }
 
     private void validate(APIRegisterVmInstanceFromMetadataMsg msg) {
-        String path = msg.getMetadataPath();
-        if (StringUtils.isEmpty(path)) {
-            throw new ApiMessageInterceptionException(argerr("metadataPath cannot be empty or null"));
+        boolean hasMetadataPath = StringUtils.isNotBlank(msg.getMetadataPath());
+        boolean hasMetadata = StringUtils.isNotBlank(msg.getMetadata());
+        if (hasMetadataPath == hasMetadata) {
+            throw new ApiMessageInterceptionException(argerr(
+                    "exactly one of metadataPath and metadata must be specified"));
         }
 
-        // Delegate path validation to the storage-type-specific extension
         String psUuid = msg.getPrimaryStorageUuid();
         String psType = Q.New(PrimaryStorageVO.class).select(PrimaryStorageVO_.type).eq(PrimaryStorageVO_.uuid, psUuid).findValue();
         if (psType == null) {
@@ -1346,15 +1349,31 @@ public class VmInstanceApiInterceptor implements ApiMessageInterceptor {
                     "primary storage[uuid:%s] not found", psUuid));
         }
 
-        VmMetadataPathBuildExtensionPoint ext = pluginRgty.getExtensionFromMap(psType, VmMetadataPathBuildExtensionPoint.class);
-        if (ext == null) {
-            throw new ApiMessageInterceptionException(argerr(
-                    "primary storage[uuid:%s, type:%s] does not support vm metadata", psUuid, psType));
-        }
+        if (hasMetadataPath) {
+            VmMetadataPathBuildExtensionPoint ext = pluginRgty.getExtensionFromMap(psType, VmMetadataPathBuildExtensionPoint.class);
+            if (ext == null) {
+                throw new ApiMessageInterceptionException(argerr(
+                        "primary storage[uuid:%s, type:%s] does not support vm metadata", psUuid, psType));
+            }
 
-        String error = ext.validateMetadataPath(psUuid, path);
-        if (error != null) {
-            throw new ApiMessageInterceptionException(argerr("%s", error));
+            String error = ext.validateMetadataPath(psUuid, msg.getMetadataPath());
+            if (error != null) {
+                throw new ApiMessageInterceptionException(argerr("%s", error));
+            }
+        } else {
+            long threshold = VmGlobalConfig.VM_METADATA_PAYLOAD_REJECT_THRESHOLD.value(Long.class);
+            int metadataSize = msg.getMetadata().getBytes(StandardCharsets.UTF_8).length;
+            if (metadataSize > threshold) {
+                throw new ApiMessageInterceptionException(argerr(
+                        "metadata payload size[%s bytes] exceeds threshold[%s bytes]", metadataSize, threshold));
+            }
+
+            try {
+                JSONObjectUtil.toObject(msg.getMetadata(), VmInstanceMetadataDTO.class);
+            } catch (Exception e) {
+                throw new ApiMessageInterceptionException(argerr(
+                        "failed to parse metadata JSON: %s", e.getMessage()));
+            }
         }
 
         // Validate cluster belongs to the specified zone

--- a/header/src/main/java/org/zstack/header/vm/APIRegisterVmInstanceFromMetadataMsg.java
+++ b/header/src/main/java/org/zstack/header/vm/APIRegisterVmInstanceFromMetadataMsg.java
@@ -22,8 +22,11 @@ import java.util.concurrent.TimeUnit;
 )
 @DefaultTimeout(timeunit = TimeUnit.HOURS, value = 1)
 public class APIRegisterVmInstanceFromMetadataMsg extends APIMessage {
-    @APIParam(nonempty = true, maxLength = 2048)
+    @APIParam(required = false, nonempty = true, maxLength = 2048)
     private String metadataPath;
+
+    @APIParam(required = false, nonempty = true)
+    private String metadata;
 
     @APIParam(resourceType = PrimaryStorageVO.class)
     private String primaryStorageUuid;
@@ -46,6 +49,14 @@ public class APIRegisterVmInstanceFromMetadataMsg extends APIMessage {
 
     public void setMetadataPath(String metadataPath) {
         this.metadataPath = metadataPath;
+    }
+
+    public String getMetadata() {
+        return metadata;
+    }
+
+    public void setMetadata(String metadata) {
+        this.metadata = metadata;
     }
 
     public String getPrimaryStorageUuid() {

--- a/header/src/main/java/org/zstack/header/vm/APIRegisterVmInstanceFromMetadataMsgDoc_zh_cn.groovy
+++ b/header/src/main/java/org/zstack/header/vm/APIRegisterVmInstanceFromMetadataMsgDoc_zh_cn.groovy
@@ -27,8 +27,17 @@ doc {
 					desc "元数据文件在主存储上的路径"
 					location "body"
 					type "String"
-					optional false
+					optional true
 					since "5.0.0"
+				}
+				column {
+					name "metadata"
+					enclosedIn "params"
+					desc "VM metadata JSON content, mutually exclusive with metadataPath"
+					location "body"
+					type "String"
+					optional true
+					since "5.1.0"
 				}
 				column {
 					name "primaryStorageUuid"

--- a/sdk/src/main/java/org/zstack/sdk/RegisterVmInstanceFromMetadataAction.java
+++ b/sdk/src/main/java/org/zstack/sdk/RegisterVmInstanceFromMetadataAction.java
@@ -25,8 +25,11 @@ public class RegisterVmInstanceFromMetadataAction extends AbstractAction {
         }
     }
 
-    @Param(required = true, maxLength = 2048, nonempty = true, nullElements = false, emptyString = true, noTrim = false)
+    @Param(required = false, maxLength = 2048, nonempty = true, nullElements = false, emptyString = true, noTrim = false)
     public java.lang.String metadataPath;
+
+    @Param(required = false, nonempty = true, nullElements = false, emptyString = true, noTrim = false)
+    public java.lang.String metadata;
 
     @Param(required = true, nonempty = false, nullElements = false, emptyString = true, noTrim = false)
     public java.lang.String primaryStorageUuid;


### PR DESCRIPTION
Allow RegisterVmInstanceFromMetadata to accept a metadata JSON payload as an alternative to metadataPath. Validate exactly one metadata source, reject oversized inline payloads, and expose the parameter in API docs and SDK.

Resolves: ZSV-12447

Change-Id: Iee540c610311317f58380aec494adbdae0382176

sync from gitlab !10216