### PR TITLE
Sync hanyu.liang license commits to 5.5.28

### DIFF
--- a/sdk/src/main/java/SourceClassMap.java
+++ b/sdk/src/main/java/SourceClassMap.java
@@ -514,6 +514,8 @@ public class SourceClassMap {
 			put("org.zstack.license.AdditionalLicenseInfo", "org.zstack.sdk.AdditionalLicenseInfo");
 			put("org.zstack.license.AdditionalLicenseType", "org.zstack.sdk.AdditionalLicenseType");
 			put("org.zstack.license.LicenseAddOnInventory", "org.zstack.sdk.LicenseAddOnInventory");
+			put("org.zstack.license.LicenseAuthorizationInfo", "org.zstack.sdk.LicenseAuthorizationInfo");
+			put("org.zstack.license.LicenseAuthorizationQuotaInventory", "org.zstack.sdk.LicenseAuthorizationQuotaInventory");
 			put("org.zstack.license.LicenseInventory", "org.zstack.sdk.LicenseInventory");
 			put("org.zstack.license.UKeyInventory", "org.zstack.sdk.UKeyInventory");
 			put("org.zstack.license.UKeyStatus", "org.zstack.sdk.UKeyStatus");
@@ -1233,6 +1235,8 @@ public class SourceClassMap {
 			put("org.zstack.sdk.LdapResourceRefInventory", "org.zstack.login.entity.LdapResourceRefInventory");
 			put("org.zstack.sdk.LdapServerInventory", "org.zstack.ldap.LdapServerInventory");
 			put("org.zstack.sdk.LicenseAddOnInventory", "org.zstack.license.LicenseAddOnInventory");
+			put("org.zstack.sdk.LicenseAuthorizationInfo", "org.zstack.license.LicenseAuthorizationInfo");
+			put("org.zstack.sdk.LicenseAuthorizationQuotaInventory", "org.zstack.license.LicenseAuthorizationQuotaInventory");
 			put("org.zstack.sdk.LicenseInventory", "org.zstack.license.LicenseInventory");
 			put("org.zstack.sdk.LoadBalancerDataInventory", "org.zstack.observabilityServer.service.loadBalancer.LoadBalancerDataInventory");
 			put("org.zstack.sdk.LoadBalancerInventory", "org.zstack.network.service.lb.LoadBalancerInventory");

--- a/sdk/src/main/java/org/zstack/sdk/GetLicenseAuthorizationInfoAction.java
+++ b/sdk/src/main/java/org/zstack/sdk/GetLicenseAuthorizationInfoAction.java
@@ -1,0 +1,86 @@
+package org.zstack.sdk;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.zstack.sdk.*;
+
+public class GetLicenseAuthorizationInfoAction extends AbstractAction {
+
+    private static final HashMap<String, Parameter> parameterMap = new HashMap<>();
+
+    private static final HashMap<String, Parameter> nonAPIParameterMap = new HashMap<>();
+
+    public static class Result {
+        public ErrorCode error;
+        public org.zstack.sdk.GetLicenseAuthorizationInfoResult value;
+
+        public Result throwExceptionIfError() {
+            if (error != null) {
+                throw new ApiException(
+                    String.format("error[code: %s, description: %s, details: %s, globalErrorCode: %s]", error.code, error.description, error.details, error.globalErrorCode)    
+                );
+            }
+            
+            return this;
+        }
+    }
+
+    @Param(required = false)
+    public java.util.List systemTags;
+
+    @Param(required = false)
+    public java.util.List userTags;
+
+    @NonAPIParam
+    public boolean isSuppressCredentialCheck = true;
+
+    @Param(required = false)
+    public String requestIp;
+
+
+    private Result makeResult(ApiResult res) {
+        Result ret = new Result();
+        if (res.error != null) {
+            ret.error = res.error;
+            return ret;
+        }
+        
+        org.zstack.sdk.GetLicenseAuthorizationInfoResult value = res.getResult(org.zstack.sdk.GetLicenseAuthorizationInfoResult.class);
+        ret.value = value == null ? new org.zstack.sdk.GetLicenseAuthorizationInfoResult() : value; 
+
+        return ret;
+    }
+
+    public Result call() {
+        ApiResult res = ZSClient.call(this);
+        return makeResult(res);
+    }
+
+    public void call(final Completion<Result> completion) {
+        ZSClient.call(this, new InternalCompletion() {
+            @Override
+            public void complete(ApiResult res) {
+                completion.complete(makeResult(res));
+            }
+        });
+    }
+
+    protected Map<String, Parameter> getParameterMap() {
+        return parameterMap;
+    }
+
+    protected Map<String, Parameter> getNonAPIParameterMap() {
+        return nonAPIParameterMap;
+    }
+
+    protected RestInfo getRestInfo() {
+        RestInfo info = new RestInfo();
+        info.httpMethod = "GET";
+        info.path = "/licenses/authorization-info";
+        info.needSession = false;
+        info.needPoll = false;
+        info.parameterName = "";
+        return info;
+    }
+
+}

--- a/sdk/src/main/java/org/zstack/sdk/GetLicenseAuthorizationInfoResult.java
+++ b/sdk/src/main/java/org/zstack/sdk/GetLicenseAuthorizationInfoResult.java
@@ -1,0 +1,14 @@
+package org.zstack.sdk;
+
+import org.zstack.sdk.LicenseAuthorizationInfo;
+
+public class GetLicenseAuthorizationInfoResult {
+    public LicenseAuthorizationInfo info;
+    public void setInfo(LicenseAuthorizationInfo info) {
+        this.info = info;
+    }
+    public LicenseAuthorizationInfo getInfo() {
+        return this.info;
+    }
+
+}

--- a/sdk/src/main/java/org/zstack/sdk/LicenseAuthorizationInfo.java
+++ b/sdk/src/main/java/org/zstack/sdk/LicenseAuthorizationInfo.java
@@ -1,0 +1,111 @@
+package org.zstack.sdk;
+
+import org.zstack.sdk.LicenseInventory;
+
+public class LicenseAuthorizationInfo  {
+
+    public java.lang.String authType;
+    public void setAuthType(java.lang.String authType) {
+        this.authType = authType;
+    }
+    public java.lang.String getAuthType() {
+        return this.authType;
+    }
+
+    public boolean connected;
+    public void setConnected(boolean connected) {
+        this.connected = connected;
+    }
+    public boolean getConnected() {
+        return this.connected;
+    }
+
+    public java.lang.String serverUrl;
+    public void setServerUrl(java.lang.String serverUrl) {
+        this.serverUrl = serverUrl;
+    }
+    public java.lang.String getServerUrl() {
+        return this.serverUrl;
+    }
+
+    public java.lang.String serverVersion;
+    public void setServerVersion(java.lang.String serverVersion) {
+        this.serverVersion = serverVersion;
+    }
+    public java.lang.String getServerVersion() {
+        return this.serverVersion;
+    }
+
+    public java.lang.String siteUuid;
+    public void setSiteUuid(java.lang.String siteUuid) {
+        this.siteUuid = siteUuid;
+    }
+    public java.lang.String getSiteUuid() {
+        return this.siteUuid;
+    }
+
+    public java.lang.String siteName;
+    public void setSiteName(java.lang.String siteName) {
+        this.siteName = siteName;
+    }
+    public java.lang.String getSiteName() {
+        return this.siteName;
+    }
+
+    public java.lang.String productLine;
+    public void setProductLine(java.lang.String productLine) {
+        this.productLine = productLine;
+    }
+    public java.lang.String getProductLine() {
+        return this.productLine;
+    }
+
+    public java.lang.String snapshotState;
+    public void setSnapshotState(java.lang.String snapshotState) {
+        this.snapshotState = snapshotState;
+    }
+    public java.lang.String getSnapshotState() {
+        return this.snapshotState;
+    }
+
+    public java.lang.String source;
+    public void setSource(java.lang.String source) {
+        this.source = source;
+    }
+    public java.lang.String getSource() {
+        return this.source;
+    }
+
+    public java.lang.String lastSyncDate;
+    public void setLastSyncDate(java.lang.String lastSyncDate) {
+        this.lastSyncDate = lastSyncDate;
+    }
+    public java.lang.String getLastSyncDate() {
+        return this.lastSyncDate;
+    }
+
+    public LicenseInventory platformLicense;
+    public void setPlatformLicense(LicenseInventory platformLicense) {
+        this.platformLicense = platformLicense;
+    }
+    public LicenseInventory getPlatformLicense() {
+        return this.platformLicense;
+    }
+
+    public java.util.List addOns;
+    public void setAddOns(java.util.List addOns) {
+        this.addOns = addOns;
+    }
+    public java.util.List getAddOns() {
+        return this.addOns;
+    }
+
+    public java.util.List quotas;
+    public void setQuotas(java.util.List quotas) {
+        this.quotas = quotas;
+    }
+    public java.util.List getQuotas() {
+        return this.quotas;
+    }
+
+}

--- a/sdk/src/main/java/org/zstack/sdk/LicenseAuthorizationInfo.java
+++ b/sdk/src/main/java/org/zstack/sdk/LicenseAuthorizationInfo.java
@@ -36,6 +36,14 @@ public class LicenseAuthorizationInfo  {
         return this.serverVersion;
     }
 
+    public java.lang.String localVersion;
+    public void setLocalVersion(java.lang.String localVersion) {
+        this.localVersion = localVersion;
+    }
+    public java.lang.String getLocalVersion() {
+        return this.localVersion;
+    }
+
     public java.lang.String siteUuid;
     public void setSiteUuid(java.lang.String siteUuid) {
         this.siteUuid = siteUuid;

--- a/sdk/src/main/java/org/zstack/sdk/LicenseAuthorizationQuotaInventory.java
+++ b/sdk/src/main/java/org/zstack/sdk/LicenseAuthorizationQuotaInventory.java
@@ -1,0 +1,119 @@
+package org.zstack.sdk;
+
+
+
+public class LicenseAuthorizationQuotaInventory  {
+
+    public java.lang.String authEntity;
+    public void setAuthEntity(java.lang.String authEntity) {
+        this.authEntity = authEntity;
+    }
+    public java.lang.String getAuthEntity() {
+        return this.authEntity;
+    }
+
+    public java.lang.String name;
+    public void setName(java.lang.String name) {
+        this.name = name;
+    }
+    public java.lang.String getName() {
+        return this.name;
+    }
+
+    public java.lang.String product;
+    public void setProduct(java.lang.String product) {
+        this.product = product;
+    }
+    public java.lang.String getProduct() {
+        return this.product;
+    }
+
+    public java.lang.String module;
+    public void setModule(java.lang.String module) {
+        this.module = module;
+    }
+    public java.lang.String getModule() {
+        return this.module;
+    }
+
+    public java.lang.String licenseType;
+    public void setLicenseType(java.lang.String licenseType) {
+        this.licenseType = licenseType;
+    }
+    public java.lang.String getLicenseType() {
+        return this.licenseType;
+    }
+
+    public java.lang.String quotaType;
+    public void setQuotaType(java.lang.String quotaType) {
+        this.quotaType = quotaType;
+    }
+    public java.lang.String getQuotaType() {
+        return this.quotaType;
+    }
+
+    public long quota;
+    public void setQuota(long quota) {
+        this.quota = quota;
+    }
+    public long getQuota() {
+        return this.quota;
+    }
+
+    public long used;
+    public void setUsed(long used) {
+        this.used = used;
+    }
+    public long getUsed() {
+        return this.used;
+    }
+
+    public long available;
+    public void setAvailable(long available) {
+        this.available = available;
+    }
+    public long getAvailable() {
+        return this.available;
+    }
+
+    public java.lang.String issuedDate;
+    public void setIssuedDate(java.lang.String issuedDate) {
+        this.issuedDate = issuedDate;
+    }
+    public java.lang.String getIssuedDate() {
+        return this.issuedDate;
+    }
+
+    public java.lang.String expiredDate;
+    public void setExpiredDate(java.lang.String expiredDate) {
+        this.expiredDate = expiredDate;
+    }
+    public java.lang.String getExpiredDate() {
+        return this.expiredDate;
+    }
+
+    public boolean expired;
+    public void setExpired(boolean expired) {
+        this.expired = expired;
+    }
+    public boolean getExpired() {
+        return this.expired;
+    }
+
+    public boolean platform;
+    public void setPlatform(boolean platform) {
+        this.platform = platform;
+    }
+    public boolean getPlatform() {
+        return this.platform;
+    }
+
+    public java.lang.String status;
+    public void setStatus(java.lang.String status) {
+        this.status = status;
+    }
+    public java.lang.String getStatus() {
+        return this.status;
+    }
+
+}

--- a/sdk/src/main/java/org/zstack/sdk/RegisterLicenseClientAction.java
+++ b/sdk/src/main/java/org/zstack/sdk/RegisterLicenseClientAction.java
@@ -38,6 +38,9 @@ public class RegisterLicenseClientAction extends AbstractAction {
     public java.lang.String siteUuid;
 
     @Param(required = false, nonempty = false, nullElements = false, emptyString = true, noTrim = false)
+    public java.lang.String siteAccessKey;
+
+    @Param(required = false, nonempty = false, nullElements = false, emptyString = true, noTrim = false)
     public java.lang.String baseAuthEntity;
 
     @Param(required = false, nonempty = false, nullElements = false, emptyString = true, noTrim = false)

--- a/sdk/src/main/java/org/zstack/sdk/RegisterLicenseClientAction.java
+++ b/sdk/src/main/java/org/zstack/sdk/RegisterLicenseClientAction.java
@@ -44,6 +44,12 @@ public class RegisterLicenseClientAction extends AbstractAction {
     public java.lang.String baseAuthEntity;
 
     @Param(required = false, nonempty = false, nullElements = false, emptyString = true, noTrim = false)
+    public java.lang.String tlsCaPem;
+
+    @Param(required = false, nonempty = false, nullElements = false, emptyString = true, noTrim = false)
+    public java.lang.String tlsServerName;
+
+    @Param(required = false, nonempty = false, nullElements = false, emptyString = true, noTrim = false)
     public java.lang.String bundle;
 
     @Param(required = false, nonempty = false, nullElements = false, emptyString = true, noTrim = false)

--- a/testlib/src/main/java/org/zstack/testlib/ApiHelper.groovy
+++ b/testlib/src/main/java/org/zstack/testlib/ApiHelper.groovy
@@ -21,20 +21,20 @@ abstract class ApiHelper {
         c.resolveStrategy = Closure.OWNER_FIRST
         c.delegate = a
         c()
-        
+
 
         if (System.getProperty("apipath") != null) {
             if (a.apiId == null) {
                 a.apiId = Platform.uuid
             }
-    
+
             def tracker = new ApiPathTracker(a.apiId)
             def out = errorOut(a.call())
             def path = tracker.getApiPath()
             if (!path.isEmpty()) {
                 Test.apiPaths[a.class.name] = path.join(" --->\n")
             }
-        
+
             return out
         } else {
             return errorOut(a.call())
@@ -3682,6 +3682,33 @@ abstract class ApiHelper {
                 Test.apiPaths[a.class.name] = path.join(" --->\n")
             }
         
+            return out
+        } else {
+            return errorOut(a.call())
+        }
+    }
+
+
+    def attachDGpuToVm(@DelegatesTo(strategy = Closure.OWNER_FIRST, value = org.zstack.sdk.AttachDGpuToVmAction.class) Closure c) {
+        def a = new org.zstack.sdk.AttachDGpuToVmAction()
+        a.sessionId = Test.currentEnvSpec?.session?.uuid
+        c.resolveStrategy = Closure.OWNER_FIRST
+        c.delegate = a
+        c()
+
+
+        if (System.getProperty("apipath") != null) {
+            if (a.apiId == null) {
+                a.apiId = Platform.uuid
+            }
+
+            def tracker = new ApiPathTracker(a.apiId)
+            def out = errorOut(a.call())
+            def path = tracker.getApiPath()
+            if (!path.isEmpty()) {
+                Test.apiPaths[a.class.name] = path.join(" --->\n")
+            }
+
             return out
         } else {
             return errorOut(a.call())
@@ -18620,33 +18647,6 @@ abstract class ApiHelper {
     }
 
 
-    def attachDGpuToVm(@DelegatesTo(strategy = Closure.OWNER_FIRST, value = org.zstack.sdk.AttachDGpuToVmAction.class) Closure c) {
-        def a = new org.zstack.sdk.AttachDGpuToVmAction()
-        a.sessionId = Test.currentEnvSpec?.session?.uuid
-        c.resolveStrategy = Closure.OWNER_FIRST
-        c.delegate = a
-        c()
-        
-
-        if (System.getProperty("apipath") != null) {
-            if (a.apiId == null) {
-                a.apiId = Platform.uuid
-            }
-    
-            def tracker = new ApiPathTracker(a.apiId)
-            def out = errorOut(a.call())
-            def path = tracker.getApiPath()
-            if (!path.isEmpty()) {
-                Test.apiPaths[a.class.name] = path.join(" --->\n")
-            }
-        
-            return out
-        } else {
-            return errorOut(a.call())
-        }
-    }
-
-
     def detachBaremetalPxeServerFromCluster(@DelegatesTo(strategy = Closure.OWNER_FIRST, value = org.zstack.sdk.DetachBaremetalPxeServerFromClusterAction.class) Closure c) {
         def a = new org.zstack.sdk.DetachBaremetalPxeServerFromClusterAction()
         a.sessionId = Test.currentEnvSpec?.session?.uuid
@@ -23696,26 +23696,53 @@ abstract class ApiHelper {
     }
 
 
-    def getLicenseCapabilities(@DelegatesTo(strategy = Closure.OWNER_FIRST, value = org.zstack.sdk.GetLicenseCapabilitiesAction.class) Closure c) {
-        def a = new org.zstack.sdk.GetLicenseCapabilitiesAction()
-        a.sessionId = Test.currentEnvSpec?.session?.uuid
+    def getLicenseAuthorizationInfo(@DelegatesTo(strategy = Closure.OWNER_FIRST, value = org.zstack.sdk.GetLicenseAuthorizationInfoAction.class) Closure c) {
+        def a = new org.zstack.sdk.GetLicenseAuthorizationInfoAction()
+
         c.resolveStrategy = Closure.OWNER_FIRST
         c.delegate = a
         c()
-        
+
 
         if (System.getProperty("apipath") != null) {
             if (a.apiId == null) {
                 a.apiId = Platform.uuid
             }
-    
+
             def tracker = new ApiPathTracker(a.apiId)
             def out = errorOut(a.call())
             def path = tracker.getApiPath()
             if (!path.isEmpty()) {
                 Test.apiPaths[a.class.name] = path.join(" --->\n")
             }
-        
+
+            return out
+        } else {
+            return errorOut(a.call())
+        }
+    }
+
+
+    def getLicenseCapabilities(@DelegatesTo(strategy = Closure.OWNER_FIRST, value = org.zstack.sdk.GetLicenseCapabilitiesAction.class) Closure c) {
+        def a = new org.zstack.sdk.GetLicenseCapabilitiesAction()
+        a.sessionId = Test.currentEnvSpec?.session?.uuid
+        c.resolveStrategy = Closure.OWNER_FIRST
+        c.delegate = a
+        c()
+
+
+        if (System.getProperty("apipath") != null) {
+            if (a.apiId == null) {
+                a.apiId = Platform.uuid
+            }
+
+            def tracker = new ApiPathTracker(a.apiId)
+            def out = errorOut(a.call())
+            def path = tracker.getApiPath()
+            if (!path.isEmpty()) {
+                Test.apiPaths[a.class.name] = path.join(" --->\n")
+            }
+
             return out
         } else {
             return errorOut(a.call())
@@ -40683,33 +40710,6 @@ abstract class ApiHelper {
     }
 
 
-    def updateVmDGpu(@DelegatesTo(strategy = Closure.OWNER_FIRST, value = org.zstack.sdk.UpdateVmDGpuAction.class) Closure c) {
-        def a = new org.zstack.sdk.UpdateVmDGpuAction()
-        a.sessionId = Test.currentEnvSpec?.session?.uuid
-        c.resolveStrategy = Closure.OWNER_FIRST
-        c.delegate = a
-        c()
-        
-
-        if (System.getProperty("apipath") != null) {
-            if (a.apiId == null) {
-                a.apiId = Platform.uuid
-            }
-    
-            def tracker = new ApiPathTracker(a.apiId)
-            def out = errorOut(a.call())
-            def path = tracker.getApiPath()
-            if (!path.isEmpty()) {
-                Test.apiPaths[a.class.name] = path.join(" --->\n")
-            }
-        
-            return out
-        } else {
-            return errorOut(a.call())
-        }
-    }
-
-
     def setVmEmulatorPinning(@DelegatesTo(strategy = Closure.OWNER_FIRST, value = org.zstack.sdk.SetVmEmulatorPinningAction.class) Closure c) {
         def a = new org.zstack.sdk.SetVmEmulatorPinningAction()
         a.sessionId = Test.currentEnvSpec?.session?.uuid
@@ -48101,6 +48101,33 @@ abstract class ApiHelper {
                 Test.apiPaths[a.class.name] = path.join(" --->\n")
             }
         
+            return out
+        } else {
+            return errorOut(a.call())
+        }
+    }
+
+
+    def updateVmDGpu(@DelegatesTo(strategy = Closure.OWNER_FIRST, value = org.zstack.sdk.UpdateVmDGpuAction.class) Closure c) {
+        def a = new org.zstack.sdk.UpdateVmDGpuAction()
+        a.sessionId = Test.currentEnvSpec?.session?.uuid
+        c.resolveStrategy = Closure.OWNER_FIRST
+        c.delegate = a
+        c()
+
+
+        if (System.getProperty("apipath") != null) {
+            if (a.apiId == null) {
+                a.apiId = Platform.uuid
+            }
+
+            def tracker = new ApiPathTracker(a.apiId)
+            def out = errorOut(a.call())
+            def path = tracker.getApiPath()
+            if (!path.isEmpty()) {
+                Test.apiPaths[a.class.name] = path.join(" --->\n")
+            }
+
             return out
         } else {
             return errorOut(a.call())


### PR DESCRIPTION
## Summary

Sync hanyu.liang-authored license commits from upstream/5.5.24 to upstream/5.5.28.

Cherry-picked commits:
- 4bd879eb2a8f <feature>[license]: add license auth info api
- 13b69c91e006 <feature>[license]: complete auth info output
- 13b4267c7128 <fix>[license]: support LS HTTPS SDK

## Verification

Worktree: `/home/openclaw/zstack-dev/worktrees/5.5.28/SYNC-HANYU-5524-5528/zstack`
Maven repo: `/home/openclaw/zstack-build-cache/bugs/5.5.28/SYNC-HANYU-5524-5528/repository`

- `zstack-mvn -P premium -pl premium/mevoco -am -DskipTests install` PASS
  - log: `/home/openclaw/zstack-build-logs/5.5.28/SYNC-HANYU-5524-5528/focused-build-mevoco-reactor.log`
- `zstack-env-manager.sh build-bug 5.5.28 SYNC-HANYU-5524-5528 --full --offline 0 --threads 8` PASS
  - log: `/home/openclaw/zstack-build-logs/5.5.28/SYNC-HANYU-5524-5528/full-build-20260615-165140.log`
- `LicenseClientGateTest` PASS
  - log: `/home/openclaw/zstack-build-logs/5.5.28/SYNC-HANYU-5524-5528/test-LicenseClientGateTest.log`
- `LicenseClientApiPoolUsageCase,LicenseClientPolicyRegistryCase,LicenseClientStrategyUnitCase,LicenseClientUsageReporterUnitCase` PASS
  - log: `/home/openclaw/zstack-build-logs/5.5.28/SYNC-HANYU-5524-5528/test-license-unit-cases-online.log`

sync from gitlab !10224