### PR TITLE
[ZSV-12438] Support encrypted data volume SDK creation

### DIFF
--- a/header/src/main/java/org/zstack/header/volume/APICreateDataVolumeFromVolumeTemplateMsg.java
+++ b/header/src/main/java/org/zstack/header/volume/APICreateDataVolumeFromVolumeTemplateMsg.java
@@ -32,6 +32,8 @@ public class APICreateDataVolumeFromVolumeTemplateMsg extends APICreateMessage i
     private String primaryStorageUuid;
     @APIParam(resourceType = HostVO.class, required = false)
     private String hostUuid;
+    @APIParam(required = false)
+    private Boolean encrypted;
 
     public String getHostUuid() {
         return hostUuid;
@@ -91,6 +93,16 @@ public class APICreateDataVolumeFromVolumeTemplateMsg extends APICreateMessage i
     @Override
     public void setDiskSize(long diskSize) {
 
+    }
+
+    @Override
+    public Boolean getEncrypted() {
+        return encrypted;
+    }
+
+    @Override
+    public void setEncrypted(Boolean encrypted) {
+        this.encrypted = encrypted;
     }
 
     public static APICreateDataVolumeFromVolumeTemplateMsg __example__() {

--- a/header/src/main/java/org/zstack/header/volume/APICreateDataVolumeFromVolumeTemplateMsgDoc_zh_cn.groovy
+++ b/header/src/main/java/org/zstack/header/volume/APICreateDataVolumeFromVolumeTemplateMsgDoc_zh_cn.groovy
@@ -67,6 +67,15 @@ doc {
 					since "0.6"
 				}
 				column {
+					name "encrypted"
+					enclosedIn "params"
+					desc "是否创建加密云盘"
+					location "body"
+					type "Boolean"
+					optional true
+					since "5.1.0"
+				}
+				column {
 					name "resourceUuid"
 					enclosedIn "params"
 					desc ""

--- a/header/src/main/java/org/zstack/header/volume/APICreateDataVolumeMsg.java
+++ b/header/src/main/java/org/zstack/header/volume/APICreateDataVolumeMsg.java
@@ -70,6 +70,9 @@ public class APICreateDataVolumeMsg extends APICreateMessage implements APIAudit
     @APIParam(required = false, resourceType = PrimaryStorageVO.class)
     private String primaryStorageUuid;
 
+    @APIParam(required = false)
+    private Boolean encrypted;
+
     public String getPrimaryStorageUuid() {
         return primaryStorageUuid;
     }
@@ -108,6 +111,16 @@ public class APICreateDataVolumeMsg extends APICreateMessage implements APIAudit
 
     public void setDiskSize(long diskSize) {
         this.diskSize = diskSize;
+    }
+
+    @Override
+    public Boolean getEncrypted() {
+        return encrypted;
+    }
+
+    @Override
+    public void setEncrypted(Boolean encrypted) {
+        this.encrypted = encrypted;
     }
 
     public static APICreateDataVolumeMsg __example__() {

--- a/header/src/main/java/org/zstack/header/volume/APICreateDataVolumeMsgDoc_zh_cn.groovy
+++ b/header/src/main/java/org/zstack/header/volume/APICreateDataVolumeMsgDoc_zh_cn.groovy
@@ -58,6 +58,15 @@ doc {
 					since "0.6"
 				}
 				column {
+					name "encrypted"
+					enclosedIn "params"
+					desc "是否创建加密云盘"
+					location "body"
+					type "Boolean"
+					optional true
+					since "5.1.0"
+				}
+				column {
 					name "resourceUuid"
 					enclosedIn "params"
 					desc "资源的Uuid"

--- a/header/src/main/java/org/zstack/header/volume/CreateDataVolumeFromVolumeTemplateMsg.java
+++ b/header/src/main/java/org/zstack/header/volume/CreateDataVolumeFromVolumeTemplateMsg.java
@@ -32,6 +32,7 @@ public class CreateDataVolumeFromVolumeTemplateMsg extends NeedReplyMessage impl
         hostUuid = amsg.getHostUuid();
         resourceUuid = amsg.getResourceUuid();
         accountUuid = amsg.getSession().getAccountUuid();
+        encrypted = amsg.getEncrypted();
         apiMsg = amsg;
     }
 

--- a/header/src/main/java/org/zstack/header/volume/CreateDataVolumeMsg.java
+++ b/header/src/main/java/org/zstack/header/volume/CreateDataVolumeMsg.java
@@ -10,6 +10,7 @@ public class CreateDataVolumeMsg extends NeedReplyMessage implements VolumeCreat
     private String primaryStorageUuid;
     private String accountUuid;
     private String resourceUuid;
+    private Boolean encrypted;
     private APICreateDataVolumeMsg apiMsg;
 
     public String getPrimaryStorageUuid() {
@@ -74,5 +75,15 @@ public class CreateDataVolumeMsg extends NeedReplyMessage implements VolumeCreat
 
     public void setApiMsg(APICreateDataVolumeMsg apiMsg) {
         this.apiMsg = apiMsg;
+    }
+
+    @Override
+    public Boolean getEncrypted() {
+        return encrypted;
+    }
+
+    @Override
+    public void setEncrypted(Boolean encrypted) {
+        this.encrypted = encrypted;
     }
 }

--- a/sdk/src/main/java/org/zstack/sdk/CreateDataVolumeAction.java
+++ b/sdk/src/main/java/org/zstack/sdk/CreateDataVolumeAction.java
@@ -41,6 +41,9 @@ public class CreateDataVolumeAction extends AbstractAction {
     public java.lang.String primaryStorageUuid;
 
     @Param(required = false)
+    public java.lang.Boolean encrypted;
+
+    @Param(required = false)
     public java.lang.String resourceUuid;
 
     @Param(required = false, nonempty = false, nullElements = false, emptyString = true, noTrim = false)

--- a/sdk/src/main/java/org/zstack/sdk/CreateDataVolumeFromVolumeTemplateAction.java
+++ b/sdk/src/main/java/org/zstack/sdk/CreateDataVolumeFromVolumeTemplateAction.java
@@ -41,6 +41,9 @@ public class CreateDataVolumeFromVolumeTemplateAction extends AbstractAction {
     public java.lang.String hostUuid;
 
     @Param(required = false)
+    public java.lang.Boolean encrypted;
+
+    @Param(required = false)
     public java.lang.String resourceUuid;
 
     @Param(required = false, nonempty = false, nullElements = false, emptyString = true, noTrim = false)

--- a/storage/src/main/java/org/zstack/storage/volume/VolumeManagerImpl.java
+++ b/storage/src/main/java/org/zstack/storage/volume/VolumeManagerImpl.java
@@ -1147,6 +1147,7 @@ public class VolumeManagerImpl extends AbstractService implements VolumeManager,
         vo.setType(VolumeType.Data);
         vo.setStatus(VolumeStatus.NotInstantiated);
         vo.setAccountUuid(msg.getAccountUuid());
+        vo.setEncrypted(Boolean.TRUE.equals(msg.getEncrypted()));
 
         if (msg.getSystemTags() != null) {
             Iterator<String> iterators = msg.getSystemTags().iterator();
@@ -1240,6 +1241,7 @@ public class VolumeManagerImpl extends AbstractService implements VolumeManager,
         cmsg.setDiskOfferingUuid(msg.getDiskOfferingUuid());
         cmsg.setPrimaryStorageUuid(msg.getPrimaryStorageUuid());
         cmsg.setDescription(msg.getDescription());
+        cmsg.setEncrypted(msg.getEncrypted());
         cmsg.setApiMsg(msg);
         bus.makeLocalServiceId(cmsg, VolumeConstant.SERVICE_ID);
         bus.send(cmsg, new CloudBusCallBack(msg) {

--- a/test/src/test/java/org/zstack/test/unittest/storage/volume/EncryptedDataVolumeCreateApiTest.java
+++ b/test/src/test/java/org/zstack/test/unittest/storage/volume/EncryptedDataVolumeCreateApiTest.java
@@ -1,0 +1,55 @@
+package org.zstack.test.unittest.storage.volume;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.zstack.header.volume.APICreateDataVolumeFromVolumeTemplateMsg;
+import org.zstack.header.volume.APICreateDataVolumeMsg;
+import org.zstack.header.volume.CreateDataVolumeFromVolumeTemplateMsg;
+import org.zstack.header.volume.CreateDataVolumeMsg;
+import org.zstack.header.volume.VolumeCreateMessage;
+import org.zstack.sdk.CreateDataVolumeAction;
+import org.zstack.sdk.CreateDataVolumeFromVolumeTemplateAction;
+
+import java.lang.reflect.Field;
+
+public class EncryptedDataVolumeCreateApiTest {
+    @Test
+    public void testSdkCreateDataVolumeActionExposesEncryptedParameter() throws Exception {
+        Field encrypted = CreateDataVolumeAction.class.getField("encrypted");
+        Assert.assertEquals(Boolean.class, encrypted.getType());
+    }
+
+    @Test
+    public void testSdkCreateDataVolumeFromVolumeTemplateActionExposesEncryptedParameter() throws Exception {
+        Field encrypted = CreateDataVolumeFromVolumeTemplateAction.class.getField("encrypted");
+        Assert.assertEquals(Boolean.class, encrypted.getType());
+    }
+
+    @Test
+    public void testApiCreateDataVolumeMessageCarriesEncryptedFlag() {
+        VolumeCreateMessage msg = new APICreateDataVolumeMsg();
+        msg.setEncrypted(Boolean.TRUE);
+        Assert.assertEquals(Boolean.TRUE, msg.getEncrypted());
+    }
+
+    @Test
+    public void testCreateDataVolumeMessageCarriesEncryptedFlag() {
+        CreateDataVolumeMsg msg = new CreateDataVolumeMsg();
+        msg.setEncrypted(Boolean.TRUE);
+        Assert.assertEquals(Boolean.TRUE, msg.getEncrypted());
+    }
+
+    @Test
+    public void testApiCreateDataVolumeFromTemplateMessageCarriesEncryptedFlag() {
+        VolumeCreateMessage msg = new APICreateDataVolumeFromVolumeTemplateMsg();
+        msg.setEncrypted(Boolean.TRUE);
+        Assert.assertEquals(Boolean.TRUE, msg.getEncrypted());
+    }
+
+    @Test
+    public void testCreateDataVolumeFromTemplateMessageCarriesEncryptedFlag() {
+        CreateDataVolumeFromVolumeTemplateMsg msg = new CreateDataVolumeFromVolumeTemplateMsg();
+        msg.setEncrypted(Boolean.TRUE);
+        Assert.assertEquals(Boolean.TRUE, msg.getEncrypted());
+    }
+}


### PR DESCRIPTION
Summary: expose encrypted parameter on CreateDataVolume and CreateDataVolumeFromVolumeTemplate API/SDK messages; propagate encrypted flag into internal volume creation and persist it; add unit coverage. Test: deployed jars to 172.26.213.50; SDK CreateDataVolumeAction(encrypted=True) created encrypted=True volume; SDK CreateDataVolumeFromVolumeTemplateAction(encrypted=True) created Ready encrypted=True volume on sblk; with keyProvider/default.keyProviderUuid=None both SDK calls failed with default key provider is not configured and config was restored. Jira: http://jira.zstack.io/browse/ZSV-12438

sync from gitlab !10228