### PR TITLE
<fix>[storage]: reject RBD encryption conversion with snapshots

### DIFF
--- a/storage/src/main/java/org/zstack/storage/volume/VolumeBase.java
+++ b/storage/src/main/java/org/zstack/storage/volume/VolumeBase.java
@@ -3329,27 +3329,16 @@ public class VolumeBase extends AbstractVolume implements Volume {
             @Override
             public void setup() {
                 flow(new NoRollbackFlow() {
-                    String __name__ = "merge-ceph-volume-snapshots-before-encryption-conversion";
-
-                    @Override
-                    public boolean skip(Map data) {
-                        return !isCephInstallPath(self.getInstallPath());
-                    }
+                    String __name__ = "validate-volume-encryption-conversion";
 
                     @Override
                     public void run(FlowTrigger trigger, Map data) {
-                        mergeCephSnapshotsBeforeEncryptionConversion(new Completion(trigger) {
-                            @Override
-                            public void success() {
-                                refreshVO();
-                                trigger.next();
-                            }
-
-                            @Override
-                            public void fail(ErrorCode errorCode) {
-                                trigger.fail(errorCode);
-                            }
-                        });
+                        ErrorCode errorCode = validateVolumeEncryptionConversion();
+                        if (errorCode != null) {
+                            trigger.fail(errorCode);
+                            return;
+                        }
+                        trigger.next();
                     }
                 });
 
@@ -3522,44 +3511,21 @@ public class VolumeBase extends AbstractVolume implements Volume {
         return ctx;
     }
 
-    private void mergeCephSnapshotsBeforeEncryptionConversion(Completion completion) {
-        List<VolumeSnapshotVO> roots = Q.New(VolumeSnapshotVO.class)
-                .eq(VolumeSnapshotVO_.volumeUuid, self.getUuid())
-                .notNull(VolumeSnapshotVO_.primaryStorageUuid)
-                .isNull(VolumeSnapshotVO_.parentUuid)
-                .list();
-        if (roots.isEmpty()) {
-            completion.success();
-            return;
+    private ErrorCode validateVolumeEncryptionConversion() {
+        if (!isCephInstallPath(self.getInstallPath())) {
+            return null;
         }
 
-        new While<>(roots).step((root, whileCompletion) -> {
-            VolumeSnapshotDeletionMsg dmsg = new VolumeSnapshotDeletionMsg();
-            dmsg.setTreeUuid(root.getTreeUuid());
-            dmsg.setVolumeUuid(root.getVolumeUuid());
-            dmsg.setSnapshotUuid(root.getUuid());
-            dmsg.setDirection(DeleteVolumeSnapshotDirection.Commit.toString());
-            dmsg.setScope(DeleteVolumeSnapshotScope.Chain.toString());
-            bus.makeTargetServiceIdByResourceUuid(dmsg, VolumeSnapshotConstant.SERVICE_ID, root.getUuid());
-            bus.send(dmsg, new CloudBusCallBack(whileCompletion) {
-                @Override
-                public void run(MessageReply reply) {
-                    if (!reply.isSuccess()) {
-                        whileCompletion.addError(reply.getError());
-                    }
-                    whileCompletion.done();
-                }
-            });
-        }, 1).run(new WhileDoneCompletion(completion) {
-            @Override
-            public void done(ErrorCodeList errorCodeList) {
-                if (errorCodeList.getCauses().isEmpty()) {
-                    completion.success();
-                } else {
-                    completion.fail(errorCodeList.getCauses().get(0));
-                }
-            }
-        });
+        boolean hasSnapshots = Q.New(VolumeSnapshotVO.class)
+                .eq(VolumeSnapshotVO_.volumeUuid, self.getUuid())
+                .notNull(VolumeSnapshotVO_.primaryStorageUuid)
+                .isExists();
+        if (!hasSnapshots) {
+            return null;
+        }
+
+        return operr("cannot change encryption for Ceph/RBD volume[uuid:%s] because it has snapshots; delete snapshots before changing volume encryption",
+                self.getUuid());
     }
 
     private String resolveVolumeSecretHostUuid(VolumeVO volume) {


### PR DESCRIPTION
Summary:\n- Reject Ceph/RBD volume encryption conversion when primary-storage snapshots exist.\n- Stop implicitly merging/deleting Ceph snapshots before encryption conversion.\n\nJira:\n- ZSV-12449\n\nTest:\n- mvn -DskipTests -Dmaven.test.skip=true -DskipJacoco=true -pl storage -am clean install\n- Deployed storage jar on 172.26.213.50 and verified ChangeVolumeEncryption fails for an RBD volume with snapshot while the snapshot remains.

sync from gitlab !10231