### PR TITLE
<fix>[mgt-ipv6]: ZSTAC-86059 bind MN id to host fingerprint

### DIFF
--- a/core/src/main/java/org/zstack/core/Platform.java
+++ b/core/src/main/java/org/zstack/core/Platform.java
@@ -1,5 +1,6 @@
 package org.zstack.core;
 
+import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang.LocaleUtils;
 import org.apache.commons.lang.RandomStringUtils;
@@ -101,11 +102,21 @@ public class Platform {
     private static final String JAVA_TMP_DIR_PROPERTY = "java.io.tmpdir";
     private static final String UNIT_TEST_DATA_DIR_NAME = "zstack-unit-test";
     private static final String MANAGEMENT_SERVER_ID_STATE_FILE_NAME = "management-server-id.properties";
+    private static final String MANAGEMENT_SERVER_FINGERPRINT_VERSION = "1";
+    private static final String MANAGEMENT_SERVER_FINGERPRINT_ALGORITHM = "sha256:";
+    private static final List<String> MANAGEMENT_SERVER_FINGERPRINT_SOURCE_FILES = Arrays.asList(
+            "/etc/machine-id",
+            "/sys/class/dmi/id/product_uuid",
+            "/sys/class/dmi/id/product_serial",
+            "/sys/class/dmi/id/board_serial"
+    );
     private static final String ZSTACK_UUID_PATTERN = "[0-9a-fA-F]{32}";
     private static EncryptRSA rsa = new EncryptRSA();
     private static Map<String, Double> errorCounter = new HashMap<>();
 
     public static final String MANAGEMENT_SERVER_ID_PROPERTY = "managementServerId";
+    public static final String MANAGEMENT_SERVER_FINGERPRINT_PROPERTY = "managementServerFingerprint";
+    public static final String MANAGEMENT_SERVER_FINGERPRINT_VERSION_PROPERTY = "managementServerFingerprintVersion";
     public static final String COMPONENT_CLASSPATH_HOME = "componentsHome";
     public static final String FAKE_UUID = "THIS_IS_A_FAKE_UUID";
 
@@ -731,6 +742,10 @@ public class Platform {
     }
 
     public static synchronized String loadOrCreateManagementServerId(File propertiesFile, File stateFile, Supplier<String> idSupplier) {
+        return loadOrCreateManagementServerId(propertiesFile, stateFile, idSupplier, Platform::getManagementServerFingerprint);
+    }
+
+    public static synchronized String loadOrCreateManagementServerId(File propertiesFile, File stateFile, Supplier<String> idSupplier, Supplier<String> fingerprintSupplier) {
         Properties properties = loadProperties(propertiesFile);
 
         String configuredId = properties.getProperty(MANAGEMENT_SERVER_ID_PROPERTY);
@@ -739,11 +754,17 @@ public class Platform {
             return configuredId;
         }
 
+        String currentFingerprint = fingerprintSupplier.get();
         Properties state = loadProperties(stateFile);
         String persistedId = state.getProperty(MANAGEMENT_SERVER_ID_PROPERTY);
         if (isValidManagementServerId(persistedId)) {
-            System.setProperty(MANAGEMENT_SERVER_ID_PROPERTY, persistedId);
-            return persistedId;
+            if (canReusePersistedManagementServerId(state, currentFingerprint)) {
+                ensureManagementServerFingerprint(stateFile, state, currentFingerprint);
+                System.setProperty(MANAGEMENT_SERVER_ID_PROPERTY, persistedId);
+                return persistedId;
+            }
+
+            logger.warn(String.format("management server id state file[%s] fingerprint does not match current machine, regenerate management server id", stateFile.getAbsolutePath()));
         }
 
         String generatedId = idSupplier.get();
@@ -752,6 +773,7 @@ public class Platform {
         }
 
         state.setProperty(MANAGEMENT_SERVER_ID_PROPERTY, generatedId);
+        setManagementServerFingerprint(state, currentFingerprint);
         saveManagementServerId(stateFile, state);
         System.setProperty(MANAGEMENT_SERVER_ID_PROPERTY, generatedId);
         return generatedId;
@@ -779,6 +801,87 @@ public class Platform {
         }
 
         return new File(dataDir, MANAGEMENT_SERVER_ID_STATE_FILE_NAME);
+    }
+
+    private static boolean canReusePersistedManagementServerId(Properties state, String currentFingerprint) {
+        if (StringUtils.isBlank(currentFingerprint)) {
+            return true;
+        }
+
+        String persistedFingerprint = state.getProperty(MANAGEMENT_SERVER_FINGERPRINT_PROPERTY);
+        String persistedFingerprintVersion = state.getProperty(MANAGEMENT_SERVER_FINGERPRINT_VERSION_PROPERTY);
+        if (StringUtils.isBlank(persistedFingerprint) || !MANAGEMENT_SERVER_FINGERPRINT_VERSION.equals(persistedFingerprintVersion)) {
+            return true;
+        }
+
+        return currentFingerprint.equals(persistedFingerprint);
+    }
+
+    private static void ensureManagementServerFingerprint(File stateFile, Properties state, String currentFingerprint) {
+        if (StringUtils.isBlank(currentFingerprint)) {
+            return;
+        }
+
+        String persistedFingerprint = state.getProperty(MANAGEMENT_SERVER_FINGERPRINT_PROPERTY);
+        String persistedFingerprintVersion = state.getProperty(MANAGEMENT_SERVER_FINGERPRINT_VERSION_PROPERTY);
+        if (currentFingerprint.equals(persistedFingerprint) && MANAGEMENT_SERVER_FINGERPRINT_VERSION.equals(persistedFingerprintVersion)) {
+            return;
+        }
+
+        setManagementServerFingerprint(state, currentFingerprint);
+        saveManagementServerId(stateFile, state);
+    }
+
+    private static void setManagementServerFingerprint(Properties state, String fingerprint) {
+        if (StringUtils.isBlank(fingerprint)) {
+            state.remove(MANAGEMENT_SERVER_FINGERPRINT_PROPERTY);
+            state.remove(MANAGEMENT_SERVER_FINGERPRINT_VERSION_PROPERTY);
+            return;
+        }
+
+        state.setProperty(MANAGEMENT_SERVER_FINGERPRINT_PROPERTY, fingerprint);
+        state.setProperty(MANAGEMENT_SERVER_FINGERPRINT_VERSION_PROPERTY, MANAGEMENT_SERVER_FINGERPRINT_VERSION);
+    }
+
+    private static String getManagementServerFingerprint() {
+        List<String> identities = new ArrayList<>();
+        for (String path : MANAGEMENT_SERVER_FINGERPRINT_SOURCE_FILES) {
+            String identity = readMachineIdentity(path);
+            if (identity != null) {
+                identities.add(String.format("%s=%s", path, identity));
+            }
+        }
+
+        if (identities.isEmpty()) {
+            logger.warn("cannot calculate management server fingerprint because no stable machine identity source is available");
+            return null;
+        }
+
+        return MANAGEMENT_SERVER_FINGERPRINT_ALGORITHM + DigestUtils.sha256Hex(StringUtils.join(identities, "\n"));
+    }
+
+    private static String readMachineIdentity(String path) {
+        File file = new File(path);
+        if (!file.isFile() || !file.canRead()) {
+            return null;
+        }
+
+        try {
+            String identity = FileUtils.readFileToString(file).trim().toLowerCase();
+            return isUsableMachineIdentity(identity) ? identity : null;
+        } catch (IOException e) {
+            logger.warn(String.format("unable to read machine identity file[%s], skip it", path), e);
+            return null;
+        }
+    }
+
+    private static boolean isUsableMachineIdentity(String identity) {
+        if (StringUtils.isBlank(identity)) {
+            return false;
+        }
+
+        String normalized = identity.replace("-", "");
+        return !StringUtils.containsOnly(normalized, "0") && !StringUtils.containsOnly(normalized, "f");
     }
 
     private static boolean isValidManagementServerId(String id) {

--- a/core/src/main/java/org/zstack/core/Platform.java
+++ b/core/src/main/java/org/zstack/core/Platform.java
@@ -791,7 +791,7 @@ public class Platform {
         return properties;
     }
 
-    private static File getManagementServerIdStateFile() {
+    public static File getManagementServerIdStateFile() {
         String dataDir = System.getProperty(DATA_DIR_PROPERTY);
         if (dataDir == null && Boolean.parseBoolean(System.getProperty(UNIT_TEST_ON_PROPERTY))) {
             dataDir = new File(System.getProperty(JAVA_TMP_DIR_PROPERTY), UNIT_TEST_DATA_DIR_NAME).getAbsolutePath();

--- a/portal/src/main/java/org/zstack/portal/managementnode/ManagementNodeManagerImpl.java
+++ b/portal/src/main/java/org/zstack/portal/managementnode/ManagementNodeManagerImpl.java
@@ -523,6 +523,14 @@ public class ManagementNodeManagerImpl extends AbstractService implements Manage
                             String ip = Platform.getManagementServerIp();
                             String uuid = Platform.getManagementServerId();
 
+                            ManagementNodeVO existing = findByUuid(uuid, ManagementNodeVO.class);
+                            if (ManagementNodeManagerImpl.this.isDuplicatedActiveManagementServerId(existing, ip, databaseFacade.getCurrentSqlTime())) {
+                                throw new CloudRuntimeException(String.format(
+                                        "duplicated management server id[%s] detected, current management.server.ip[%s], existing management node hostName[%s]. " +
+                                                "Please remove /var/lib/zstack/management-server-id.properties on the cloned or peer management node and restart it",
+                                        uuid, ip, existing.getHostName()));
+                            }
+
                             sql(ManagementNodeVO.class).eq(ManagementNodeVO_.uuid, uuid).hardDelete();
 
                             ManagementNodeVO vo = new ManagementNodeVO();
@@ -723,6 +731,17 @@ public class ManagementNodeManagerImpl extends AbstractService implements Manage
 
             connectionTimeoutExecutor.shutdown();
         }
+    }
+
+    private boolean isDuplicatedActiveManagementServerId(ManagementNodeVO existing, String currentHostName, Timestamp currentTime) {
+        if (existing == null || StringUtils.equals(existing.getHostName(), currentHostName) || existing.getHeartBeat() == null) {
+            return false;
+        }
+
+        long heartbeatExpirationMillis = TimeUnit.SECONDS.toMillis(
+                (long) (PortalGlobalProperty.MAX_HEARTBEAT_FAILURE + 1)
+                        * ManagementNodeGlobalConfig.NODE_HEARTBEAT_INTERVAL.value(Integer.class));
+        return currentTime.getTime() - existing.getHeartBeat().getTime() <= heartbeatExpirationMillis;
     }
 
     private ManagementNodeVO node() {

--- a/portal/src/main/java/org/zstack/portal/managementnode/ManagementNodeManagerImpl.java
+++ b/portal/src/main/java/org/zstack/portal/managementnode/ManagementNodeManagerImpl.java
@@ -527,8 +527,8 @@ public class ManagementNodeManagerImpl extends AbstractService implements Manage
                             if (ManagementNodeManagerImpl.this.isDuplicatedActiveManagementServerId(existing, ip, databaseFacade.getCurrentSqlTime())) {
                                 throw new CloudRuntimeException(String.format(
                                         "duplicated management server id[%s] detected, current management.server.ip[%s], existing management node hostName[%s]. " +
-                                                "Please remove /var/lib/zstack/management-server-id.properties on the cloned or peer management node and restart it",
-                                        uuid, ip, existing.getHostName()));
+                                                "Please remove %s on the cloned or peer management node and restart it",
+                                        uuid, ip, existing.getHostName(), Platform.getManagementServerIdStateFile().getAbsolutePath()));
                             }
 
                             sql(ManagementNodeVO.class).eq(ManagementNodeVO_.uuid, uuid).hardDelete();

--- a/test/src/test/groovy/org/zstack/test/integration/core/ManagementNetworkIpv6Case.groovy
+++ b/test/src/test/groovy/org/zstack/test/integration/core/ManagementNetworkIpv6Case.groovy
@@ -111,6 +111,7 @@ class ManagementNetworkIpv6Case extends SubCase {
         testManagementCidrCommandOutputParsing()
         testManagementCidrIpVersionOverload()
         testManagementServerIdPersisted()
+        testManagementServerIdStateFileUsesConfiguredDataDir()
         testNfsIpv6UrlParsing()
         testCephIpv6MonUrlParsing()
         testCephMetadataAgentUrlUsesBracketedIpv6Host()
@@ -396,6 +397,23 @@ class ManagementNetworkIpv6Case extends SubCase {
             } else {
                 System.setProperty(Platform.MANAGEMENT_SERVER_ID_PROPERTY, oldValue)
             }
+        }
+    }
+
+    void testManagementServerIdStateFileUsesConfiguredDataDir() {
+        String oldDataDir = System.getProperty("dataDir")
+        File dataDir = File.createTempDir()
+        try {
+            System.setProperty("dataDir", dataDir.absolutePath)
+
+            assert Platform.getManagementServerIdStateFile() == new File(dataDir, "management-server-id.properties")
+        } finally {
+            if (oldDataDir == null) {
+                System.clearProperty("dataDir")
+            } else {
+                System.setProperty("dataDir", oldDataDir)
+            }
+            dataDir.deleteDir()
         }
     }
 

--- a/test/src/test/groovy/org/zstack/test/integration/core/ManagementNetworkIpv6Case.groovy
+++ b/test/src/test/groovy/org/zstack/test/integration/core/ManagementNetworkIpv6Case.groovy
@@ -43,6 +43,8 @@ class ManagementNetworkIpv6Case extends SubCase {
     private static final String INVALID_IP = "not-an-ip!!"
     private static final String MANAGEMENT_SERVER_ID = "1234567890abcdef1234567890abcdef"
     private static final String NEW_MANAGEMENT_SERVER_ID = "abcdef1234567890abcdef1234567890"
+    private static final String MANAGEMENT_SERVER_FINGERPRINT = "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    private static final String NEW_MANAGEMENT_SERVER_FINGERPRINT = "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
     private static final String NFS_EXPORT_PATH = "/export/nfs"
     private static final String NFS_IPV4_URL = "${IPV4}:${NFS_EXPORT_PATH}"
     private static final String NFS_IPV6_URL = "[${IPV6}]:${NFS_EXPORT_PATH}"
@@ -327,7 +329,8 @@ class ManagementNetworkIpv6Case extends SubCase {
             String generatedId = Platform.loadOrCreateManagementServerId(
                     propertiesFile,
                     stateFile,
-                    { -> MANAGEMENT_SERVER_ID } as Supplier<String>)
+                    { -> MANAGEMENT_SERVER_ID } as Supplier<String>,
+                    { -> MANAGEMENT_SERVER_FINGERPRINT } as Supplier<String>)
             assert generatedId == MANAGEMENT_SERVER_ID
             Properties properties = new Properties()
             propertiesFile.withInputStream { properties.load(it) }
@@ -335,18 +338,55 @@ class ManagementNetworkIpv6Case extends SubCase {
             Properties state = new Properties()
             stateFile.withInputStream { state.load(it) }
             assert state.getProperty(Platform.MANAGEMENT_SERVER_ID_PROPERTY) == MANAGEMENT_SERVER_ID
+            assert state.getProperty(Platform.MANAGEMENT_SERVER_FINGERPRINT_PROPERTY) == MANAGEMENT_SERVER_FINGERPRINT
+            assert state.getProperty(Platform.MANAGEMENT_SERVER_FINGERPRINT_VERSION_PROPERTY) != null
 
             String persistedId = Platform.loadOrCreateManagementServerId(
                     propertiesFile,
                     stateFile,
-                    { -> NEW_MANAGEMENT_SERVER_ID } as Supplier<String>)
+                    { -> NEW_MANAGEMENT_SERVER_ID } as Supplier<String>,
+                    { -> MANAGEMENT_SERVER_FINGERPRINT } as Supplier<String>)
             assert persistedId == MANAGEMENT_SERVER_ID
+
+            stateFile.text = "${Platform.MANAGEMENT_SERVER_ID_PROPERTY}=${MANAGEMENT_SERVER_ID}\n"
+            String upgradedId = Platform.loadOrCreateManagementServerId(
+                    propertiesFile,
+                    stateFile,
+                    { -> NEW_MANAGEMENT_SERVER_ID } as Supplier<String>,
+                    { -> MANAGEMENT_SERVER_FINGERPRINT } as Supplier<String>)
+            assert upgradedId == MANAGEMENT_SERVER_ID
+            state = new Properties()
+            stateFile.withInputStream { state.load(it) }
+            assert state.getProperty(Platform.MANAGEMENT_SERVER_FINGERPRINT_PROPERTY) == MANAGEMENT_SERVER_FINGERPRINT
+
+            String regeneratedId = Platform.loadOrCreateManagementServerId(
+                    propertiesFile,
+                    stateFile,
+                    { -> NEW_MANAGEMENT_SERVER_ID } as Supplier<String>,
+                    { -> NEW_MANAGEMENT_SERVER_FINGERPRINT } as Supplier<String>)
+            assert regeneratedId == NEW_MANAGEMENT_SERVER_ID
+            state = new Properties()
+            stateFile.withInputStream { state.load(it) }
+            assert state.getProperty(Platform.MANAGEMENT_SERVER_ID_PROPERTY) == NEW_MANAGEMENT_SERVER_ID
+            assert state.getProperty(Platform.MANAGEMENT_SERVER_FINGERPRINT_PROPERTY) == NEW_MANAGEMENT_SERVER_FINGERPRINT
+
+            stateFile.text = "${Platform.MANAGEMENT_SERVER_ID_PROPERTY}=${MANAGEMENT_SERVER_ID}\n"
+            String legacyIdWithoutFingerprint = Platform.loadOrCreateManagementServerId(
+                    propertiesFile,
+                    stateFile,
+                    { -> NEW_MANAGEMENT_SERVER_ID } as Supplier<String>,
+                    { -> null } as Supplier<String>)
+            assert legacyIdWithoutFingerprint == MANAGEMENT_SERVER_ID
+            state = new Properties()
+            stateFile.withInputStream { state.load(it) }
+            assert state.getProperty(Platform.MANAGEMENT_SERVER_FINGERPRINT_PROPERTY) == null
 
             propertiesFile.text = "${Platform.MANAGEMENT_SERVER_ID_PROPERTY}=${NEW_MANAGEMENT_SERVER_ID}\n"
             String configuredId = Platform.loadOrCreateManagementServerId(
                     propertiesFile,
                     stateFile,
-                    { -> MANAGEMENT_SERVER_ID } as Supplier<String>)
+                    { -> MANAGEMENT_SERVER_ID } as Supplier<String>,
+                    { -> MANAGEMENT_SERVER_FINGERPRINT } as Supplier<String>)
             assert configuredId == NEW_MANAGEMENT_SERVER_ID
         } finally {
             propertiesFile.delete()


### PR DESCRIPTION
## Summary
Fix ZSTAC-86059 by keeping managementServerId as a random persisted MN id and binding the state file to a local machine fingerprint.

## Changes
- Store managementServerFingerprint and version next to managementServerId.
- Reuse the id when fingerprint is stable, legacy, or unavailable.
- Regenerate the id when a fingerprinted state file is copied to another host.
- Fail fast when an active ManagementNodeVO row already owns the same id from another host.
- Extend ManagementNetworkIpv6Case coverage for fingerprint reuse, upgrade, mismatch, and fallback.

## Testing
- [x] mvn -pl core,portal -am -DskipTests compile
- [x] mvn -f test/pom.xml -DskipTests test-compile
- [x] git diff --check
- [x] Remote Codex review: No findings

Resolves: ZSTAC-86059

sync from gitlab !10233