### PR TITLE
ZSTAC-86015 cherry-pick security group port range fix to 4.8.38

### DIFF
--- a/conf/db/upgrade/V4.8.38__schema.sql
+++ b/conf/db/upgrade/V4.8.38__schema.sql
@@ -13,3 +13,6 @@ WHERE sp.primaryStorageUuid = ps.uuid
 DELETE FROM `SystemTagVO`
 WHERE `resourceUuid` IN (SELECT uuid FROM HostCapacityVO WHERE cpuSockets != 1)
   AND tag LIKE "cpuProcessorNum::%";
+
+ALTER TABLE SecurityGroupRuleVO MODIFY COLUMN `dstPortRange` varchar(1024) DEFAULT NULL;
+ALTER TABLE SecurityGroupRuleVO MODIFY COLUMN `srcPortRange` varchar(1024) DEFAULT NULL;

--- a/plugin/securityGroup/src/main/java/org/zstack/network/securitygroup/SecurityGroupApiInterceptor.java
+++ b/plugin/securityGroup/src/main/java/org/zstack/network/securitygroup/SecurityGroupApiInterceptor.java
@@ -704,7 +704,8 @@ public class SecurityGroupApiInterceptor implements ApiMessageInterceptor, Globa
         }
         String portArray[];
         if (ports.contains(SecurityGroupConstant.IP_SPLIT)) {
-            String[] tmpPorts = ports.split(SecurityGroupConstant.IP_SPLIT);
+            // The port range in iptables, such as 10-20, will occupy the number of two multiports
+            String[] tmpPorts = ports.split(String.format("%s|%s", SecurityGroupConstant.IP_SPLIT, SecurityGroupConstant.RANGE_SPLIT));
             if (tmpPorts.length > SecurityGroupGlobalProperty.PORT_GROUP_NUMBER_LIMIT) {
                 throw new ApiMessageInterceptionException(err(SecurityGroupErrors.RULE_PORT_FIELD_ERROR, "invalid ports[%s], port range[%s] number[%d] is out of max limit[%d]", ports, Arrays.toString(tmpPorts), tmpPorts.length, SecurityGroupGlobalProperty.PORT_GROUP_NUMBER_LIMIT));
             }

--- a/plugin/securityGroup/src/main/java/org/zstack/network/securitygroup/SecurityGroupApiInterceptor.java
+++ b/plugin/securityGroup/src/main/java/org/zstack/network/securitygroup/SecurityGroupApiInterceptor.java
@@ -704,9 +704,9 @@ public class SecurityGroupApiInterceptor implements ApiMessageInterceptor, Globa
         }
         String portArray[];
         if (ports.contains(SecurityGroupConstant.IP_SPLIT)) {
-            String[] tmpPorts = ports.split(String.format("%s|%s", SecurityGroupConstant.IP_SPLIT, SecurityGroupConstant.RANGE_SPLIT));
-            if (tmpPorts.length > SecurityGroupConstant.PORT_GROUP_NUMBER_LIMIT) {
-                throw new ApiMessageInterceptionException(err(SecurityGroupErrors.RULE_PORT_FIELD_ERROR, "invalid ports[%s], port range[%s] number[%d] is out of max limit[%d]", ports, Arrays.toString(tmpPorts), tmpPorts.length, SecurityGroupConstant.PORT_GROUP_NUMBER_LIMIT));
+            String[] tmpPorts = ports.split(SecurityGroupConstant.IP_SPLIT);
+            if (tmpPorts.length > SecurityGroupGlobalProperty.PORT_GROUP_NUMBER_LIMIT) {
+                throw new ApiMessageInterceptionException(err(SecurityGroupErrors.RULE_PORT_FIELD_ERROR, "invalid ports[%s], port range[%s] number[%d] is out of max limit[%d]", ports, Arrays.toString(tmpPorts), tmpPorts.length, SecurityGroupGlobalProperty.PORT_GROUP_NUMBER_LIMIT));
             }
 
             portArray = ports.split(SecurityGroupConstant.IP_SPLIT);
@@ -759,8 +759,8 @@ public class SecurityGroupApiInterceptor implements ApiMessageInterceptor, Globa
         String ipArray[];
         if (ips.contains(SecurityGroupConstant.IP_SPLIT)) {
             ipArray = ips.split(SecurityGroupConstant.IP_SPLIT);
-            if (ipArray.length > SecurityGroupConstant.IP_GROUP_NUMBER_LIMIT) {
-                throw new ApiMessageInterceptionException(err(SecurityGroupErrors.RULE_IP_FIELD_ERROR, "invalid ips[%s], ip number[%d] is out of max limit[%d]", ips, ipArray.length, SecurityGroupConstant.IP_GROUP_NUMBER_LIMIT));
+            if (ipArray.length > SecurityGroupGlobalProperty.IP_GROUP_NUMBER_LIMIT) {
+                throw new ApiMessageInterceptionException(err(SecurityGroupErrors.RULE_IP_FIELD_ERROR, "invalid ips[%s], ip number[%d] is out of max limit[%d]", ips, ipArray.length, SecurityGroupGlobalProperty.IP_GROUP_NUMBER_LIMIT));
             }
             Stream<String> stream = Stream.of(ipArray).distinct();
             if (ipArray.length != stream.count()) {

--- a/plugin/securityGroup/src/main/java/org/zstack/network/securitygroup/SecurityGroupGlobalProperty.java
+++ b/plugin/securityGroup/src/main/java/org/zstack/network/securitygroup/SecurityGroupGlobalProperty.java
@@ -7,4 +7,8 @@ import org.zstack.core.GlobalPropertyDefinition;
 public class SecurityGroupGlobalProperty {
     @GlobalProperty(name="upgradeSecurityGroup", defaultValue = "false")
     public static boolean UPGRADE_SECURITY_GROUP;
+    @GlobalProperty(name="SecurityGroupRuleIpLimit", defaultValue = "10")
+    public static int IP_GROUP_NUMBER_LIMIT;
+    @GlobalProperty(name="SecurityGroupRulePortLimit", defaultValue = "50")
+    public static int PORT_GROUP_NUMBER_LIMIT;
 }

--- a/plugin/securityGroup/src/main/java/org/zstack/network/securitygroup/SecurityGroupGlobalProperty.java
+++ b/plugin/securityGroup/src/main/java/org/zstack/network/securitygroup/SecurityGroupGlobalProperty.java
@@ -9,6 +9,6 @@ public class SecurityGroupGlobalProperty {
     public static boolean UPGRADE_SECURITY_GROUP;
     @GlobalProperty(name="SecurityGroupRuleIpLimit", defaultValue = "50")
     public static int IP_GROUP_NUMBER_LIMIT;
-    @GlobalProperty(name="SecurityGroupRulePortLimit", defaultValue = "50")
+    @GlobalProperty(name="SecurityGroupRulePortLimit", defaultValue = "15")  //The max number of multiport modes in iptables is 15
     public static int PORT_GROUP_NUMBER_LIMIT;
 }

--- a/plugin/securityGroup/src/main/java/org/zstack/network/securitygroup/SecurityGroupGlobalProperty.java
+++ b/plugin/securityGroup/src/main/java/org/zstack/network/securitygroup/SecurityGroupGlobalProperty.java
@@ -7,7 +7,7 @@ import org.zstack.core.GlobalPropertyDefinition;
 public class SecurityGroupGlobalProperty {
     @GlobalProperty(name="upgradeSecurityGroup", defaultValue = "false")
     public static boolean UPGRADE_SECURITY_GROUP;
-    @GlobalProperty(name="SecurityGroupRuleIpLimit", defaultValue = "10")
+    @GlobalProperty(name="SecurityGroupRuleIpLimit", defaultValue = "50")
     public static int IP_GROUP_NUMBER_LIMIT;
     @GlobalProperty(name="SecurityGroupRulePortLimit", defaultValue = "50")
     public static int PORT_GROUP_NUMBER_LIMIT;

--- a/test/src/test/groovy/org/zstack/test/integration/networkservice/provider/flat/securitygroup/AddSecurityGroupRuleOptimizedCase.groovy
+++ b/test/src/test/groovy/org/zstack/test/integration/networkservice/provider/flat/securitygroup/AddSecurityGroupRuleOptimizedCase.groovy
@@ -172,7 +172,8 @@ class AddSecurityGroupRuleOptimizedCase extends SubCase {
         errorRule.protocol = "TCP"
         errorRule.startPort = null
         errorRule.endPort = null
-        errorRule.dstPortRange = "1,2,3,4,5,6-7,8-10,11-12"
+        // The current security group allows a maximum of 50 ports (ver:5.4.0)
+        errorRule.dstPortRange = "1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51"
         expect(AssertionError) {
             addSecurityGroupRule {
                 securityGroupUuid = sg1.uuid

--- a/test/src/test/groovy/org/zstack/test/integration/networkservice/provider/flat/securitygroup/AddSecurityGroupRuleOptimizedCase.groovy
+++ b/test/src/test/groovy/org/zstack/test/integration/networkservice/provider/flat/securitygroup/AddSecurityGroupRuleOptimizedCase.groovy
@@ -173,7 +173,7 @@ class AddSecurityGroupRuleOptimizedCase extends SubCase {
         errorRule.startPort = null
         errorRule.endPort = null
         // The current security group allows a maximum of 50 ports (ver:5.4.0)
-        errorRule.dstPortRange = "1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51"
+        errorRule.dstPortRange = "1,2,3,4,5,6,7,8,9,10,11,12,13,14-16,17"
         expect(AssertionError) {
             addSecurityGroupRule {
                 securityGroupUuid = sg1.uuid


### PR DESCRIPTION
Cherry-pick ZSTAC-76328 dependency chain to 4.8.38 for ZSTAC-86015. Includes source commits 2a1907075c6a, d80857d0c217, 7c4c584c97f5. Schema change adapted from V5.4.0__schema.sql to V4.8.38__schema.sql. Local verification: git diff --check passed; conflict marker check passed. Maven compile/test not run because mvn is not installed in local PATH.

sync from gitlab !10238