### PR TITLE
<fix>[conf]: clean stale cpu processor tag on 4.8.38

### DIFF
--- a/conf/db/upgrade/V4.8.38__schema.sql
+++ b/conf/db/upgrade/V4.8.38__schema.sql
@@ -9,3 +9,7 @@ WHERE sp.primaryStorageUuid = ps.uuid
   AND ps.type = 'SharedBlock'
   AND sp.volumeType = 'Memory'
   AND sp.primaryStorageInstallPath LIKE '/dev/%';
+
+DELETE FROM `SystemTagVO`
+WHERE `resourceUuid` IN (SELECT uuid FROM HostCapacityVO WHERE cpuSockets != 1)
+  AND tag LIKE "cpuProcessorNum::%";


### PR DESCRIPTION
## Summary
- Backport the DB cleanup part of ZSTAC-64602 for the 4.8.38 clone ZSTAC-69803.
- 4.8.38 already contains the kvmagent cpuProcessorNum calculation fix in zstack-utility; this adds the missing one-time cleanup for stale host system tags.

## Root Cause
- Existing upgraded environments with multiple CPU sockets can retain old `cpuProcessorNum::*` system tags generated before the corrected kvmagent calculation.

## Change
- Add a V4.8.38 schema cleanup deleting `cpuProcessorNum::*` system tags for hosts whose `HostCapacityVO.cpuSockets != 1`.
- The tag is regenerated on reconnect/facts collection from corrected kvmagent data.

## Verification
- `git diff --check upstream/4.8.38...HEAD`: passed.

## Risk
- Narrow DB cleanup. The DELETE only targets host CPU processor system tags for multi-socket hosts.
- Live upgrade DB migration not exercised locally.

Resolves: ZSTAC-69803
Related: ZSTAC-64602
Source MR: http://dev.zstack.io:9080/zstackio/zstack/-/merge_requests/6059

sync from gitlab !10241