### PR TITLE
<fix>[utils]: parse ipv6 system tag tokens

### DIFF
--- a/utils/src/main/java/org/zstack/utils/TagUtils.java
+++ b/utils/src/main/java/org/zstack/utils/TagUtils.java
@@ -8,14 +8,20 @@ import java.util.*;
 /**
  */
 public class TagUtils {
+    private static final String TAG_DELIMITER = "::";
+    private static final char TOKEN_START = '{';
+    private static final char TOKEN_END = '}';
+
     public static Map<String, String> parse(String fmt, String tag) {
-        List<String> origins =  new ArrayList<String>();
-        Collections.addAll(origins, tag.split("::"));
-
         List<String> t = new ArrayList<String>();
-        Collections.addAll(t, fmt.split("::"));
+        t.addAll(splitTagFields(fmt));
 
+        List<String> origins = splitTagFieldsByFormat(t, tag);
         Map<String, String> ret = new HashMap();
+        if (origins == null) {
+            return ret;
+        }
+
         for (int i=0;i<t.size(); i++) {
             String key = t.get(i);
             if (!key.startsWith("{") || !key.endsWith("}")) {
@@ -37,17 +43,15 @@ public class TagUtils {
             return false;
         }
 
-        List<String> origins =  new ArrayList<String>();
-        Collections.addAll(origins, tag.split("::"));
-
         List<String> t = new ArrayList<String>();
-        Collections.addAll(t, fmt.split("::"));
+        t.addAll(splitTagFields(fmt));
 
-        if (fmt.indexOf("::") == -1) {
+        if (fmt.indexOf(TAG_DELIMITER) == -1) {
             return fmt.equals(tag);
         }
 
-        if (origins.size() != t.size()) {
+        List<String> origins = splitTagFieldsByFormat(t, tag);
+        if (origins == null || origins.size() != t.size()) {
             return false;
         }
 
@@ -64,6 +68,99 @@ public class TagUtils {
         }
 
         return true;
+    }
+
+    private static List<String> splitTagFieldsByFormat(List<String> fmtFields, String tag) {
+        List<String> fields = new ArrayList<>();
+        int offset = 0;
+
+        for (int i = 0; i < fmtFields.size(); i++) {
+            String fmtField = fmtFields.get(i);
+            boolean lastField = i == fmtFields.size() - 1;
+            if (isTokenField(fmtField)) {
+                if (lastField) {
+                    fields.add(tag.substring(offset));
+                    offset = tag.length();
+                    continue;
+                }
+
+                int end = indexOfDelimiterOutsideToken(tag, offset);
+                if (end < 0) {
+                    return null;
+                }
+                fields.add(tag.substring(offset, end));
+                offset = end + TAG_DELIMITER.length();
+                continue;
+            }
+
+            if (!tag.startsWith(fmtField, offset)) {
+                return null;
+            }
+
+            fields.add(fmtField);
+            offset += fmtField.length();
+            if (!lastField) {
+                if (!tag.startsWith(TAG_DELIMITER, offset)) {
+                    return null;
+                }
+                offset += TAG_DELIMITER.length();
+            }
+        }
+
+        return offset == tag.length() ? fields : null;
+    }
+
+    private static boolean isTokenField(String field) {
+        return field.startsWith(String.valueOf(TOKEN_START)) && field.endsWith(String.valueOf(TOKEN_END));
+    }
+
+    private static List<String> splitTagFields(String tag) {
+        List<String> fields = new ArrayList<>();
+        StringBuilder field = new StringBuilder();
+        int braceDepth = 0;
+
+        for (int i = 0; i < tag.length(); i++) {
+            char current = tag.charAt(i);
+            if (current == TOKEN_START) {
+                braceDepth++;
+            } else if (current == TOKEN_END && braceDepth > 0) {
+                braceDepth--;
+            }
+
+            if (braceDepth == 0 && tag.startsWith(TAG_DELIMITER, i)) {
+                fields.add(field.toString());
+                field.setLength(0);
+                i += TAG_DELIMITER.length() - 1;
+                continue;
+            }
+
+            field.append(current);
+        }
+
+        fields.add(field.toString());
+        while (!fields.isEmpty() && fields.get(fields.size() - 1).isEmpty()) {
+            fields.remove(fields.size() - 1);
+        }
+
+        return fields;
+    }
+
+    private static int indexOfDelimiterOutsideToken(String tag, int offset) {
+        int braceDepth = 0;
+        for (int i = offset; i < tag.length(); i++) {
+            char current = tag.charAt(i);
+            if (current == TOKEN_START) {
+                braceDepth++;
+            } else if (current == TOKEN_END && braceDepth > 0) {
+                braceDepth--;
+            }
+
+            if (braceDepth == 0 && tag.startsWith(TAG_DELIMITER, i)) {
+                return i;
+            }
+        }
+
+        return -1;
     }
 
     public static Map<String, String> parseIfMatch(String fmt, String tag) {

--- a/utils/src/test/java/org/zstack/utils/test/TestTagUtils.java
+++ b/utils/src/test/java/org/zstack/utils/test/TestTagUtils.java
@@ -1,0 +1,30 @@
+package org.zstack.utils.test;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.zstack.utils.TagUtils;
+
+import java.util.Map;
+
+public class TestTagUtils {
+    @Test
+    public void testIpv6CidrTokenAtEnd() {
+        String format = "conversion::network::cidr::{conversionNetwork}";
+        String tag = "conversion::network::cidr::fd66:6:6:6::/64";
+
+        Assert.assertTrue(TagUtils.isMatch(format, tag));
+        Map<String, String> tokens = TagUtils.parseIfMatch(format, tag);
+        Assert.assertEquals("fd66:6:6:6::/64", tokens.get("conversionNetwork"));
+    }
+
+    @Test
+    public void testBracedIpv6TokenBeforeStaticField() {
+        String format = "resource::{cidr}::state::{state}";
+        String tag = "resource::{fd66:6:6:6::/64}::state::enabled";
+
+        Assert.assertTrue(TagUtils.isMatch(format, tag));
+        Map<String, String> tokens = TagUtils.parseIfMatch(format, tag);
+        Assert.assertEquals("{fd66:6:6:6::/64}", tokens.get("cidr"));
+        Assert.assertEquals("enabled", tokens.get("state"));
+    }
+}


### PR DESCRIPTION
Patterned system tags used to split format and tag by ::.
IPv6 CIDR tokens like fd66:6:6:6::/64 were split into extra fields,
so TagManager rejected valid V2V conversion network tags.

Resolves: ZSTAC-85618
Related: ZCF-4134

Test: mvn -pl utils -Dtest=TestTagUtils test

Change-Id: I52c6f8f8b3e3473392f55d4d7a497d7b51c87171

sync from gitlab !10243