### PR TITLE
fix(ZSTAC-86045): add ip version error codes

### DIFF
--- a/plugin/kvm/src/main/java/org/zstack/kvm/KVMHost.java
+++ b/plugin/kvm/src/main/java/org/zstack/kvm/KVMHost.java
@@ -98,6 +98,7 @@ import org.zstack.utils.data.SizeUnit;
 import org.zstack.utils.gson.JSONObjectUtil;
 import org.zstack.utils.logging.CLogger;
 import org.zstack.utils.message.OperationChecker;
+import org.zstack.utils.network.IPv6NetworkUtils;
 import org.zstack.utils.network.NetworkUtils;
 import org.zstack.utils.path.PathUtil;
 import org.zstack.utils.ssh.Ssh;
@@ -108,6 +109,8 @@ import org.zstack.utils.tester.ZTester;
 
 import javax.persistence.TypedQuery;
 import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -2727,15 +2730,36 @@ public class KVMHost extends HostBase implements Host {
     }
 
     public static String buildAgentUrl(String host, String path) {
-        UriComponentsBuilder ub = UriComponentsBuilder.newInstance();
-        ub.scheme(KVMGlobalProperty.AGENT_URL_SCHEME);
-        ub.host(KVMHostUtils.formatHostForUrl(host));
-        ub.port(KVMGlobalProperty.AGENT_PORT);
-        if (!"".equals(KVMGlobalProperty.AGENT_URL_ROOT_PATH)) {
-            ub.path(KVMGlobalProperty.AGENT_URL_ROOT_PATH);
+        try {
+            return new URI(
+                    KVMGlobalProperty.AGENT_URL_SCHEME,
+                    null,
+                    IPv6NetworkUtils.stripHostUrlBrackets(host),
+                    KVMGlobalProperty.AGENT_PORT,
+                    joinAgentPath(KVMGlobalProperty.AGENT_URL_ROOT_PATH, path),
+                    null,
+                    null).toString();
+        } catch (URISyntaxException e) {
+            throw new CloudRuntimeException(String.format("failed to build KVM agent url for host[%s], path[%s]", host, path), e);
         }
-        ub.path(path);
-        return ub.build().toUriString();
+    }
+
+    private static String joinAgentPath(String rootPath, String path) {
+        if (rootPath == null || rootPath.isEmpty()) {
+            return path;
+        }
+        if (path == null || path.isEmpty()) {
+            return rootPath.startsWith("/") ? rootPath : "/" + rootPath;
+        }
+
+        String normalizedRootPath = rootPath.startsWith("/") ? rootPath : "/" + rootPath;
+        if (normalizedRootPath.endsWith("/") && path.startsWith("/")) {
+            return normalizedRootPath + path.substring(1);
+        }
+        if (!normalizedRootPath.endsWith("/") && !path.startsWith("/")) {
+            return normalizedRootPath + "/" + path;
+        }
+        return normalizedRootPath + path;
     }
 
     private String buildUrl(String path) {

--- a/test/src/test/groovy/org/zstack/test/integration/core/ManagementNetworkIpv6Case.groovy
+++ b/test/src/test/groovy/org/zstack/test/integration/core/ManagementNetworkIpv6Case.groovy
@@ -199,6 +199,8 @@ class ManagementNetworkIpv6Case extends SubCase {
                 "http://[2001:db8::1]:${KVMGlobalProperty.AGENT_PORT}/vm/migrate"
         assert KVMHost.buildAgentUrl(IPV6, KVMConstant.CLEAN_FIRMWARE_FLASH) ==
                 "http://[2001:db8::1]:${KVMGlobalProperty.AGENT_PORT}/clean/firmware/flash"
+        assert KVMHost.buildAgentUrl(IPV6, "/storagedevice/iscsi/login") ==
+                "http://[2001:db8::1]:${KVMGlobalProperty.AGENT_PORT}/storagedevice/iscsi/login"
         assert KVMHost.buildAgentUrl(IPV4, KVMConstant.KVM_MIGRATE_VM_PATH) ==
                 "http://192.168.1.10:${KVMGlobalProperty.AGENT_PORT}/vm/migrate"
     }

--- a/utils/src/main/java/org/zstack/utils/clouderrorcode/CloudOperationsErrorCode.java
+++ b/utils/src/main/java/org/zstack/utils/clouderrorcode/CloudOperationsErrorCode.java
@@ -3366,6 +3366,8 @@ public class CloudOperationsErrorCode {
 
     public static final String ORG_ZSTACK_STORAGE_DEVICE_10048 = "ORG_ZSTACK_STORAGE_DEVICE_10048";
 
+    public static final String ORG_ZSTACK_STORAGE_DEVICE_10049 = "ORG_ZSTACK_STORAGE_DEVICE_10049";
+
     public static final String ORG_ZSTACK_CORE_GC_10000 = "ORG_ZSTACK_CORE_GC_10000";
 
     public static final String ORG_ZSTACK_CORE_GC_10001 = "ORG_ZSTACK_CORE_GC_10001";
@@ -5535,6 +5537,8 @@ public class CloudOperationsErrorCode {
     public static final String ORG_ZSTACK_BAREMETAL2_GATEWAY_10085 = "ORG_ZSTACK_BAREMETAL2_GATEWAY_10085";
 
     public static final String ORG_ZSTACK_BAREMETAL2_GATEWAY_10086 = "ORG_ZSTACK_BAREMETAL2_GATEWAY_10086";
+
+    public static final String ORG_ZSTACK_BAREMETAL2_GATEWAY_10087 = "ORG_ZSTACK_BAREMETAL2_GATEWAY_10087";
 
     public static final String ORG_ZSTACK_BAREMETAL2_DPU_10000 = "ORG_ZSTACK_BAREMETAL2_DPU_10000";
 


### PR DESCRIPTION
## Summary
Replacement for !10242 with @@2 branch suffix so zstack + premium CI runs as a paired build.

## Changes
- Add ORG_ZSTACK_STORAGE_DEVICE_10049 for iSCSI server / host management IP version mismatch.
- Add ORG_ZSTACK_BAREMETAL2_GATEWAY_10087 for baremetal2 gateway / iSCSI server IP version mismatch.

## Related MR
- premium paired MR: to be filled after creation
- supersedes http://dev.zstack.io:9080/zstackio/zstack/-/merge_requests/10242

## CI failure root cause
Old branches used shixin-ZSTAC-86045 without @@2, so premium !14377 compiled without this zstack error-code change and failed with ORG_ZSTACK_STORAGE_DEVICE_10049 cannot be resolved.

Resolves: ZSTAC-86045

sync from gitlab !10246