### PR TITLE
<fix>[4.8.38]: backport ssh timeout + ceph capacity fix

### DIFF
--- a/longjob/src/main/java/org/zstack/longjob/LongJobUtils.java
+++ b/longjob/src/main/java/org/zstack/longjob/LongJobUtils.java
@@ -112,7 +112,8 @@ public class LongJobUtils {
     }
 
     static LongJobVO updateByUuid(String uuid, Consumer<LongJobVO> consumer) {
-        return new SQLBatchWithReturn<LongJobVO>(){
+        final boolean[] jobCompleted = {false};
+        LongJobVO job = new SQLBatchWithReturn<LongJobVO>(){
 
             @Override
             protected LongJobVO scripts() {
@@ -123,7 +124,7 @@ public class LongJobUtils {
 
                 if (jobCompleted(job)) {
                     setExecuteTimeIfNeed(job);
-                    cleanProgress(job);
+                    jobCompleted[0] = true;
                 }
 
                 if (originState != newState) {
@@ -134,6 +135,10 @@ public class LongJobUtils {
                 return job;
             }
         }.execute();
+        if (jobCompleted[0]) {
+            cleanProgress(job);
+        }
+        return job;
     }
 
     static LongJobVO changeState(String uuid, LongJobStateEvent stateEvent) {

--- a/plugin/ceph/src/main/java/org/zstack/storage/ceph/primary/CephImageCacheCleaner.java
+++ b/plugin/ceph/src/main/java/org/zstack/storage/ceph/primary/CephImageCacheCleaner.java
@@ -7,6 +7,7 @@ import org.zstack.header.storage.primary.ImageCacheShadowVO;
 import org.zstack.header.storage.primary.ImageCacheVO;
 import org.zstack.storage.ceph.CephConstants;
 import org.zstack.storage.ceph.CephGlobalConfig;
+import org.zstack.storage.primary.ImageCacheCleanParam;
 import org.zstack.storage.primary.ImageCacheCleaner;
 import org.zstack.utils.Utils;
 import org.zstack.utils.logging.CLogger;
@@ -32,8 +33,8 @@ public class CephImageCacheCleaner extends ImageCacheCleaner implements Manageme
 
     @Transactional
     @Override
-    protected List<ImageCacheShadowVO> createShadowImageCacheVOsForNewDeletedAndOld(String psUuid) {
-        List<Long> staleImageCacheIds = getStaleImageCacheIds(psUuid);
+    protected List<ImageCacheShadowVO> createShadowImageCacheVOsForNewDeletedAndOld(String psUuid, ImageCacheCleanParam param) {
+        List<Long> staleImageCacheIds = getStaleImageCacheIds(psUuid, false);
         if (staleImageCacheIds == null || staleImageCacheIds.isEmpty()) {
             return null;
         }

--- a/plugin/ceph/src/main/java/org/zstack/storage/ceph/primary/CephPrimaryStorageBase.java
+++ b/plugin/ceph/src/main/java/org/zstack/storage/ceph/primary/CephPrimaryStorageBase.java
@@ -2105,7 +2105,7 @@ public class CephPrimaryStorageBase extends PrimaryStorageBase {
     @Override
     protected void handle(APICleanUpImageCacheOnPrimaryStorageMsg msg) {
         APICleanUpImageCacheOnPrimaryStorageEvent evt = new APICleanUpImageCacheOnPrimaryStorageEvent(msg.getId());
-        imageCacheCleaner.cleanup(msg.getUuid(), false);
+        imageCacheCleaner.cleanup(msg.getUuid(), new ImageCacheCleanParam(true, msg.isForce()));
         bus.publish(evt);
     }
 

--- a/plugin/ceph/src/main/java/org/zstack/storage/ceph/primary/capacity/CephOsdGroupCapacityHelper.java
+++ b/plugin/ceph/src/main/java/org/zstack/storage/ceph/primary/capacity/CephOsdGroupCapacityHelper.java
@@ -1,6 +1,7 @@
 package org.zstack.storage.ceph.primary.capacity;
 
 import org.apache.commons.collections.CollectionUtils;
+import org.apache.logging.log4j.util.Strings;
 import org.springframework.beans.factory.annotation.Autowire;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Configurable;
@@ -238,7 +239,7 @@ public class CephOsdGroupCapacityHelper {
         for (String poolName : poolNames) {
             String installPathPrefix = String.format("ceph://%s", poolName);
             long volSize = volumes.parallelStream()
-                    .filter(v -> v.getInstallPath() != null && v.getInstallPath()
+                    .filter(v -> Strings.isNotEmpty(v.getInstallPath()) && v.getInstallPath()
                             .substring(0, v.getInstallPath().lastIndexOf("/"))
                             .equals((installPathPrefix)))
                     .map(VolumeVO::getSize)
@@ -246,7 +247,7 @@ public class CephOsdGroupCapacityHelper {
                     .reduce(0L, Long::sum);
 
             long imageCacheSize = imageCaches.parallelStream()
-                    .filter(v -> v.getInstallUrl() != null && v.getInstallUrl()
+                    .filter(v -> Strings.isNotEmpty(v.getInstallUrl()) && v.getInstallUrl()
                             .substring(0, v.getInstallUrl().lastIndexOf("/"))
                             .equals((installPathPrefix)))
                     .map(ImageCacheVO::getSize)
@@ -254,7 +255,7 @@ public class CephOsdGroupCapacityHelper {
                     .reduce(0L, Long::sum);
 
             long snapShotSize = snapshots.parallelStream()
-                    .filter(v -> v.getPrimaryStorageInstallPath() != null && v.getPrimaryStorageInstallPath()
+                    .filter(v -> Strings.isNotEmpty(v.getPrimaryStorageInstallPath()) && v.getPrimaryStorageInstallPath()
                             .substring(0, v.getPrimaryStorageInstallPath().lastIndexOf("/"))
                             .equals((installPathPrefix)))
                     .map(VolumeSnapshotVO::getSize)

--- a/plugin/kvm/src/main/java/org/zstack/kvm/KVMHost.java
+++ b/plugin/kvm/src/main/java/org/zstack/kvm/KVMHost.java
@@ -5378,7 +5378,7 @@ public class KVMHost extends HostBase implements Host {
                 sshShell.setPassword(getSelf().getPassword());
                 sshShell.setPort(getSelf().getPort());
                 sshShell.setWithSudo(false);
-                final String cmd = String.format("curl --connect-timeout 10 %s|| wget --spider -q --connect-timeout=10 %s|| test $? -eq 8", restf.getCallbackUrl(), restf.getCallbackUrl());
+                final String cmd = String.format("curl --connect-timeout 10 --max-time 15 %s|| wget --spider -q --connect-timeout=10 --read-timeout=10 --tries=1 %s|| test $? -eq 8", restf.getCallbackUrl(), restf.getCallbackUrl());
                 SshResult ret = sshShell.runCommand(cmd);
                 if (ret.getStderr() != null && ret.getStderr().contains("No route to host")) {
                     // c.f. https://access.redhat.com/solutions/1120533

--- a/plugin/localstorage/src/main/java/org/zstack/storage/primary/local/LocalStorageBase.java
+++ b/plugin/localstorage/src/main/java/org/zstack/storage/primary/local/LocalStorageBase.java
@@ -908,10 +908,9 @@ public class LocalStorageBase extends PrimaryStorageBase {
 
     @Override
     protected void handle(APICleanUpImageCacheOnPrimaryStorageMsg msg) {
-            APICleanUpImageCacheOnPrimaryStorageEvent evt = new APICleanUpImageCacheOnPrimaryStorageEvent(msg.getId());
-            imageCacheCleaner.setForce(msg.isForce());
-            imageCacheCleaner.cleanup(msg.getUuid(), false);
-            bus.publish(evt);
+        APICleanUpImageCacheOnPrimaryStorageEvent evt = new APICleanUpImageCacheOnPrimaryStorageEvent(msg.getId());
+        imageCacheCleaner.cleanup(msg.getUuid(), new ImageCacheCleanParam(true, msg.isForce()));
+        bus.publish(evt);
     }
 
 

--- a/plugin/localstorage/src/main/java/org/zstack/storage/primary/local/LocalStorageImageCleaner.java
+++ b/plugin/localstorage/src/main/java/org/zstack/storage/primary/local/LocalStorageImageCleaner.java
@@ -26,6 +26,7 @@ import org.zstack.header.storage.backup.BackupStoragePrimaryStorageExtensionPoin
 import org.zstack.header.storage.primary.*;
 import org.zstack.header.volume.VolumeStatus;
 import org.zstack.header.volume.VolumeVO;
+import org.zstack.storage.primary.ImageCacheCleanParam;
 import org.zstack.storage.primary.ImageCacheCleaner;
 import org.zstack.storage.primary.local.LocalStorageUtils.InstallPath;
 import org.zstack.utils.CollectionUtils;
@@ -56,38 +57,13 @@ public class LocalStorageImageCleaner extends ImageCacheCleaner implements Manag
         return LocalStorageConstants.LOCAL_STORAGE_TYPE;
     }
 
-    private boolean force;
-
-    public boolean isForce() {
-        return force;
-    }
-
-    public void setForce(boolean force) {
-        this.force = force;
-    }
-
     @Transactional
-    protected List<ImageCacheShadowVO> createShadowImageCacheVOsForNewDeletedAndOld(String psUUid) {
+    protected List<ImageCacheShadowVO> createShadowImageCacheVOsForNewDeletedAndOld(String psUUid, ImageCacheCleanParam param) {
         // 1. images has been deleted
         List<Long> staleImageCacheIds = new ArrayList<>();
-        List<Long> imageDeletedCacheIds = getStaleImageCacheIds(psUUid);
+        List<Long> imageDeletedCacheIds = getStaleImageCacheIds(psUUid, param.includeReadyImage);
         if (!CollectionUtils.isEmpty(imageDeletedCacheIds)) {
             staleImageCacheIds.addAll(imageDeletedCacheIds);
-        }
-
-        if (force){
-            // 2. no vm used but image is not deleted
-            // FIXME: it means nothing. think about host ref.
-            String sql;
-            if (psUUid == null) {
-                sql = "select c.id from ImageCacheVO c, PrimaryStorageVO pri where c.imageUuid not in (select vm.imageUuid from VmInstanceVO vm) and" +
-                        " c.primaryStorageUuid = pri.uuid and pri.type = :psType";
-                staleImageCacheIds.addAll(SQL.New(sql).param("psType", getPrimaryStorageType()).list());
-            } else {
-                sql = "select c.id from ImageCacheVO c, PrimaryStorageVO pri where c.imageUuid not in (select vm.imageUuid from VmInstanceVO vm) and" +
-                        " c.primaryStorageUuid = pri.uuid and pri.type = :psType and pri.uuid = :psUuid";
-                staleImageCacheIds.addAll(SQL.New(sql).param("psType", getPrimaryStorageType()).param("psUuid", psUUid).list());
-            }
         }
 
         if (staleImageCacheIds.isEmpty()) {
@@ -242,19 +218,19 @@ public class LocalStorageImageCleaner extends ImageCacheCleaner implements Manag
     }
 
     @Override
-    protected void cleanUpVolumeCache(String psUuid, boolean needDestinationCheck, NoErrorCompletion completion) {
-        List<ImageCacheShadowVO> shadowVOs = createShadowImageCacheVOs(psUuid);
+    protected void cleanUpVolumeCache(String psUuid, ImageCacheCleanParam param, NoErrorCompletion completion) {
+        List<ImageCacheShadowVO> shadowVOs = createShadowImageCacheVOs(psUuid, param);
         if (shadowVOs == null || shadowVOs.isEmpty()) {
             completion.done();
             return;
         }
 
-        new While<>(shadowVOs).each((vo, whileCompletion) -> {
-            if (needDestinationCheck && !destMaker.isManagedByUs(vo.getImageUuid())) {
-                whileCompletion.done();
-                return;
-            }
 
+        if (!param.triggerByApi) {
+            shadowVOs.removeIf(vo -> !destMaker.isManagedByUs(vo.getImageUuid()));
+        }
+
+        new While<>(shadowVOs).each((vo, whileCompletion) -> {
             InstallPath p = new InstallPath();
             p.fullPath = vo.getInstallUrl();
             p.disassemble();
@@ -295,7 +271,7 @@ public class LocalStorageImageCleaner extends ImageCacheCleaner implements Manag
     }
 
     @Override
-    protected void doCleanup(String psUuid, boolean needDestinationCheck, NoErrorCompletion completion) {
+    protected void doCleanup(String psUuid, ImageCacheCleanParam param, NoErrorCompletion completion) {
         List<String> psUuids = new ArrayList<>();
         if (psUuid == null) {
             psUuids.addAll(listPrimaryStoragesBySelfType());
@@ -308,7 +284,7 @@ public class LocalStorageImageCleaner extends ImageCacheCleaner implements Manag
         chain.then(new NoRollbackFlow() {
             @Override
             public void run(FlowTrigger trigger, Map data) {
-                cleanUpVolumeCache(psUuid, needDestinationCheck, new NoErrorCompletion() {
+                cleanUpVolumeCache(psUuid, param, new NoErrorCompletion() {
                     @Override
                     public void done() {
                         trigger.next();
@@ -379,7 +355,7 @@ public class LocalStorageImageCleaner extends ImageCacheCleaner implements Manag
     }
 
     @Override
-    public void cleanup(String psUuid, boolean needDestinationCheck) {
+    public void cleanup(String psUuid, ImageCacheCleanParam param) {
         ImageCacheCleaner self = this;
         thdf.chainSubmit(new ChainTask(null) {
             @Override
@@ -390,7 +366,7 @@ public class LocalStorageImageCleaner extends ImageCacheCleaner implements Manag
             @Override
             public void run(SyncTaskChain chain) {
                 logger.debug("start clean up cache");
-                doCleanup(psUuid, needDestinationCheck, new NoErrorCompletion() {
+                doCleanup(psUuid, param, new NoErrorCompletion() {
                     @Override
                     public void done() {
                         chain.next();

--- a/plugin/nfsPrimaryStorage/src/main/java/org/zstack/storage/primary/nfs/NfsPrimaryStorage.java
+++ b/plugin/nfsPrimaryStorage/src/main/java/org/zstack/storage/primary/nfs/NfsPrimaryStorage.java
@@ -293,7 +293,7 @@ public class NfsPrimaryStorage extends PrimaryStorageBase {
     @Override
     protected void handle(APICleanUpImageCacheOnPrimaryStorageMsg msg) {
         APICleanUpImageCacheOnPrimaryStorageEvent evt = new APICleanUpImageCacheOnPrimaryStorageEvent(msg.getId());
-        imageCacheCleaner.cleanup(msg.getUuid(), false);
+        imageCacheCleaner.cleanup(msg.getUuid(), new ImageCacheCleanParam(true, msg.isForce()));
         bus.publish(evt);
     }
 

--- a/plugin/sharedMountPointPrimaryStorage/src/main/java/org/zstack/storage/primary/smp/SMPPrimaryStorageBase.java
+++ b/plugin/sharedMountPointPrimaryStorage/src/main/java/org/zstack/storage/primary/smp/SMPPrimaryStorageBase.java
@@ -38,10 +38,7 @@ import org.zstack.kvm.KVMAgentCommands;
 import org.zstack.kvm.KVMConstant;
 import org.zstack.kvm.KVMHostInventory;
 import org.zstack.kvm.KVMTakeSnapshotExtensionPoint;
-import org.zstack.storage.primary.EstimateVolumeTemplateSizeOnPrimaryStorageMsg;
-import org.zstack.storage.primary.EstimateVolumeTemplateSizeOnPrimaryStorageReply;
-import org.zstack.storage.primary.PrimaryStorageBase;
-import org.zstack.storage.primary.PrimaryStorageCapacityUpdater;
+import org.zstack.storage.primary.*;
 import org.zstack.storage.snapshot.reference.VolumeSnapshotReferenceUtils;
 import org.zstack.storage.volume.VolumeErrors;
 import org.zstack.storage.volume.VolumeSystemTags;
@@ -809,7 +806,7 @@ public class SMPPrimaryStorageBase extends PrimaryStorageBase implements KVMTake
     @Override
     protected void handle(APICleanUpImageCacheOnPrimaryStorageMsg msg) {
         APICleanUpImageCacheOnPrimaryStorageEvent evt = new APICleanUpImageCacheOnPrimaryStorageEvent(msg.getId());
-        imageCacheCleaner.cleanup(msg.getUuid(), false);
+        imageCacheCleaner.cleanup(msg.getUuid(), new ImageCacheCleanParam(true, msg.isForce()));
         bus.publish(evt);
     }
 

--- a/storage/src/main/java/org/zstack/storage/primary/ImageCacheCleanParam.java
+++ b/storage/src/main/java/org/zstack/storage/primary/ImageCacheCleanParam.java
@@ -1,0 +1,15 @@
+package org.zstack.storage.primary;
+
+public class ImageCacheCleanParam {
+    public boolean triggerByApi;
+    public boolean includeReadyImage;
+
+    public ImageCacheCleanParam() {
+
+    }
+
+    public ImageCacheCleanParam(boolean triggerByApi, boolean includeReadyImage) {
+        this.triggerByApi = triggerByApi;
+        this.includeReadyImage = includeReadyImage;
+    }
+}

--- a/storage/src/main/java/org/zstack/storage/primary/ImageCacheCleaner.java
+++ b/storage/src/main/java/org/zstack/storage/primary/ImageCacheCleaner.java
@@ -80,11 +80,7 @@ public abstract class ImageCacheCleaner {
         return PrimaryStorageGlobalConfig.IMAGE_CACHE_GARBAGE_COLLECTOR_INTERVAL;
     }
 
-    public void cleanup(boolean needDestinationCheck) {
-        cleanup(null, needDestinationCheck);
-    }
-
-    public void cleanup(String psUuid, boolean needDestinationCheck) {
+    public void cleanup(String psUuid, ImageCacheCleanParam param) {
         ImageCacheCleaner self = this;
         thdf.chainSubmit(new ChainTask(null) {
             @Override
@@ -94,7 +90,7 @@ public abstract class ImageCacheCleaner {
 
             @Override
             public void run(SyncTaskChain chain) {
-                doCleanup(psUuid, needDestinationCheck, new NoErrorCompletion() {
+                doCleanup(psUuid, param, new NoErrorCompletion() {
                     @Override
                     public void done() {
                         chain.next();
@@ -109,19 +105,18 @@ public abstract class ImageCacheCleaner {
         });
     }
 
-    protected void cleanUpVolumeCache(String psUuid, boolean needDestinationCheck, NoErrorCompletion completion) {
-        List<ImageCacheShadowVO> shadowVOs = createShadowImageCacheVOs(psUuid);
+    protected void cleanUpVolumeCache(String psUuid, ImageCacheCleanParam param, NoErrorCompletion completion) {
+        List<ImageCacheShadowVO> shadowVOs = createShadowImageCacheVOs(psUuid, param);
         if (shadowVOs == null || shadowVOs.isEmpty()) {
             completion.done();
             return;
         }
 
-        new While<>(shadowVOs).each((vo, whileCompletion) -> {
-            if (needDestinationCheck && !destMaker.isManagedByUs(vo.getImageUuid())) {
-                whileCompletion.done();
-                return;
-            }
+        if (!param.triggerByApi) {
+            shadowVOs.removeIf(vo -> !destMaker.isManagedByUs(vo.getImageUuid()));
+        }
 
+        new While<>(shadowVOs).each((vo, whileCompletion) -> {
             DeleteImageCacheOnPrimaryStorageMsg msg = new DeleteImageCacheOnPrimaryStorageMsg();
             msg.setImageUuid(vo.getImageUuid());
             msg.setInstallPath(vo.getInstallUrl());
@@ -175,7 +170,7 @@ public abstract class ImageCacheCleaner {
         });
     }
 
-    protected void doCleanup(String psUuid, boolean needDestinationCheck, NoErrorCompletion completion) {
+    protected void doCleanup(String psUuid, ImageCacheCleanParam param, NoErrorCompletion completion) {
         List<String> psUuids = new ArrayList<>();
         if (psUuid == null) {
             psUuids.addAll(listPrimaryStoragesBySelfType());
@@ -188,7 +183,7 @@ public abstract class ImageCacheCleaner {
         chain.then(new NoRollbackFlow() {
             @Override
             public void run(FlowTrigger trigger, Map data) {
-                cleanUpVolumeCache(psUuid, needDestinationCheck, new NoErrorCompletion() {
+                cleanUpVolumeCache(psUuid, param, new NoErrorCompletion() {
                     @Override
                     public void done() {
                         trigger.next();
@@ -283,7 +278,7 @@ public abstract class ImageCacheCleaner {
 
             @Override
             public void run() {
-                cleanup(true);
+                cleanup(null, new ImageCacheCleanParam(false, false));
             }
         });
     }
@@ -324,14 +319,43 @@ public abstract class ImageCacheCleaner {
      * @return image cache ids whose image is expunged
      */
     @Transactional
-    protected List<Long> getStaleImageCacheIds(String psUuid) {
+    protected List<Long> getStaleImageCacheIds(String psUuid, boolean includeReadyImage) {
         if (volumeFindMissingImageUuid(psUuid)) {
             return null;
         }
 
+        List<Long> ids;
+        if (includeReadyImage) {
+            ids = queryCacheOfAllImage(psUuid);
+        } else {
+            ids = queryCacheOfExpungedImage(psUuid);
+        }
+
+        return VolumeSnapshotReferenceUtils.filterStaleImageCache(ids);
+    }
+
+    private List<Long> queryCacheOfAllImage(String psUuid) {
+        if (psUuid == null) {
+            String sql = "select c.id from ImageCacheVO c, PrimaryStorageVO pri" +
+                    " where c.primaryStorageUuid = pri.uuid" +
+                    " and pri.type = :ptype";
+            return SQL.New(sql, Long.class)
+                    .param("ptype", getPrimaryStorageType())
+                    .list();
+        } else {
+            return Q.New(ImageCacheVO.class).eq(ImageCacheVO_.primaryStorageUuid, psUuid)
+                    .select(ImageCacheVO_.id).listValues();
+        }
+    }
+
+    private List<Long> queryCacheOfExpungedImage(String psUuid) {
         String sql;
         if (psUuid == null) {
-            sql = "select c.id from ImageCacheVO c, PrimaryStorageVO pri, ImageEO i where c.primaryStorageUuid = pri.uuid and i.uuid = c.imageUuid and i.deleted is not null and pri.type = :ptype";
+            sql = "select c.id from ImageCacheVO c, PrimaryStorageVO pri, ImageEO i" +
+                    " where c.primaryStorageUuid = pri.uuid" +
+                    " and i.uuid = c.imageUuid" +
+                    " and i.deleted is not null" +
+                    " and pri.type = :ptype";
         } else  {
             sql = "select c.id from ImageCacheVO c, PrimaryStorageVO pri, ImageEO i where c.primaryStorageUuid = pri.uuid and i.uuid = c.imageUuid and i.deleted is not null and pri.type = :ptype and pri.uuid = :psUuid";
         }
@@ -357,19 +381,14 @@ public abstract class ImageCacheCleaner {
             cq.setParameter("psUuid", psUuid);
         }
         deleted.addAll(cq.getResultList());
-
-        if (deleted.isEmpty()) {
-            return null;
-        }
-
-        return VolumeSnapshotReferenceUtils.filterStaleImageCache(deleted);
+        return deleted;
     }
 
 
     @Transactional
-    protected List<ImageCacheShadowVO> createShadowImageCacheVOsForNewDeletedAndOld(String psUuid) {
+    protected List<ImageCacheShadowVO> createShadowImageCacheVOsForNewDeletedAndOld(String psUuid, ImageCacheCleanParam param) {
         // 1. image has been deleted
-        List<Long> staleImageCacheIds = getStaleImageCacheIds(psUuid);
+        List<Long> staleImageCacheIds = getStaleImageCacheIds(psUuid, false);
         if (staleImageCacheIds == null || staleImageCacheIds.isEmpty()) {
             return null;
         }
@@ -409,8 +428,8 @@ public abstract class ImageCacheCleaner {
     }
 
     @Transactional
-    protected List<ImageCacheShadowVO> createShadowImageCacheVOs(String psUuid) {
-        List<ImageCacheShadowVO> newDeletedAndOld = createShadowImageCacheVOsForNewDeletedAndOld(psUuid);
+    protected List<ImageCacheShadowVO> createShadowImageCacheVOs(String psUuid, ImageCacheCleanParam param) {
+        List<ImageCacheShadowVO> newDeletedAndOld = createShadowImageCacheVOsForNewDeletedAndOld(psUuid, param);
         if (newDeletedAndOld == null) {
             // no new deleted images, let's check if there any old that failed to be deleted last time
             String sql = "select s from ImageCacheShadowVO s, PrimaryStorageVO p where p.uuid = s.primaryStorageUuid and p.type = :ptype";

--- a/storage/src/main/java/org/zstack/storage/snapshot/reference/VolumeSnapshotReferenceUtils.java
+++ b/storage/src/main/java/org/zstack/storage/snapshot/reference/VolumeSnapshotReferenceUtils.java
@@ -370,6 +370,7 @@ public class VolumeSnapshotReferenceUtils {
         });
     }
 
+    // FIXME: consider path and psUuid
     public static List<Long> filterStaleImageCache(List<Long> ids) {
         if (CollectionUtils.isEmpty(ids)) {
             return Collections.emptyList();

--- a/test/src/test/groovy/org/zstack/test/integration/storage/primary/local/CleanImageCacheOnLocalPrimaryStorageCase.groovy
+++ b/test/src/test/groovy/org/zstack/test/integration/storage/primary/local/CleanImageCacheOnLocalPrimaryStorageCase.groovy
@@ -12,6 +12,7 @@ import org.zstack.header.vm.VmInstanceDeletionPolicyManager
 import org.zstack.network.securitygroup.SecurityGroupConstant
 import org.zstack.network.service.virtualrouter.VirtualRouterConstant
 import org.zstack.sdk.ApplianceVmInventory
+import org.zstack.sdk.HostInventory
 import org.zstack.sdk.ImageInventory
 import org.zstack.sdk.PrimaryStorageInventory
 import org.zstack.sdk.VmInstanceInventory
@@ -90,6 +91,11 @@ class CleanImageCacheOnLocalPrimaryStorageCase extends SubCase{
                     availableCapacity = SizeUnit.GIGABYTE.toByte(100)
                 }
 
+                nfsPrimaryStorage {
+                    name = "nfs"
+                    url = "localhost:/test"
+                }
+
                 cluster {
                     name = "cluster"
                     hypervisorType = "KVM"
@@ -101,7 +107,15 @@ class CleanImageCacheOnLocalPrimaryStorageCase extends SubCase{
                         password = "password"
                     }
 
+                    kvm {
+                        name = "kvm2"
+                        managementIp = "127.0.0.2"
+                        username = "root"
+                        password = "password"
+                    }
+
                     attachPrimaryStorage("local-ps")
+                    attachPrimaryStorage("nfs")
                     attachL2Network("l2")
                 }
 
@@ -157,6 +171,7 @@ class CleanImageCacheOnLocalPrimaryStorageCase extends SubCase{
             vm {
                 name = "vm"
                 useInstanceOffering("instanceOffering")
+                usePrimaryStorage("local-ps")
                 useCluster("cluster")
                 useImage("image1")
                 useL3Networks("l3")
@@ -164,6 +179,27 @@ class CleanImageCacheOnLocalPrimaryStorageCase extends SubCase{
                 useHost("kvm")
             }
 
+            vm {
+                name = "vm2"
+                useInstanceOffering("instanceOffering")
+                usePrimaryStorage("nfs")
+                useCluster("cluster")
+                useImage("image1")
+                useL3Networks("l3")
+                useRootDiskOffering("diskOffering")
+                useHost("kvm")
+            }
+
+            vm {
+                name = "vm3"
+                useInstanceOffering("instanceOffering")
+                usePrimaryStorage("local-ps")
+                useCluster("cluster")
+                useImage("image1")
+                useL3Networks("l3")
+                useRootDiskOffering("diskOffering")
+                useHost("kvm2")
+            }
         }
     }
 
@@ -178,9 +214,16 @@ class CleanImageCacheOnLocalPrimaryStorageCase extends SubCase{
         PrimaryStorageInventory localps = env.inventoryByName("local-ps")
         ImageInventory image1 = env.inventoryByName("image1")
         ImageInventory vrImage = env.inventoryByName("vr")
+        HostInventory host1 = env.inventoryByName("kvm") as HostInventory
+        HostInventory host2 = env.inventoryByName("kvm2") as HostInventory
 
-        ImageCacheVO c = Q.New(ImageCacheVO.class).eq(ImageCacheVO_.imageUuid,image1.getUuid()).find()
-        assert c != null
+        assert Q.New(ImageCacheVO.class)
+                .eq(ImageCacheVO_.primaryStorageUuid, localps.uuid)
+                .eq(ImageCacheVO_.imageUuid,image1.getUuid()).count() == 2L
+        ImageCacheVO c = Q.New(ImageCacheVO.class)
+                .eq(ImageCacheVO_.primaryStorageUuid, localps.uuid)
+                .like(ImageCacheVO_.installUrl, String.format("%%%s%%", host1.uuid))
+                .eq(ImageCacheVO_.imageUuid,image1.getUuid()).find()
 
         def checked = false
         def cmdTemp
@@ -207,14 +250,35 @@ class CleanImageCacheOnLocalPrimaryStorageCase extends SubCase{
 
         PrimaryStorageGlobalConfig.IMAGE_CACHE_GARBAGE_COLLECTOR_INTERVAL.updateValue(1)
         retryInSecs {
-            assert Q.New(ImageCacheShadowVO.class).eq(ImageCacheShadowVO_.imageUuid, image1.getUuid()).find() == null
-            assert Q.New(ImageCacheVO.class).eq(ImageCacheVO_.imageUuid, image1.getUuid()).find() == null
+            assert Q.New(ImageCacheShadowVO.class)
+                    .eq(ImageCacheShadowVO_.primaryStorageUuid, localps.uuid)
+                    .eq(ImageCacheShadowVO_.imageUuid, image1.getUuid()).find() == null
+            assert Q.New(ImageCacheVO.class).select(ImageCacheVO_.installUrl)
+                    .eq(ImageCacheVO_.primaryStorageUuid, localps.uuid)
+                    .eq(ImageCacheVO_.imageUuid, image1.getUuid()).findValue().contains(host2.uuid)
         }
 
         ApplianceVmInventory vr = queryApplianceVm {}[0] as ApplianceVmInventory
         destroyVmInstance {
             uuid = vr.uuid
         }
+
+        sleep(TimeUnit.SECONDS.toMillis(1))
+
+        assert !Q.New(ImageCacheShadowVO.class)
+                .eq(ImageCacheShadowVO_.imageUuid, vrImage.getUuid())
+                .isExists()
+        assert Q.New(ImageCacheVO.class)
+                .eq(ImageCacheVO_.imageUuid, vrImage.getUuid())
+                .isExists()
+
+        deleteImage {
+            uuid = vrImage.uuid
+        }
+        expungeImage {
+            imageUuid = vrImage.uuid
+        }
+
         retryInSecs {
             assert !Q.New(ImageCacheShadowVO.class)
                     .eq(ImageCacheShadowVO_.imageUuid, vrImage.getUuid())

--- a/utils/src/main/java/org/zstack/utils/ssh/SshShell.java
+++ b/utils/src/main/java/org/zstack/utils/ssh/SshShell.java
@@ -29,6 +29,14 @@ public class SshShell {
     private String privateKey;
     private int port = 22;
     private Boolean withSudo = true;
+    private int connectTimeoutSeconds = 10;
+    private int serverAliveIntervalSeconds = 5;
+    private int serverAliveCountMax = 2;
+
+    private String sshTimeoutOptions() {
+        return String.format("-o ConnectTimeout=%d -o ServerAliveInterval=%d -o ServerAliveCountMax=%d",
+                connectTimeoutSeconds, serverAliveIntervalSeconds, serverAliveCountMax);
+    }
 
     private void checkParams() {
         DebugUtils.Assert(hostname != null && !hostname.trim().equals(""), "hostname cannot be null");
@@ -45,13 +53,13 @@ public class SshShell {
             if (privateKey != null) {
                 tempPasswordFile = File.createTempFile("zstack", "tmp");
                 writeSecretFile(tempPasswordFile, privateKey);
-                ssh = String.format("ssh -q -i %s -o UserKnownHostsFile=/dev/null -o PasswordAuthentication=no -o StrictHostKeyChecking=no -p %s %s@%s '%s'",
-                        tempPasswordFile.getAbsolutePath(), port, username, hostname, cmd);
+                ssh = String.format("ssh -q -i %s -o UserKnownHostsFile=/dev/null -o PasswordAuthentication=no -o StrictHostKeyChecking=no %s -p %s %s@%s '%s'",
+                        tempPasswordFile.getAbsolutePath(), sshTimeoutOptions(), port, username, hostname, cmd);
             } else {
                 tempPasswordFile = File.createTempFile("zstack", "tmp");
                 writeSecretFile(tempPasswordFile, password);
-                ssh = String.format("sshpass -f%s ssh -q -o UserKnownHostsFile=/dev/null -o PubkeyAuthentication=no -o StrictHostKeyChecking=no -p %s %s@%s '%s'",
-                        tempPasswordFile.getAbsolutePath(), port, username, hostname, cmd);
+                ssh = String.format("sshpass -f%s ssh -q -o UserKnownHostsFile=/dev/null -o PubkeyAuthentication=no -o StrictHostKeyChecking=no %s -p %s %s@%s '%s'",
+                        tempPasswordFile.getAbsolutePath(), sshTimeoutOptions(), port, username, hostname, cmd);
             }
 
             if (logger.isTraceEnabled()) {
@@ -89,7 +97,7 @@ public class SshShell {
                 tempPasswordFile = File.createTempFile("zstack", "tmp");
                 writeSecretFile(tempPasswordFile, privateKey);
                 ssh = ln(
-                        "ssh -q -i {0} -o UserKnownHostsFile=/dev/null -o PasswordAuthentication=no -o StrictHostKeyChecking=no -p {1} -T {2}@{3} << 'EOF'",
+                        "ssh -q -i {0} -o UserKnownHostsFile=/dev/null -o PasswordAuthentication=no -o StrictHostKeyChecking=no {5} -p {1} -T {2}@{3} << 'EOF'",
                         "s=`mktemp`",
                         "cat << 'EOT' > $s",
                         "{4}",
@@ -99,12 +107,12 @@ public class SshShell {
                         "rm -f $s",
                         "exit $ret",
                         "EOF"
-                ).format(tempPasswordFile.getAbsolutePath(), port, username, hostname, script);
+                ).format(tempPasswordFile.getAbsolutePath(), port, username, hostname, script, sshTimeoutOptions());
             } else {
                 tempPasswordFile = File.createTempFile("zstack", "tmp");
                 writeSecretFile(tempPasswordFile, password);
                 ssh = ln(
-                        "sshpass -f{0} ssh -q -o UserKnownHostsFile=/dev/null -o PubkeyAuthentication=no -o StrictHostKeyChecking=no -p {1} -T {2}@{3} << 'EOF'",
+                        "sshpass -f{0} ssh -q -o UserKnownHostsFile=/dev/null -o PubkeyAuthentication=no -o StrictHostKeyChecking=no {5} -p {1} -T {2}@{3} << 'EOF'",
                         "s=`mktemp`",
                         "cat << 'EOT' > $s",
                         "{4}",
@@ -114,7 +122,7 @@ public class SshShell {
                         "rm -f $s",
                         "exit $ret",
                         "EOF"
-                ).format(tempPasswordFile.getAbsolutePath(), port, username, hostname, script);
+                ).format(tempPasswordFile.getAbsolutePath(), port, username, hostname, script, sshTimeoutOptions());
             }
 
             if (logger.isTraceEnabled()) {
@@ -208,5 +216,29 @@ public class SshShell {
 
     public void setWithSudo(Boolean withSudo) {
         this.withSudo = withSudo;
+    }
+
+    public int getConnectTimeoutSeconds() {
+        return connectTimeoutSeconds;
+    }
+
+    public void setConnectTimeoutSeconds(int connectTimeoutSeconds) {
+        this.connectTimeoutSeconds = connectTimeoutSeconds;
+    }
+
+    public int getServerAliveIntervalSeconds() {
+        return serverAliveIntervalSeconds;
+    }
+
+    public void setServerAliveIntervalSeconds(int serverAliveIntervalSeconds) {
+        this.serverAliveIntervalSeconds = serverAliveIntervalSeconds;
+    }
+
+    public int getServerAliveCountMax() {
+        return serverAliveCountMax;
+    }
+
+    public void setServerAliveCountMax(int serverAliveCountMax) {
+        this.serverAliveCountMax = serverAliveCountMax;
     }
 }


### PR DESCRIPTION
Backport 3 fixes to 4.8.38 (@@2 group with premium).

**ZSTAC-86006** (source: ZSTAC-72837)
- `<fix>[utils]: SshShell add ssh client timeouts` (3cffcd3c82 → zstack!9859)
- `<fix>[kvm]: bound host reachability check timeout` (a6b84f720c → zstack!10043)
- Fix: SshShell inject ConnectTimeout=10s + ServerAlive to prevent 222-host concurrent SSH hang on reconnect

**ZSTAC-86012** (source: ZSTAC-74848)
- `<fix>[ceph]: enhance ceph capacity calculate` (5082eabe35 → zstack!7921)
- Fix: ignore empty installPath in ceph capacity calc to prevent StringIndexOutOfBoundsException on reconnect

Resolves: ZSTAC-86006
Resolves: ZSTAC-86012

sync from gitlab !10254