### PR TITLE
[ZSTAC-65483][4.8.38] Mask invalid userdata tag

### DIFF
--- a/compute/src/main/java/org/zstack/compute/vm/VmSystemTags.java
+++ b/compute/src/main/java/org/zstack/compute/vm/VmSystemTags.java
@@ -251,7 +251,13 @@ public class VmSystemTags {
                 }
 
                 Yaml yaml = new Yaml();
-                Object obj = yaml.load(userdata);
+                Object obj;
+                try {
+                    obj = yaml.load(userdata);
+                } catch (RuntimeException e) {
+                    tokens.put(t, "*****");
+                    continue;
+                }
                 if (!(obj instanceof LinkedHashMap)) {
                     return tag;
                 }

--- a/test/src/test/java/org/zstack/test/userdata/TestUserdataTagOutputHandler.java
+++ b/test/src/test/java/org/zstack/test/userdata/TestUserdataTagOutputHandler.java
@@ -1,0 +1,44 @@
+package org.zstack.test.userdata;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.zstack.compute.vm.VmSystemTags;
+
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.Map;
+
+public class TestUserdataTagOutputHandler {
+    private final VmSystemTags.UserdataTagOutputHandler handler = new VmSystemTags.UserdataTagOutputHandler();
+
+    @Before
+    public void setUp() throws NoSuchFieldException {
+        VmSystemTags.USERDATA.annotation = VmSystemTags.class.getField("USERDATA").getAnnotation(org.zstack.tag.SensitiveTag.class);
+    }
+
+    @Test
+    public void desensitizeMalformedCloudConfigMasksUserdata() {
+        String userdata = "#cloud-config\nchpasswd:\n  list: |\nroot:word\nexpire: False\n";
+        String maskedTag = handler.desensitizeTag(VmSystemTags.USERDATA, userdataTag(userdata));
+
+        Assert.assertEquals("*****", VmSystemTags.USERDATA.getTokenByTag(maskedTag, VmSystemTags.USERDATA_TOKEN));
+    }
+
+    @Test
+    public void desensitizeValidCloudConfigKeepsStructuredMask() {
+        String userdata = "#cloud-config\nchpasswd:\n  list: |\n    root:word\n  expire: False\n";
+        String maskedTag = handler.desensitizeTag(VmSystemTags.USERDATA, userdataTag(userdata));
+        String maskedUserdata = new String(Base64.getDecoder().decode(
+                VmSystemTags.USERDATA.getTokenByTag(maskedTag, VmSystemTags.USERDATA_TOKEN).getBytes()));
+
+        Assert.assertTrue(maskedUserdata.contains("*****:*****"));
+        Assert.assertFalse(maskedUserdata.contains("root:word"));
+    }
+
+    private String userdataTag(String userdata) {
+        Map<String, String> tokens = new HashMap<>();
+        tokens.put(VmSystemTags.USERDATA_TOKEN, new String(Base64.getEncoder().encode(userdata.getBytes())));
+        return VmSystemTags.USERDATA.instantiateTag(tokens);
+    }
+}


### PR DESCRIPTION
## Summary

Fix HTTP 500 when querying userdata system tags with `Rest.maskSensitiveInfo` enabled and malformed userdata content.

## Root Cause

`VmSystemTags.UserdataTagOutputHandler` decoded userdata and parsed it as YAML without handling SnakeYAML runtime parse errors. If the userdata looked like cloud-config but had invalid indentation, the sensitive-output masking path threw during query response serialization.

## Change

- Catch YAML parsing failures in userdata sensitive tag masking.
- Replace the whole userdata token with `*****` when parsing fails, avoiding both the API 500 and plaintext exposure.
- Add focused JUnit coverage for malformed userdata and valid `chpasswd.list` structured masking.

## Verification

Ran in PR Docker through `scripts/verify-case-docker.sh`:

```bash
cd /zstack && mvn -pl compute,testlib -am -DskipTests -DskipJacoco=true install
cd /zstack/test && mvn test -Dtest=org.zstack.test.userdata.TestUserdataTagOutputHandler -Dsurefire.useFile=false -DskipJacoco=true
```

Result:

```text
Tests run: 2, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```

## Risk

Scope is limited to userdata sensitive tag output masking. Full CI pending.

Resolves: ZSTAC-65483

sync from gitlab !10262