### PR TITLE
<fix>[ansible]: validate repo content before IP rewrite

### DIFF
--- a/core/src/main/java/org/zstack/core/ansible/SshYumRepoChecker.java
+++ b/core/src/main/java/org/zstack/core/ansible/SshYumRepoChecker.java
@@ -19,6 +19,11 @@ public class SshYumRepoChecker implements AnsibleChecker {
     protected RESTFacade restf;
 
     private static final CLogger logger = Utils.getLogger(SshYumRepoChecker.class);
+
+    public static final String VALIDATE_REPO_CONTENT_CMD =
+            "for f in /etc/yum.repos.d/zstack-mn.repo /etc/yum.repos.d/qemu-kvm-ev-mn.repo; "
+                    + "do test -e \"$f\" || continue; test -s \"$f\" || exit 1; grep -q '^baseurl=' \"$f\" || exit 1; done";
+
     private String username;
     private String password;
     private String privateKey;
@@ -36,6 +41,16 @@ public class SshYumRepoChecker implements AnsibleChecker {
                 .setPassword(password).setPort(sshPort)
                 .setHostname(targetIp);
         try {
+            ssh.sudoCommand(VALIDATE_REPO_CONTENT_CMD);
+            SshResult validateRet = ssh.setTimeout(60).run();
+            ssh.reset();
+            if (validateRet.getReturnCode() != 0) {
+                logger.warn(String.format("zstack-mn.repo or qemu-kvm-ev-mn.repo is empty or corrupted on %s, " +
+                        "redeploy to regenerate them, return code: %d, stdout: %s, stderr: %s",
+                        targetIp, validateRet.getReturnCode(), validateRet.getStdout(), validateRet.getStderr()));
+                return true;
+            }
+
             ssh.sudoCommand(String.format("sed -i '/baseurl/s/\\([0-9]\\{1,3\\}\\.\\)\\{3\\}[0-9]\\{1,3\\}:\\([0-9]\\+\\)/%s/g' /etc/yum.repos.d/{zstack,qemu-kvm-ev}-mn.repo",
                     restf.getHostName() + ":" + restf.getPort()
             ));

--- a/test/src/test/groovy/org/zstack/test/unittest/core/SshYumRepoCheckerCmdCase.groovy
+++ b/test/src/test/groovy/org/zstack/test/unittest/core/SshYumRepoCheckerCmdCase.groovy
@@ -1,0 +1,71 @@
+package org.zstack.test.unittest.core
+
+import org.junit.Test
+import org.zstack.core.ansible.SshYumRepoChecker
+
+class SshYumRepoCheckerCmdCase {
+    private static final String VALID_ZSTACK_MN_REPO =
+            "[zstack-mn]\nname=zstack-mn\nbaseurl=http://172.24.242.88:8080/zstack/static/zstack-repo/\$basearch/\$YUM0/\ngpgcheck=0\nenabled=0\n"
+    private static final String VALID_QEMU_KVM_EV_MN_REPO =
+            "[qemu-kvm-ev-mn]\nname=qemu-kvm-ev-mn\nbaseurl=http://172.24.242.88:8080/zstack/static/zstack-repo/\$basearch/\$YUM0/Extra/qemu-kvm-ev/\ngpgcheck=0\nenabled=0\n"
+
+    private int runValidation(String zstackMnContent, String qemuKvmEvContent) {
+        File dir = File.createTempDir()
+        try {
+            writeRepo(dir, "zstack-mn.repo", zstackMnContent)
+            writeRepo(dir, "qemu-kvm-ev-mn.repo", qemuKvmEvContent)
+
+            String cmd = SshYumRepoChecker.VALIDATE_REPO_CONTENT_CMD
+                    .replace("/etc/yum.repos.d/", dir.absolutePath + "/")
+
+            Process p = ["bash", "-c", cmd].execute()
+            p.waitFor()
+            return p.exitValue()
+        } finally {
+            dir.deleteDir()
+        }
+    }
+
+    private void writeRepo(File dir, String name, String content) {
+        if (content == null) {
+            return
+        }
+        new File(dir, name).text = content
+    }
+
+    @Test
+    void validRepoFilesPassValidation() {
+        assert runValidation(VALID_ZSTACK_MN_REPO, VALID_QEMU_KVM_EV_MN_REPO) == 0:
+                "intact zstack-mn.repo and qemu-kvm-ev-mn.repo must not trigger redeploy"
+    }
+
+    @Test
+    void emptyZstackMnRepoTriggersDeploy() {
+        assert runValidation("", VALID_QEMU_KVM_EV_MN_REPO) != 0:
+                "zstack-mn.repo truncated to 0 bytes by cold reboot must trigger redeploy"
+    }
+
+    @Test
+    void emptyQemuKvmEvRepoTriggersDeploy() {
+        assert runValidation(VALID_ZSTACK_MN_REPO, "") != 0:
+                "qemu-kvm-ev-mn.repo truncated to 0 bytes must trigger redeploy"
+    }
+
+    @Test
+    void absentQemuKvmEvRepoDoesNotTriggerDeploy() {
+        assert runValidation(VALID_ZSTACK_MN_REPO, null) == 0:
+                "legitimately absent qemu-kvm-ev-mn.repo (e.g. CentOS 6) must not trigger redeploy"
+    }
+
+    @Test
+    void bothReposAbsentDoesNotTriggerDeploy() {
+        assert runValidation(null, null) == 0:
+                "both repos absent (first-ever connect before ansible) must not trigger redeploy"
+    }
+
+    @Test
+    void repoWithoutBaseurlTriggersDeploy() {
+        assert runValidation("[zstack-mn]\nname=zstack-mn\ngpgcheck=0\nenabled=0\n", VALID_QEMU_KVM_EV_MN_REPO) != 0:
+                "zstack-mn.repo missing baseurl line must trigger redeploy"
+    }
+}


### PR DESCRIPTION
## ZSTAC-86141

### Root Cause
SshYumRepoChecker.needDeploy() only runs a sed baseurl IP-rewrite on zstack-mn.repo and qemu-kvm-ev-mn.repo. After a cold reboot these files get truncated to 0 bytes. sed on an empty file returns exit 0, so needDeploy() returns false, ansible redeploy is skipped, and the empty repo is never regenerated. Downstream update-kvmagent-dependencies fails with "no zstack-mn repo found".

### Changes
| Module | Change |
|--------|--------|
| `core` | Add validate-if-exists check to SshYumRepoChecker.needDeploy() before the sed IP-rewrite: present-but-empty or missing-baseurl triggers redeploy; absent files are skipped (legitimately never created on some distros) |
| `test` | Add SshYumRepoCheckerCmdCase with 6 scenarios: both-valid, empty-zstack-mn, empty-qemu, absent-qemu (CentOS 6), both-absent, missing-baseurl |

### Test
- SshYumRepoCheckerCmdCase: 6/6 passed (0.916s)
- Full premium build: BUILD SUCCESS

Related: ZSTAC-86141

sync from gitlab !10272