### PR TITLE
<fix>[zwatch]: clean alarm resource state label and prune stale ones

### DIFF
--- a/conf/db/upgrade/V5.5.28__schema.sql
+++ b/conf/db/upgrade/V5.5.28__schema.sql
@@ -4,7 +4,7 @@ ALTER TABLE `zstack`.`AlarmVO` ADD COLUMN `recoveryThreshold` int unsigned DEFAU
 CREATE TABLE IF NOT EXISTS `zstack`.`AlarmResourceStateVO` (
     `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
     `alarmUuid` varchar(32) NOT NULL,
-    `identifyLabel` varchar(200) NOT NULL,
+    `identifyLabel` varchar(191) NOT NULL,
     `resourceUuid` varchar(32) DEFAULT NULL,
     `resourceType` varchar(256) DEFAULT NULL,
     `status` varchar(32) NOT NULL,
@@ -12,7 +12,7 @@ CREATE TABLE IF NOT EXISTS `zstack`.`AlarmResourceStateVO` (
     `lastOpDate` timestamp ON UPDATE CURRENT_TIMESTAMP,
     `createDate` timestamp,
     PRIMARY KEY (`id`),
-    UNIQUE KEY `ukAlarmUuidIdentifyLabel` (`alarmUuid`, `identifyLabel`),
+    UNIQUE KEY `ukAlarmUuidIdentifyLabel` (`alarmUuid`, `identifyLabel`, `resourceUuid`),
     KEY `idxAlarmResourceStateVOresourceUuid` (`resourceUuid`),
     CONSTRAINT `fkAlarmResourceStateVOAlarmVO` FOREIGN KEY (`alarmUuid`) REFERENCES `AlarmVO` (`uuid`) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;


### PR DESCRIPTION
## ZSTAC-85397

### Root Cause
The alarm resource state row was keyed only by (alarmUuid, identifyLabel). Now that identifyLabel stores the clean per-resource label (e.g. CPUNum:19), two resources under one multi-resource alarm can share the same label, so the unique key must also include resourceUuid.

### Changes
| Module | Change |
|--------|--------|
| conf | AlarmResourceStateVO unique key extended with resourceUuid; identifyLabel 200 to 191 so the composite unique key stays within the CI MySQL 255-char limit |

### Test
- this is the AlarmResourceStateVO table in the in-development V5.5.28 migration (table was added on this same feature branch, so the create statement is amended in place)

### Related MRs
- premium MR: !14451 (the zwatch code change carrying the clean-label + prune logic)

Related: ZSTAC-85397
Related: SUG-2677

sync from gitlab !10302