### PR TITLE
<fix>[vm]: publish HA start state change

### DIFF
--- a/compute/src/main/java/org/zstack/compute/vm/VmInstanceBase.java
+++ b/compute/src/main/java/org/zstack/compute/vm/VmInstanceBase.java
@@ -337,6 +337,10 @@ public class VmInstanceBase extends AbstractVmInstance {
     }
 
     protected VmInstanceVO changeVmStateInDb(VmInstanceStateEvent stateEvent, Runnable runnable) {
+        return changeVmStateInDb(stateEvent, runnable, null);
+    }
+
+    protected VmInstanceVO changeVmStateInDb(VmInstanceStateEvent stateEvent, Runnable runnable, String stateChangeSource) {
         VmInstanceState bs = self.getState();
         final VmInstanceState state = self.getState().nextState(stateEvent);
 
@@ -385,6 +389,7 @@ public class VmInstanceBase extends AbstractVmInstance {
             data.setVmUuid(self.getUuid());
             data.setOldState(bs.toString());
             data.setNewState(state.toString());
+            data.setStateChangeSource(stateChangeSource);
             data.setInventory(getSelfInventory());
             evtf.fire(VmCanonicalEvents.VM_FULL_STATE_CHANGED_PATH, data);
 
@@ -1024,17 +1029,7 @@ public class VmInstanceBase extends AbstractVmInstance {
                         String hostUuid = self.getHostUuid();
                         String suspectHostUuid = StringUtils.trimToNull(hostUuid);
                         String peerHostUuid = StringUtils.trimToNull(msg.getAccessiblePeerHostUuid());
-                        UpdateQuery sql = SQL.New(VmInstanceVO.class)
-                                .eq(VmInstanceVO_.uuid, self.getUuid())
-                                .set(VmInstanceVO_.state, VmInstanceState.Stopped)
-                                .set(VmInstanceVO_.hostUuid, null);
-
-                        if (hostUuid != null) {
-                            sql.set(VmInstanceVO_.lastHostUuid, hostUuid);
-                        }
-
-                        sql.update();
-                        refreshVO();
+                        changeVmStateInDb(VmInstanceStateEvent.stopped, null, HaStartVmInstanceMsg.class.getName());
                         if (suspectHostUuid == null) {
                             logger.debug(String.format("HA-start vm[%s]: skip creating pre-fence tag because suspect host is absent",
                                     self.getUuid()));

--- a/header/src/main/java/org/zstack/header/vm/VmCanonicalEvents.java
+++ b/header/src/main/java/org/zstack/header/vm/VmCanonicalEvents.java
@@ -155,6 +155,7 @@ public class VmCanonicalEvents {
         private String vmUuid;
         private String oldState;
         private String newState;
+        private String stateChangeSource;
         private VmInstanceInventory inventory;
         private Date date = new Date();
 
@@ -196,6 +197,14 @@ public class VmCanonicalEvents {
 
         public void setNewState(String newState) {
             this.newState = newState;
+        }
+
+        public String getStateChangeSource() {
+            return stateChangeSource;
+        }
+
+        public void setStateChangeSource(String stateChangeSource) {
+            this.stateChangeSource = stateChangeSource;
         }
     }
 


### PR DESCRIPTION
Resolves: ZSTAC-84393

Root cause:
HA start changed VM state from Unknown to Stopped through direct SQL, bypassing changeVmStateInDb(). The VM full state canonical event and VmStateChangedExtensionPoint were not fired, so alarm/event consumers could miss HA state corrections.

Resolve:
Publish the HA internal state correction through changeVmStateInDb() and attach stateChangeSource to VmStateChangedData for downstream filtering.

Verification:
- zstack-mvn -P premium -pl header,compute -DskipTests -DskipJacoco=true install
- VmHaStartStateChangeEventCase: Tests run: 1, Failures: 0, Errors: 0, Skipped: 0

sync from gitlab !10111