### PR TITLE
<fix>[migration]: Compare host properties before live storage migration

### DIFF
--- a/compute/src/main/java/org/zstack/compute/allocator/AttachedVolumePrimaryStorageAllocatorFlow.java
+++ b/compute/src/main/java/org/zstack/compute/allocator/AttachedVolumePrimaryStorageAllocatorFlow.java
@@ -32,7 +32,7 @@ public class AttachedVolumePrimaryStorageAllocatorFlow extends AbstractHostAlloc
     public void allocate() {
         throwExceptionIfIAmTheFirstFlow();
 
-        if (VmOperation.NewCreate.toString().equals(spec.getVmOperation())) {
+        if (VmOperation.NewCreate.toString().equals(spec.getVmOperation()) || VmOperation.MigrateStorage.toString().equals(spec.getVmOperation())) {
             next(candidates);
             return;
         }

--- a/compute/src/main/java/org/zstack/compute/allocator/HostPrimaryStorageAllocatorFlow.java
+++ b/compute/src/main/java/org/zstack/compute/allocator/HostPrimaryStorageAllocatorFlow.java
@@ -142,11 +142,11 @@ public class HostPrimaryStorageAllocatorFlow extends AbstractHostAllocatorFlow {
     private List<HostVO> allocateFromCandidates() {
         List<String> huuids = getHostUuidsFromCandidates();
         Set<String> requiredPsUuids = spec.getRequiredPrimaryStorageUuids();
-        if (!VmOperation.NewCreate.toString().equals(spec.getVmOperation())) {
-            return filterHostHavingAccessiblePrimaryStorage(huuids, spec);
-        } else {
+        if (VmOperation.NewCreate.toString().equals(spec.getVmOperation()) || VmOperation.MigrateStorage.toString().equals(spec.getVmOperation())) {
             huuids = filterHostHavingAccessiblePrimaryStorage(huuids, spec)
                     .stream().map(ResourceVO::getUuid).collect(Collectors.toList());
+        } else {
+            return filterHostHavingAccessiblePrimaryStorage(huuids, spec);
         }
 
         if (huuids.isEmpty()) {

--- a/header/src/main/java/org/zstack/header/vm/VmInstanceConstant.java
+++ b/header/src/main/java/org/zstack/header/vm/VmInstanceConstant.java
@@ -62,6 +62,7 @@ public interface VmInstanceConstant {
         Reboot,
         Destroy,
         Migrate,
+        MigrateStorage,
         AttachVolume,
         AttachNic,
         ChangeNicNetwork,

--- a/plugin/kvm/src/main/java/org/zstack/kvm/KVMHostAllocatorFilterExtensionPoint.java
+++ b/plugin/kvm/src/main/java/org/zstack/kvm/KVMHostAllocatorFilterExtensionPoint.java
@@ -5,6 +5,8 @@ import org.zstack.header.allocator.HostAllocatorFilterExtensionPoint;
 import org.zstack.header.allocator.HostAllocatorSpec;
 import org.zstack.header.host.HostVO;
 import org.zstack.header.vm.VmInstanceConstant;
+import org.zstack.header.vm.VmInstanceConstant.VmOperation;
+import org.zstack.header.vm.VmInstanceState;
 import org.zstack.utils.Utils;
 import org.zstack.utils.logging.CLogger;
 
@@ -171,7 +173,11 @@ public class KVMHostAllocatorFilterExtensionPoint implements HostAllocatorFilter
             return candidates;
         }
 
-        if (!VmInstanceConstant.VmOperation.Migrate.toString().equals(spec.getVmOperation())) {
+        if (!VmOperation.Migrate.toString().equals(spec.getVmOperation()) && !VmOperation.MigrateStorage.toString().equals(spec.getVmOperation())) {
+            return candidates;
+        }
+
+        if (VmInstanceState.Stopped.toString().equals(spec.getVmInstance().getState())) {
             return candidates;
         }
 

--- a/plugin/localstorage/src/main/java/org/zstack/storage/primary/local/LocalStorageAllocatorFactory.java
+++ b/plugin/localstorage/src/main/java/org/zstack/storage/primary/local/LocalStorageAllocatorFactory.java
@@ -109,7 +109,7 @@ public class LocalStorageAllocatorFactory implements PrimaryStorageAllocatorStra
     public List<HostVO> filterHostCandidates(List<HostVO> candidates, HostAllocatorSpec spec) {
         long reservedCapacity = SizeUtils.sizeStringToBytes(PrimaryStorageGlobalConfig.RESERVED_CAPACITY.value());
 
-        if (VmOperation.NewCreate.toString().equals(spec.getVmOperation())) {
+        if (VmOperation.NewCreate.toString().equals(spec.getVmOperation()) || VmOperation.MigrateStorage.toString().equals(spec.getVmOperation())) {
             List<String> huuids = getNeedCheckHostLocalStorageList(candidates, spec);
             if (huuids.isEmpty()) {
                 return candidates;


### PR DESCRIPTION
## Summary
Introduce `MigrateStorage` host allocation semantics for live storage migration so it keeps storage capacity checks while also applying migration-time KVM host property checks.

## Changes
- Add `VmOperation.MigrateStorage`.
- Treat `MigrateStorage` like `NewCreate` for primary/local storage capacity checks.
- Skip attached-volume PS accessibility checks for storage migration.
- Treat `MigrateStorage` like `Migrate` for KVM qemu/libvirt/cpumodel/ept property filtering.

## Testing
- [x] `git diff --check zstack/5.5.28..HEAD`
- [x] `JAVA_HOME=/Users/wushan/Library/Java/JavaVirtualMachines/corretto-1.8.0_372/Contents/Home mvn -pl compute,plugin/kvm,plugin/localstorage -am -DskipTests compile`
- [ ] CI pipeline

Resolves: ZSTAC-75332

sync from gitlab !10312