### PR TITLE
&lt;fix&gt;[zbs]: skip connected protocol on reconnect

### DIFF
--- a/plugin/externalStorage/src/main/java/org/zstack/externalStorage/primary/kvm/ExternalPrimaryStorageKvmFactory.java
+++ b/plugin/externalStorage/src/main/java/org/zstack/externalStorage/primary/kvm/ExternalPrimaryStorageKvmFactory.java
@@ -202,11 +202,25 @@ public class ExternalPrimaryStorageKvmFactory implements KVMHostConnectExtension
                     extPs.getUuid(), extPs.getName(), context.getInventory().getUuid(), context.getInventory().getName()));
 
             // one deploy pass redeploys the baseline client plus every exposed
-            // protocol's data path (e.g. the vhost SPDK target) on reconnect
-            List<String> protocols = Q.New(PrimaryStorageOutputProtocolRefVO.class)
+            // protocol's data path (e.g. the vhost SPDK target). a protocol already
+            // Connected on this host is skipped so reconnect doesn't bounce a live target.
+            List<String> protocols = new ArrayList<>(Q.New(PrimaryStorageOutputProtocolRefVO.class)
                     .eq(PrimaryStorageOutputProtocolRefVO_.primaryStorageUuid, extPs.getUuid())
                     .select(PrimaryStorageOutputProtocolRefVO_.outputProtocol)
+                    .listValues());
+
+            List<String> connected = Q.New(ExternalPrimaryStorageHostProtocolRefVO.class)
+                    .eq(ExternalPrimaryStorageHostProtocolRefVO_.primaryStorageUuid, extPs.getUuid())
+                    .eq(ExternalPrimaryStorageHostProtocolRefVO_.hostUuid, context.getInventory().getUuid())
+                    .eq(ExternalPrimaryStorageHostProtocolRefVO_.status, PrimaryStorageHostStatus.Connected)
+                    .select(ExternalPrimaryStorageHostProtocolRefVO_.protocol)
                     .listValues();
+            protocols.removeAll(connected);
+
+            if (protocols.isEmpty()) {
+                compl.done();
+                return;
+            }
 
             extPsFactory.getNodeSvc(extPs.getUuid()).deployClient(context.getInventory(), protocols, new Completion(compl) {
                 @Override

--- a/test/src/test/groovy/org/zstack/test/integration/storage/primary/addon/zbs/ZbsVhostVolumeCase.groovy
+++ b/test/src/test/groovy/org/zstack/test/integration/storage/primary/addon/zbs/ZbsVhostVolumeCase.groovy
@@ -41,6 +41,7 @@ import org.zstack.utils.gson.JSONObjectUtil
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicReference
 
 /**
@@ -174,6 +175,7 @@ class ZbsVhostVolumeCase extends SubCase {
             testVhostVmStartActivationChain()
             testAddProtocolPreparesHostsAndRecordsProtocolRefs()
             testProtocolRecoveryBackoff()
+            testReconnectSkipsConnectedProtocolDeploy()
         }
     }
 
@@ -810,6 +812,64 @@ class ZbsVhostVolumeCase extends SubCase {
                     .eq(ExternalPrimaryStorageHostProtocolRefVO_.status, PrimaryStorageHostStatus.Connected)
                     .isExists()
         }
+
+        detachPrimaryStorageFromCluster {
+            primaryStorageUuid = ps.uuid
+            clusterUuid = cluster.uuid
+        }
+    }
+
+    // reconnect re-runs the host-connect prepare flow, but a protocol already Connected
+    // on this host must NOT be redeployed: bouncing a live vhost SPDK target on every
+    // reconnect would interrupt running vhost VMs. only down/absent protocols deploy.
+    void testReconnectSkipsConnectedProtocolDeploy() {
+        HostInventory host = env.inventoryByName("kvm-1") as HostInventory
+        AtomicInteger deployCount = new AtomicInteger(0)
+
+        env.simulator(ZbsStorageController.DEPLOY_VHOST_PATH) { HttpEntity<String> e, EnvSpec spec ->
+            deployCount.incrementAndGet()
+            return new ZbsStorageController.AgentResponse()
+        }
+        env.simulator(ZbsStorageController.PREPARE_VHOST_TARGET_ENV_PATH) { HttpEntity<String> e, EnvSpec spec ->
+            return new ZbsStorageController.AgentResponse()
+        }
+        env.simulator(ZbsStorageController.VHOST_TARGET_HEALTH_PATH) { HttpEntity<String> e, EnvSpec spec ->
+            def rsp = new ZbsStorageController.VhostTargetHealthRsp()
+            rsp.targetRunning = true
+            return rsp
+        }
+        env.afterSimulator(ZbsStorageController.CREATE_VOLUME_PATH) { rsp, HttpEntity<String> e ->
+            def cmd = JSONObjectUtil.toObject(e.body, ZbsStorageController.CreateVolumeCmd)
+            if (cmd.volume == ZbsConstants.ZBS_HEARTBEAT_VOLUME_NAME) {
+                def vrsp = new ZbsStorageController.CreateVolumeRsp()
+                vrsp.installPath = "zbs://${cmd.logicalPool}/${cmd.volume}".toString()
+                return vrsp
+            }
+            return rsp
+        }
+
+        attachPrimaryStorageToCluster {
+            primaryStorageUuid = ps.uuid
+            clusterUuid = cluster.uuid
+        }
+
+        // wait until the vhost protocol row is Connected on this host
+        retryInSecs {
+            assert Q.New(ExternalPrimaryStorageHostProtocolRefVO.class)
+                    .eq(ExternalPrimaryStorageHostProtocolRefVO_.primaryStorageUuid, ps.uuid)
+                    .eq(ExternalPrimaryStorageHostProtocolRefVO_.hostUuid, host.uuid)
+                    .eq(ExternalPrimaryStorageHostProtocolRefVO_.protocol, VolumeProtocol.Vhost.toString())
+                    .eq(ExternalPrimaryStorageHostProtocolRefVO_.status, PrimaryStorageHostStatus.Connected)
+                    .isExists()
+        }
+
+        // every exposed protocol Connected -> reconnect must not deploy any of them
+        deployCount.set(0)
+        reconnectHost { uuid = host.uuid }
+        Thread.sleep(2000)
+        assert deployCount.get() == 0 : \
+                "reconnect redeployed an already-Connected vhost target ${deployCount.get()} time(s); " +
+                "host-connect must skip protocols already Connected"
 
         detachPrimaryStorageFromCluster {
             primaryStorageUuid = ps.uuid


### PR DESCRIPTION
## 问题
KVM host 连接/重连时 `ExternalPrimaryStorageKvmFactory.deployClient` 无条件重部署 PS 暴露的**所有**协议。即使某协议（如 vhost）已 Connected、SPDK target 在跑，每次 reconnect 都会重 deploy 一次，可能打断在该 host 上运行的 vhost VM。reconnect 是每次 host 连接生命周期都会触发的（手动 ReconnectHost / MN 重启 / 自动重连）。

## 修复
deploy 前查 `ExternalPrimaryStorageHostProtocolRefVO`，剔除该 (ps,host) 已 Connected 的协议；全部 Connected 则整体跳过。首连（无 ref 行）不受影响仍全 deploy；部分断开只 deploy 未连协议，与 ping 自愈路径 `recoverDisconnectedProtocols` 的 due-filter 语义一致。

## 自测
新增 `ZbsVhostVolumeCase.testReconnectSkipsConnectedProtocolDeploy`：attach→等 Vhost Connected→清 deploy 计数→ReconnectHost→断言 DEPLOY_VHOST 计数为 0。premium build + test 模块编译通过。

Resolves: ZSTAC-86286

sync from gitlab !10317