### PR TITLE
<fix>[zbs]: ZSTAC-80595 try next mds on sync failure

### DIFF
--- a/plugin/zbs/src/main/java/org/zstack/storage/zbs/ZbsMdsBase.java
+++ b/plugin/zbs/src/main/java/org/zstack/storage/zbs/ZbsMdsBase.java
@@ -76,7 +76,18 @@ public abstract class ZbsMdsBase {
     }
 
     public <T extends AgentResponse> T syncCall(final String path, final Object cmd, final Class<T> retClass, TimeUnit unit, long timeout) {
-        return restf.syncJsonPost(makeHttpPath(self.getAddr(), path), cmd, retClass, unit, timeout);
+        try {
+            return restf.syncJsonPost(makeHttpPath(self.getAddr(), path), cmd, retClass, unit, timeout);
+        } catch (OperationFailureException e) {
+            try {
+                T ret = retClass.getDeclaredConstructor().newInstance();
+                ret.setError(e.getErrorCode().getDetails());
+                return ret;
+            } catch (Exception ex) {
+                throw new OperationFailureException(operr(ORG_ZSTACK_STORAGE_ZBS_10041,
+                        "failed to instantiate zbs agent response[%s], because %s", retClass.getName(), ex.getMessage()));
+            }
+        }
     }
 
     public <T extends AgentResponse> void httpCall(final String path, final Object cmd, final Class<T> retClass, final ReturnValueCompletion<T> completion) {

--- a/test/src/test/groovy/org/zstack/test/unittest/storage/zbs/ZbsMdsBaseCase.groovy
+++ b/test/src/test/groovy/org/zstack/test/unittest/storage/zbs/ZbsMdsBaseCase.groovy
@@ -1,0 +1,45 @@
+package org.zstack.test.unittest.storage.zbs
+
+import org.junit.Test
+import org.zstack.header.errorcode.OperationFailureException
+import org.zstack.header.rest.RESTFacade
+import org.zstack.storage.zbs.MdsInfo
+import org.zstack.storage.zbs.ZbsMdsBase
+import org.zstack.storage.zbs.ZbsPrimaryStorageMdsBase
+
+import java.util.concurrent.TimeUnit
+
+import static org.zstack.core.Platform.operr
+
+class ZbsMdsBaseCase {
+    @Test
+    void testSyncCallReturnsFailedResponseAfterRestException() {
+        def mds = new TestMdsBase(mdsInfo("127.0.1.1"))
+
+        def ret = mds.syncCall("/volume/clients", new ZbsMdsBase.AgentCommand(), TestResponse.class, TimeUnit.SECONDS, 1)
+
+        assert !ret.isSuccess() : "ZBS syncCall should convert REST exception to failed response"
+        assert ret.error.contains("simulated MDS network failure") : "ZBS syncCall returned wrong error: ${ret.error}"
+    }
+
+    private static MdsInfo mdsInfo(String addr) {
+        def info = new MdsInfo()
+        info.addr = addr
+        info
+    }
+
+    private static class TestMdsBase extends ZbsPrimaryStorageMdsBase {
+        TestMdsBase(MdsInfo mdsInfo) {
+            super(mdsInfo)
+
+            restf = [
+                    syncJsonPost: { String url, Object body, Class retClass, TimeUnit unit, long timeout ->
+                        throw new OperationFailureException(operr("TEST.1000", "simulated MDS network failure"))
+                    }
+            ] as RESTFacade
+        }
+    }
+
+    private static class TestResponse extends ZbsMdsBase.AgentResponse {
+    }
+}


### PR DESCRIPTION
## Summary
CBD volume/clients anti-split-brain checks can select an MDS that is still marked Connected but is already unreachable. This change makes the synchronous ZBS MDS caller treat REST network failures as tryNext candidates instead of failing on the first selected MDS.

## Changes
- Catch sync `OperationFailureException` in `ZbsStorageController.HttpCaller.doSyncCall()` and continue to the next MDS when `tryNext` is enabled.
- Add a regression test covering first-MDS sync failure followed by a successful second-MDS `GetVolumeClientsRsp`.

## Diff Stat
```text
ZbsStorageController.java        | 19 ++++-
ZbsStorageHttpCallerCase.groovy  | 83 ++++++++++++++++++++++
2 files changed, 100 insertions(+), 2 deletions(-)
```

## Testing
- [x] `git diff --check upstream/5.5.28..HEAD`
- [ ] Container Maven test: `test-zstack --package zstack/plugin/zbs ZbsStorageHttpCallerCase` (host has no Java/Maven; will verify through backend build container on MR ref)
- [ ] CI pipeline

Resolves: ZSTAC-80595

sync from gitlab !10320