### PR TITLE
<fix>[zbs]: ZSTAC-80595 try next mds on sync failure

### DIFF
--- a/plugin/zbs/src/main/java/org/zstack/storage/zbs/ZbsMdsBase.java
+++ b/plugin/zbs/src/main/java/org/zstack/storage/zbs/ZbsMdsBase.java
@@ -76,7 +76,18 @@ public abstract class ZbsMdsBase {
     }
 
     public <T extends AgentResponse> T syncCall(final String path, final Object cmd, final Class<T> retClass, TimeUnit unit, long timeout) {
-        return restf.syncJsonPost(makeHttpPath(self.getAddr(), path), cmd, retClass, unit, timeout);
+        try {
+            return restf.syncJsonPost(makeHttpPath(self.getAddr(), path), cmd, retClass, unit, timeout);
+        } catch (OperationFailureException e) {
+            try {
+                T ret = retClass.getDeclaredConstructor().newInstance();
+                ret.setError(e.getErrorCode().getDetails());
+                return ret;
+            } catch (Exception ex) {
+                throw new OperationFailureException(operr(ORG_ZSTACK_STORAGE_ZBS_10041,
+                        "failed to instantiate zbs agent response[%s], because %s", retClass.getName(), ex.getMessage()));
+            }
+        }
     }
 
     public <T extends AgentResponse> void httpCall(final String path, final Object cmd, final Class<T> retClass, final ReturnValueCompletion<T> completion) {

--- a/test/src/test/groovy/org/zstack/test/integration/storage/primary/addon/zbs/ZbsPrimaryStorageCase.groovy
+++ b/test/src/test/groovy/org/zstack/test/integration/storage/primary/addon/zbs/ZbsPrimaryStorageCase.groovy
@@ -6,6 +6,8 @@ import org.zstack.core.cloudbus.EventCallback
 import org.zstack.core.cloudbus.EventFacade
 import org.zstack.core.db.DatabaseFacade
 import org.zstack.core.db.Q
+import org.zstack.header.errorcode.ErrorCode
+import org.zstack.header.errorcode.OperationFailureException
 import org.zstack.header.message.MessageReply
 import org.zstack.header.storage.primary.GetVolumeBackingChainFromPrimaryStorageMsg
 import org.zstack.header.storage.primary.GetVolumeBackingChainFromPrimaryStorageReply
@@ -194,6 +196,7 @@ class ZbsPrimaryStorageCase extends SubCase {
             testMdsPing()
             testCheckHostStorageConnection()
             testNegativeScenario()
+            testDeleteVolumeTriesNextMdsAfterSyncFailure()
             testAddExternalPrimaryStorageWithMalformedJsonRejectedByInterceptor()
             testDataVolumeNegativeScenario()
             testDecodeMdsUriWithSpecialPassword()
@@ -895,6 +898,35 @@ class ZbsPrimaryStorageCase extends SubCase {
             assert getUsedCapacity("lpool2") == usedCapPoolBefore
             assert getUsedCapacity() == usedCapPsBefore
         }
+    }
+
+    void testDeleteVolumeTriesNextMdsAfterSyncFailure() {
+        AtomicInteger getVolumeClientsCallCount = new AtomicInteger(0)
+        List<String> getVolumeClientsMds = Collections.synchronizedList(new ArrayList<>())
+        env.simulator(ZbsStorageController.GET_VOLUME_CLIENTS_PATH) { HttpEntity<String> e, EnvSpec spec ->
+            def cmd = JSONObjectUtil.toObject(e.body, ZbsStorageController.GetVolumeClientsCmd.class)
+            getVolumeClientsMds.add(cmd.addr)
+            if (getVolumeClientsCallCount.incrementAndGet() == 1) {
+                throw new OperationFailureException(new ErrorCode("TEST.1000", "test error", "simulated MDS network failure"))
+            }
+
+            return new ZbsStorageController.GetVolumeClientsRsp()
+        }
+
+        VolumeInventory volume = createDataVolume {
+            name = "delete-after-mds-sync-failure"
+            diskOfferingUuid = diskOffering.uuid
+            primaryStorageUuid = ps.uuid
+        } as VolumeInventory
+
+        deleteVolume(volume.uuid)
+
+        assert getVolumeClientsCallCount.get() == 2 :
+                "deleteVolume expunge should retry GET_VOLUME_CLIENTS on next MDS after sync failure: expectedCalls=2 actualCalls=${getVolumeClientsCallCount.get()} mds=${getVolumeClientsMds}"
+        assert getVolumeClientsMds.toSet().size() == 2 :
+                "deleteVolume expunge should use two different MDS nodes after first sync failure: expectedDistinctMds=2 actualMds=${getVolumeClientsMds}"
+
+        env.cleanSimulatorHandlers()
     }
 
     void testNegativeScenario() {


### PR DESCRIPTION
## Summary
- Convert ZBS MDS sync REST `OperationFailureException` into a failed `AgentResponse`.
- Let the existing `if (!ret.isSuccess())` retry branch try the next MDS instead of aborting on the first unreachable MDS.
- Keep zstack MR focused on production code only; the regression test is moved to premium.

## Testing
- `git -C zstack diff --check upstream/5.5.28..HEAD`
- Combined container test will run after the paired premium MR is created.

## Note
- Replaces the earlier zstack MR `!10320`; it is intentionally left open for manual closure.

sync from gitlab !10323