### PR TITLE
<feature>[zwatch]: backport alarm optimize api to 5.5.28

### DIFF
--- a/conf/db/upgrade/V5.5.28__schema.sql
+++ b/conf/db/upgrade/V5.5.28__schema.sql
@@ -200,3 +200,22 @@ WHERE NOT EXISTS (
 
 ALTER TABLE `zstack`.`ConsoleProxyAgentVO` ADD COLUMN `consoleProxyOverriddenIpv4` varchar(255) DEFAULT NULL;
 ALTER TABLE `zstack`.`ConsoleProxyAgentVO` ADD COLUMN `consoleProxyOverriddenIpv6` varchar(255) DEFAULT NULL;
+
+ALTER TABLE `zstack`.`AlarmVO` ADD COLUMN `recoveryDuration` int unsigned DEFAULT NULL;
+ALTER TABLE `zstack`.`AlarmVO` ADD COLUMN `recoveryThreshold` int unsigned DEFAULT NULL;
+
+CREATE TABLE IF NOT EXISTS `zstack`.`AlarmResourceStateVO` (
+    `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+    `alarmUuid` varchar(32) NOT NULL,
+    `identifyLabel` varchar(191) NOT NULL,
+    `resourceUuid` varchar(32) DEFAULT NULL,
+    `resourceType` varchar(256) DEFAULT NULL,
+    `status` varchar(32) NOT NULL,
+    `lastStatusChangeTime` bigint(20) DEFAULT NULL,
+    `lastOpDate` timestamp ON UPDATE CURRENT_TIMESTAMP,
+    `createDate` timestamp,
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `ukAlarmUuidIdentifyLabel` (`alarmUuid`, `identifyLabel`, `resourceUuid`),
+    KEY `idxAlarmResourceStateVOresourceUuid` (`resourceUuid`),
+    CONSTRAINT `fkAlarmResourceStateVOAlarmVO` FOREIGN KEY (`alarmUuid`) REFERENCES `AlarmVO` (`uuid`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;

--- a/sdk/src/main/java/SourceClassMap.java
+++ b/sdk/src/main/java/SourceClassMap.java
@@ -863,6 +863,7 @@ public class SourceClassMap {
 			put("org.zstack.zwatch.alarm.AlarmDataAckInventory", "org.zstack.sdk.zwatch.alarm.AlarmDataAckInventory");
 			put("org.zstack.zwatch.alarm.AlarmInventory", "org.zstack.sdk.zwatch.alarm.AlarmInventory");
 			put("org.zstack.zwatch.alarm.AlarmLabelInventory", "org.zstack.sdk.zwatch.alarm.AlarmLabelInventory");
+			put("org.zstack.zwatch.alarm.AlarmResourceStateInventory", "org.zstack.sdk.zwatch.alarm.AlarmResourceStateInventory");
 			put("org.zstack.zwatch.alarm.AlarmState", "org.zstack.sdk.zwatch.alarm.AlarmState");
 			put("org.zstack.zwatch.alarm.AlarmStatus", "org.zstack.sdk.zwatch.alarm.AlarmStatus");
 			put("org.zstack.zwatch.alarm.AlertDataAckInventory", "org.zstack.sdk.zwatch.alarm.AlertDataAckInventory");
@@ -1781,6 +1782,7 @@ public class SourceClassMap {
 			put("org.zstack.sdk.zwatch.alarm.AlarmDataAckInventory", "org.zstack.zwatch.alarm.AlarmDataAckInventory");
 			put("org.zstack.sdk.zwatch.alarm.AlarmInventory", "org.zstack.zwatch.alarm.AlarmInventory");
 			put("org.zstack.sdk.zwatch.alarm.AlarmLabelInventory", "org.zstack.zwatch.alarm.AlarmLabelInventory");
+			put("org.zstack.sdk.zwatch.alarm.AlarmResourceStateInventory", "org.zstack.zwatch.alarm.AlarmResourceStateInventory");
 			put("org.zstack.sdk.zwatch.alarm.AlarmState", "org.zstack.zwatch.alarm.AlarmState");
 			put("org.zstack.sdk.zwatch.alarm.AlarmStatus", "org.zstack.zwatch.alarm.AlarmStatus");
 			put("org.zstack.sdk.zwatch.alarm.AlertDataAckInventory", "org.zstack.zwatch.alarm.AlertDataAckInventory");

--- a/sdk/src/main/java/org/zstack/sdk/zwatch/alarm/AlarmInventory.java
+++ b/sdk/src/main/java/org/zstack/sdk/zwatch/alarm/AlarmInventory.java
@@ -110,6 +110,22 @@ public class AlarmInventory  {
         return this.enableRecovery;
     }
 
+    public java.lang.Integer recoveryDuration;
+    public void setRecoveryDuration(java.lang.Integer recoveryDuration) {
+        this.recoveryDuration = recoveryDuration;
+    }
+    public java.lang.Integer getRecoveryDuration() {
+        return this.recoveryDuration;
+    }
+
+    public java.lang.Integer recoveryThreshold;
+    public void setRecoveryThreshold(java.lang.Integer recoveryThreshold) {
+        this.recoveryThreshold = recoveryThreshold;
+    }
+    public java.lang.Integer getRecoveryThreshold() {
+        return this.recoveryThreshold;
+    }
+
     public java.sql.Timestamp createDate;
     public void setCreateDate(java.sql.Timestamp createDate) {
         this.createDate = createDate;

--- a/sdk/src/main/java/org/zstack/sdk/zwatch/alarm/AlarmResourceStateInventory.java
+++ b/sdk/src/main/java/org/zstack/sdk/zwatch/alarm/AlarmResourceStateInventory.java
@@ -1,0 +1,79 @@
+package org.zstack.sdk.zwatch.alarm;
+
+import org.zstack.sdk.zwatch.alarm.AlarmStatus;
+
+public class AlarmResourceStateInventory  {
+
+    public long id;
+    public void setId(long id) {
+        this.id = id;
+    }
+    public long getId() {
+        return this.id;
+    }
+
+    public java.lang.String alarmUuid;
+    public void setAlarmUuid(java.lang.String alarmUuid) {
+        this.alarmUuid = alarmUuid;
+    }
+    public java.lang.String getAlarmUuid() {
+        return this.alarmUuid;
+    }
+
+    public java.lang.String identifyLabel;
+    public void setIdentifyLabel(java.lang.String identifyLabel) {
+        this.identifyLabel = identifyLabel;
+    }
+    public java.lang.String getIdentifyLabel() {
+        return this.identifyLabel;
+    }
+
+    public java.lang.String resourceUuid;
+    public void setResourceUuid(java.lang.String resourceUuid) {
+        this.resourceUuid = resourceUuid;
+    }
+    public java.lang.String getResourceUuid() {
+        return this.resourceUuid;
+    }
+
+    public java.lang.String resourceType;
+    public void setResourceType(java.lang.String resourceType) {
+        this.resourceType = resourceType;
+    }
+    public java.lang.String getResourceType() {
+        return this.resourceType;
+    }
+
+    public AlarmStatus status;
+    public void setStatus(AlarmStatus status) {
+        this.status = status;
+    }
+    public AlarmStatus getStatus() {
+        return this.status;
+    }
+
+    public java.lang.Long lastStatusChangeTime;
+    public void setLastStatusChangeTime(java.lang.Long lastStatusChangeTime) {
+        this.lastStatusChangeTime = lastStatusChangeTime;
+    }
+    public java.lang.Long getLastStatusChangeTime() {
+        return this.lastStatusChangeTime;
+    }
+
+    public java.sql.Timestamp createDate;
+    public void setCreateDate(java.sql.Timestamp createDate) {
+        this.createDate = createDate;
+    }
+    public java.sql.Timestamp getCreateDate() {
+        return this.createDate;
+    }
+
+    public java.sql.Timestamp lastOpDate;
+    public void setLastOpDate(java.sql.Timestamp lastOpDate) {
+        this.lastOpDate = lastOpDate;
+    }
+    public java.sql.Timestamp getLastOpDate() {
+        return this.lastOpDate;
+    }
+
+}

--- a/sdk/src/main/java/org/zstack/sdk/zwatch/alarm/CreateAlarmAction.java
+++ b/sdk/src/main/java/org/zstack/sdk/zwatch/alarm/CreateAlarmAction.java
@@ -64,6 +64,12 @@ public class CreateAlarmAction extends AbstractAction {
     @Param(required = false, nonempty = false, nullElements = false, emptyString = true, noTrim = false)
     public java.lang.Boolean enableRecovery = false;
 
+    @Param(required = false, nonempty = false, nullElements = false, emptyString = true, numberRange = {1L,31536000L}, noTrim = false)
+    public java.lang.Integer recoveryDuration;
+
+    @Param(required = false, nonempty = false, nullElements = false, emptyString = true, numberRange = {1L,100L}, noTrim = false)
+    public java.lang.Integer recoveryThreshold;
+
     @Param(required = false, validValues = {"Emergent","Important","Normal"}, nonempty = false, nullElements = false, emptyString = true, noTrim = false)
     public java.lang.String emergencyLevel = "Important";
 

--- a/sdk/src/main/java/org/zstack/sdk/zwatch/alarm/QueryAlarmResourceStateAction.java
+++ b/sdk/src/main/java/org/zstack/sdk/zwatch/alarm/QueryAlarmResourceStateAction.java
@@ -1,0 +1,75 @@
+package org.zstack.sdk.zwatch.alarm;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.zstack.sdk.*;
+
+public class QueryAlarmResourceStateAction extends QueryAction {
+
+    private static final HashMap<String, Parameter> parameterMap = new HashMap<>();
+
+    private static final HashMap<String, Parameter> nonAPIParameterMap = new HashMap<>();
+
+    public static class Result {
+        public ErrorCode error;
+        public org.zstack.sdk.zwatch.alarm.QueryAlarmResourceStateResult value;
+
+        public Result throwExceptionIfError() {
+            if (error != null) {
+                throw new ApiException(
+                    String.format("error[code: %s, description: %s, details: %s, globalErrorCode: %s]", error.code, error.description, error.details, error.globalErrorCode)    
+                );
+            }
+            
+            return this;
+        }
+    }
+
+
+
+    private Result makeResult(ApiResult res) {
+        Result ret = new Result();
+        if (res.error != null) {
+            ret.error = res.error;
+            return ret;
+        }
+        
+        org.zstack.sdk.zwatch.alarm.QueryAlarmResourceStateResult value = res.getResult(org.zstack.sdk.zwatch.alarm.QueryAlarmResourceStateResult.class);
+        ret.value = value == null ? new org.zstack.sdk.zwatch.alarm.QueryAlarmResourceStateResult() : value; 
+
+        return ret;
+    }
+
+    public Result call() {
+        ApiResult res = ZSClient.call(this);
+        return makeResult(res);
+    }
+
+    public void call(final Completion<Result> completion) {
+        ZSClient.call(this, new InternalCompletion() {
+            @Override
+            public void complete(ApiResult res) {
+                completion.complete(makeResult(res));
+            }
+        });
+    }
+
+    protected Map<String, Parameter> getParameterMap() {
+        return parameterMap;
+    }
+
+    protected Map<String, Parameter> getNonAPIParameterMap() {
+        return nonAPIParameterMap;
+    }
+
+    protected RestInfo getRestInfo() {
+        RestInfo info = new RestInfo();
+        info.httpMethod = "GET";
+        info.path = "/zwatch/alarms/resource-states";
+        info.needSession = true;
+        info.needPoll = false;
+        info.parameterName = "";
+        return info;
+    }
+
+}

--- a/sdk/src/main/java/org/zstack/sdk/zwatch/alarm/QueryAlarmResourceStateResult.java
+++ b/sdk/src/main/java/org/zstack/sdk/zwatch/alarm/QueryAlarmResourceStateResult.java
@@ -1,0 +1,22 @@
+package org.zstack.sdk.zwatch.alarm;
+
+
+
+public class QueryAlarmResourceStateResult {
+    public java.util.List inventories;
+    public void setInventories(java.util.List inventories) {
+        this.inventories = inventories;
+    }
+    public java.util.List getInventories() {
+        return this.inventories;
+    }
+
+    public java.lang.Long total;
+    public void setTotal(java.lang.Long total) {
+        this.total = total;
+    }
+    public java.lang.Long getTotal() {
+        return this.total;
+    }
+
+}

--- a/sdk/src/main/java/org/zstack/sdk/zwatch/alarm/UpdateAlarmAction.java
+++ b/sdk/src/main/java/org/zstack/sdk/zwatch/alarm/UpdateAlarmAction.java
@@ -52,6 +52,12 @@ public class UpdateAlarmAction extends AbstractAction {
     @Param(required = false, nonempty = false, nullElements = false, emptyString = true, noTrim = false)
     public java.lang.Boolean enableRecovery;
 
+    @Param(required = false, nonempty = false, nullElements = false, emptyString = true, numberRange = {1L,31536000L}, noTrim = false)
+    public java.lang.Integer recoveryDuration;
+
+    @Param(required = false, nonempty = false, nullElements = false, emptyString = true, numberRange = {1L,100L}, noTrim = false)
+    public java.lang.Integer recoveryThreshold;
+
     @Param(required = false, validValues = {"Emergent","Important","Normal"}, nonempty = false, nullElements = false, emptyString = true, noTrim = false)
     public java.lang.String emergencyLevel;
 

--- a/testlib/src/main/java/org/zstack/testlib/ApiHelper.groovy
+++ b/testlib/src/main/java/org/zstack/testlib/ApiHelper.groovy
@@ -56092,6 +56092,35 @@ abstract class ApiHelper {
     }
 
 
+    def queryAlarmResourceState(@DelegatesTo(strategy = Closure.OWNER_FIRST, value = org.zstack.sdk.zwatch.alarm.QueryAlarmResourceStateAction.class) Closure c) {
+        def a = new org.zstack.sdk.zwatch.alarm.QueryAlarmResourceStateAction()
+        a.sessionId = Test.currentEnvSpec?.session?.uuid
+        c.resolveStrategy = Closure.OWNER_FIRST
+        c.delegate = a
+        c()
+
+        a.conditions = a.conditions.collect { it.toString() }
+
+
+        if (System.getProperty("apipath") != null) {
+            if (a.apiId == null) {
+                a.apiId = Platform.uuid
+            }
+
+            def tracker = new ApiPathTracker(a.apiId)
+            def out = errorOut(a.call())
+            def path = tracker.getApiPath()
+            if (!path.isEmpty()) {
+                Test.apiPaths[a.class.name] = path.join(" --->\n")
+            }
+
+            return out
+        } else {
+            return errorOut(a.call())
+        }
+    }
+
+
     def queryAlertDataAck(@DelegatesTo(strategy = Closure.OWNER_FIRST, value = org.zstack.sdk.zwatch.alarm.QueryAlertDataAckAction.class) Closure c) {
         def a = new org.zstack.sdk.zwatch.alarm.QueryAlertDataAckAction()
         a.sessionId = Test.currentEnvSpec?.session?.uuid


### PR DESCRIPTION
## ZSTAC-86212

### Summary
Backport the zstack-side alarm optimize API, schema, SDK, and testlib generated changes from `feature-5.5.28-alarm-optimize` to `5.5.28`.

### Changes
| Module | Change |
|--------|--------|
| `conf/db/upgrade` | Add `AlarmVO` recovery fields and `AlarmResourceStateVO` schema. |
| `sdk` | Add alarm resource state inventory and query action wiring. |
| `testlib` | Add `queryAlarmResourceState` helper wiring. |

### Impact
- Adds `AlarmVO.recoveryDuration` and `AlarmVO.recoveryThreshold`.
- Adds `AlarmResourceStateVO` table for per-resource alarm state.

### Test
- `git diff upstream/5.5.28..HEAD --check` passed.
- `mvn -pl sdk,testlib -DskipTests compile` passed.

### Related MRs
- premium MR: pending

Related: ZSTAC-86212

sync from gitlab !10329