### PR TITLE
<fix>[zbs]: ZSTAC-80595 try next mds on sync failure

### DIFF
--- a/plugin/zbs/src/main/java/org/zstack/storage/zbs/ZbsMdsBase.java
+++ b/plugin/zbs/src/main/java/org/zstack/storage/zbs/ZbsMdsBase.java
@@ -10,6 +10,7 @@ import org.zstack.header.errorcode.ErrorCode;
 import org.zstack.header.errorcode.OperationFailureException;
 import org.zstack.header.rest.JsonAsyncRESTCallback;
 import org.zstack.header.rest.RESTFacade;
+import org.zstack.utils.gson.JSONObjectUtil;
 import org.zstack.utils.ssh.Ssh;
 import org.zstack.utils.ssh.SshException;
 import org.zstack.utils.ssh.SshResult;
@@ -76,7 +77,13 @@ public abstract class ZbsMdsBase {
     }
 
     public <T extends AgentResponse> T syncCall(final String path, final Object cmd, final Class<T> retClass, TimeUnit unit, long timeout) {
-        return restf.syncJsonPost(makeHttpPath(self.getAddr(), path), cmd, retClass, unit, timeout);
+        try {
+            return restf.syncJsonPost(makeHttpPath(self.getAddr(), path), cmd, retClass, unit, timeout);
+        } catch (OperationFailureException e) {
+            T ret = JSONObjectUtil.toObject("{}", retClass);
+            ret.setError(e.getErrorCode().getDetails());
+            return ret;
+        }
     }
 
     public <T extends AgentResponse> void httpCall(final String path, final Object cmd, final Class<T> retClass, final ReturnValueCompletion<T> completion) {

--- a/test/src/test/groovy/org/zstack/test/integration/storage/primary/addon/zbs/ZbsPrimaryStorageCase.groovy
+++ b/test/src/test/groovy/org/zstack/test/integration/storage/primary/addon/zbs/ZbsPrimaryStorageCase.groovy
@@ -6,6 +6,8 @@ import org.zstack.core.cloudbus.EventCallback
 import org.zstack.core.cloudbus.EventFacade
 import org.zstack.core.db.DatabaseFacade
 import org.zstack.core.db.Q
+import org.zstack.header.errorcode.ErrorCode
+import org.zstack.header.errorcode.OperationFailureException
 import org.zstack.header.message.MessageReply
 import org.zstack.header.storage.primary.GetVolumeBackingChainFromPrimaryStorageMsg
 import org.zstack.header.storage.primary.GetVolumeBackingChainFromPrimaryStorageReply
@@ -194,6 +196,7 @@ class ZbsPrimaryStorageCase extends SubCase {
             testMdsPing()
             testCheckHostStorageConnection()
             testNegativeScenario()
+            testDeleteVolumeTriesNextMdsAfterSyncFailure()
             testAddExternalPrimaryStorageWithMalformedJsonRejectedByInterceptor()
             testDataVolumeNegativeScenario()
             testDecodeMdsUriWithSpecialPassword()
@@ -895,6 +898,35 @@ class ZbsPrimaryStorageCase extends SubCase {
             assert getUsedCapacity("lpool2") == usedCapPoolBefore
             assert getUsedCapacity() == usedCapPsBefore
         }
+    }
+
+    void testDeleteVolumeTriesNextMdsAfterSyncFailure() {
+        AtomicInteger getVolumeClientsCallCount = new AtomicInteger(0)
+        List<String> getVolumeClientsMds = Collections.synchronizedList(new ArrayList<>())
+        env.simulator(ZbsStorageController.GET_VOLUME_CLIENTS_PATH) { HttpEntity<String> e, EnvSpec spec ->
+            def cmd = JSONObjectUtil.toObject(e.body, ZbsStorageController.GetVolumeClientsCmd.class)
+            getVolumeClientsMds.add(cmd.addr)
+            if (getVolumeClientsCallCount.incrementAndGet() == 1) {
+                throw new OperationFailureException(new ErrorCode("TEST.1000", "test error", "simulated MDS network failure"))
+            }
+
+            return new ZbsStorageController.GetVolumeClientsRsp()
+        }
+
+        VolumeInventory volume = createDataVolume {
+            name = "delete-after-mds-sync-failure"
+            diskOfferingUuid = diskOffering.uuid
+            primaryStorageUuid = ps.uuid
+        } as VolumeInventory
+
+        deleteVolume(volume.uuid)
+
+        assert getVolumeClientsCallCount.get() == 2 :
+                "deleteVolume expunge should retry GET_VOLUME_CLIENTS on next MDS after sync failure: expectedCalls=2 actualCalls=${getVolumeClientsCallCount.get()} mds=${getVolumeClientsMds}"
+        assert getVolumeClientsMds.toSet().size() == 2 :
+                "deleteVolume expunge should use two different MDS nodes after first sync failure: expectedDistinctMds=2 actualMds=${getVolumeClientsMds}"
+
+        env.cleanSimulatorHandlers()
     }
 
     void testNegativeScenario() {


### PR DESCRIPTION
## Summary
CBD volume/clients anti-split-brain checks can select an MDS that is still marked Connected but is already unreachable. This change keeps the retry decision in the existing synchronous ZBS MDS caller path: REST sync failures are converted into failed agent responses, then the existing `!ret.isSuccess()` branch decides whether to try the next MDS.

## Changes
- Convert `OperationFailureException` from `ZbsMdsBase.syncCall()` into an `AgentResponse` with `error` populated.
- Reuse the existing `ZbsStorageController.HttpCaller.doSyncCall()` `!ret.isSuccess()` retry branch without changing `ZbsStorageController`.
- Add a low-level regression test covering `syncCall()` returning a failed response when REST throws.

## Diff Stat
```text
ZbsMdsBase.java      | 13 ++++++-
ZbsMdsBaseCase.groovy| 45 ++++++++++++++++++++++
2 files changed, 57 insertions(+), 1 deletion(-)
```

## Testing
- [x] `rtk git -C zstack diff --check upstream/5.5.28..HEAD`
- [x] `rtk scripts/backend-build-container/container-run --base 5.5.28 --mr zstack:10320 java-package zstack/plugin/zbs`
- [ ] `rtk scripts/backend-build-container/container-run --base 5.5.28 --mr zstack:10320 test-zstack --package zstack/plugin/zbs ZbsMdsBaseCase` did not reach the case; it was blocked during dependency resolution by unresolved `org.zstack:test-premium` commercial artifacts such as `org.zstack:billing:jar:5.5.0`.
- [ ] GitLab CI pipeline is not available yet; `gl_get_pipelines` returned `[]`.

Resolves: ZSTAC-80595

sync from gitlab !10320