### PR TITLE
[ZSTAC-86484] Backport ZSTAC-78989 to 5.4.10

### DIFF
--- a/plugin/loadBalancer/src/main/java/org/zstack/network/service/lb/LoadBalancerApiInterceptor.java
+++ b/plugin/loadBalancer/src/main/java/org/zstack/network/service/lb/LoadBalancerApiInterceptor.java
@@ -39,6 +39,7 @@ import org.zstack.network.service.vip.VipVO;
 import org.zstack.network.service.vip.VipVO_;
 import org.zstack.tag.PatternedSystemTag;
 import org.zstack.tag.TagManager;
+import org.zstack.core.upgrade.UpgradeGlobalConfig;
 import org.zstack.utils.*;
 import org.zstack.utils.function.ForEachFunction;
 import org.zstack.utils.logging.CLogger;
@@ -151,8 +152,20 @@ public class LoadBalancerApiInterceptor implements ApiMessageInterceptor, Global
             validate((APIGetCandidateVmNicsForLoadBalancerServerGroupMsg)msg);
         } else if (msg instanceof APIChangeLoadBalancerBackendServerMsg) {
             validate((APIChangeLoadBalancerBackendServerMsg)msg);
+        } else if (msg instanceof APIDeleteLoadBalancerMsg) {
+            validate((APIDeleteLoadBalancerMsg) msg);
         }
         return msg;
+    }
+
+    private void validate(APIDeleteLoadBalancerMsg msg) {
+        if (UpgradeGlobalConfig.GRAYSCALE_UPGRADE.value(Boolean.class)) {
+            LoadBalancerVO lb = dbf.findByUuid(msg.getUuid(), LoadBalancerVO.class);
+            if (lb != null && lb.getType() == LoadBalancerType.SLB) {
+                throw new ApiMessageInterceptionException(argerr(
+                        "cannot delete the standalone load balancer[uuid:%s] during grayscale upgrade", msg.getUuid()));
+            }
+        }
     }
 
     private void validate(APIDeleteAccessControlListMsg msg) {


### PR DESCRIPTION
Clone Jira: ZSTAC-86484

Original Jira: ZSTAC-78989

Source fix MR: zstack!9187

Cherry-picked commit(s): f19223a6e726

Target branch: 5.4.10

Validation: cherry-pick completed cleanly on 5.4.10. Full regression was not run locally.

sync from gitlab !10337