### PR TITLE
[5.4.10] cherry-pick ZSTAC vhost and query fixes

### DIFF
--- a/search/src/main/java/org/zstack/query/QueryFacadeImpl.java
+++ b/search/src/main/java/org/zstack/query/QueryFacadeImpl.java
@@ -347,7 +347,7 @@ public class QueryFacadeImpl extends AbstractService implements QueryFacade, Glo
         }
     }
 
-    private void handle(APIQueryMessage msg) {
+    private APIQueryReply doQuery(APIQueryMessage msg) {
         AutoQuery at = autoQueryMap.get(msg.getClass());
         if (at == null) {
             at = msg.getClass().getAnnotation(AutoQuery.class);
@@ -372,12 +372,45 @@ public class QueryFacadeImpl extends AbstractService implements QueryFacade, Glo
             if (result.inventories != null) {
                 replySetter.invoke(reply, result.inventories);
             }
-            bus.reply(msg, reply);
+            return reply;
         } catch (OperationFailureException of) {
             throw of;
         } catch (Exception e) {
             throw new CloudRuntimeException(e);
         }
+    }
+
+    private void handle(APIQueryMessage msg) {
+        thdf.syncSubmit(new SyncTask<Void>() {
+            @Override
+            public Void call() {
+                APIQueryReply reply;
+                try {
+                    reply = doQuery(msg);
+                } catch (OperationFailureException of) {
+                    reply = new APIQueryReply();
+                    reply.setError(of.getErrorCode());
+                }
+
+                bus.reply(msg, reply);
+                return null;
+            }
+
+            @Override
+            public String getName() {
+                return getSyncSignature();
+            }
+
+            @Override
+            public String getSyncSignature() {
+                return "api-query";
+            }
+
+            @Override
+            public int getSyncLevel() {
+                return getQuerySyncLevel();
+            }
+        });
     }
 
     private String toZQLConditionString(QueryCondition c) {


### PR DESCRIPTION
## Summary
Cherry-pick 5.x fixes for the new 5.4.10 ZSTAC batch.

## Included Jira
- ZSTAC-86468 via ZSTAC-80546
- ZSTAC-86449 via ZSTAC-80742

## Source MR
- zstack !8908: http://dev.zstack.io:9080/zstackio/zstack/-/merge_requests/8908
- zstack !9866: http://dev.zstack.io:9080/zstackio/zstack/-/merge_requests/9866

## Testing
- [x] git diff --check zstack/5.4.10..HEAD

Related: ZSTAC-86468 ZSTAC-86449

sync from gitlab !10343