### PR TITLE
<fix>[snapshot]: ZSV-9792 keep incomplete snapshot groups

### DIFF
--- a/compute/src/main/java/org/zstack/compute/vm/VmInstanceApiInterceptor.java
+++ b/compute/src/main/java/org/zstack/compute/vm/VmInstanceApiInterceptor.java
@@ -28,6 +28,8 @@ import org.zstack.header.storage.primary.PrimaryStorageVO;
 import org.zstack.header.storage.primary.PrimaryStorageVO_;
 import org.zstack.header.storage.snapshot.VolumeSnapshotVO;
 import org.zstack.header.storage.snapshot.VolumeSnapshotVO_;
+import org.zstack.header.storage.snapshot.group.VolumeSnapshotGroupRefVO;
+import org.zstack.header.storage.snapshot.group.VolumeSnapshotGroupRefVO_;
 import org.zstack.header.storage.snapshot.group.VolumeSnapshotGroupVO;
 import org.zstack.header.storage.snapshot.group.VolumeSnapshotGroupVO_;
 import org.zstack.header.host.HostState;
@@ -1270,6 +1272,16 @@ public class VmInstanceApiInterceptor implements ApiMessageInterceptor {
     }
 
     private void validate(APICreateVmInstanceFromVolumeSnapshotGroupMsg msg) {
+        boolean hasDeletedSnapshot = Q.New(VolumeSnapshotGroupRefVO.class)
+                .eq(VolumeSnapshotGroupRefVO_.volumeSnapshotGroupUuid, msg.getVolumeSnapshotGroupUuid())
+                .eq(VolumeSnapshotGroupRefVO_.snapshotDeleted, true)
+                .isExists();
+        if (hasDeletedSnapshot) {
+            throw new ApiMessageInterceptionException(argerr(
+                    "volume snapshot group[uuid:%s] is incomplete, cannot create vm instance from it",
+                    msg.getVolumeSnapshotGroupUuid()));
+        }
+
         String vmInstanceUuid = Q.New(VolumeSnapshotGroupVO.class).select(VolumeSnapshotGroupVO_.vmInstanceUuid)
                 .eq(VolumeSnapshotGroupVO_.uuid, msg.getVolumeSnapshotGroupUuid()).findValue();
         if (vmInstanceUuid == null) {

--- a/header/src/main/java/org/zstack/header/storage/snapshot/CreateVolumesSnapshotMsg.java
+++ b/header/src/main/java/org/zstack/header/storage/snapshot/CreateVolumesSnapshotMsg.java
@@ -18,6 +18,8 @@ public class CreateVolumesSnapshotMsg extends NeedReplyMessage implements NeedQu
 
     private boolean backupHostFileIfNeeded;
 
+    private boolean allowPartialSuccess;
+
     public String getAccountUuid() {
         return accountUuid;
     }
@@ -53,5 +55,13 @@ public class CreateVolumesSnapshotMsg extends NeedReplyMessage implements NeedQu
 
     public void setBackupHostFileIfNeeded(boolean backupHostFileIfNeeded) {
         this.backupHostFileIfNeeded = backupHostFileIfNeeded;
+    }
+
+    public boolean isAllowPartialSuccess() {
+        return allowPartialSuccess;
+    }
+
+    public void setAllowPartialSuccess(boolean allowPartialSuccess) {
+        this.allowPartialSuccess = allowPartialSuccess;
     }
 }

--- a/header/src/main/java/org/zstack/header/storage/snapshot/CreateVolumesSnapshotOverlayInnerMsg.java
+++ b/header/src/main/java/org/zstack/header/storage/snapshot/CreateVolumesSnapshotOverlayInnerMsg.java
@@ -21,6 +21,8 @@ public class CreateVolumesSnapshotOverlayInnerMsg extends NeedReplyMessage imple
 
     private boolean backupHostFileIfNeeded;
 
+    private boolean allowPartialSuccess;
+
     public List<String> getLockedVmInstanceUuids() {
         return lockedVmInstanceUuids;
     }
@@ -72,5 +74,13 @@ public class CreateVolumesSnapshotOverlayInnerMsg extends NeedReplyMessage imple
 
     public void setBackupHostFileIfNeeded(boolean backupHostFileIfNeeded) {
         this.backupHostFileIfNeeded = backupHostFileIfNeeded;
+    }
+
+    public boolean isAllowPartialSuccess() {
+        return allowPartialSuccess;
+    }
+
+    public void setAllowPartialSuccess(boolean allowPartialSuccess) {
+        this.allowPartialSuccess = allowPartialSuccess;
     }
 }

--- a/header/src/main/java/org/zstack/header/storage/snapshot/CreateVolumesSnapshotOverlayInnerReply.java
+++ b/header/src/main/java/org/zstack/header/storage/snapshot/CreateVolumesSnapshotOverlayInnerReply.java
@@ -1,5 +1,6 @@
 package org.zstack.header.storage.snapshot;
 
+import org.zstack.header.errorcode.ErrorCode;
 import org.zstack.header.message.MessageReply;
 
 import java.util.List;
@@ -10,6 +11,8 @@ import java.util.List;
 public class CreateVolumesSnapshotOverlayInnerReply extends MessageReply {
     private List<VolumeSnapshotInventory> inventories;
     private List<String> hostBackupFileUuidList;
+    private List<CreateVolumesSnapshotsJobStruct> failedSnapshotJobs;
+    private ErrorCode partialError;
 
     public List<VolumeSnapshotInventory> getInventories() {
         return inventories;
@@ -25,5 +28,21 @@ public class CreateVolumesSnapshotOverlayInnerReply extends MessageReply {
 
     public void setHostBackupFileUuidList(List<String> hostBackupFileUuidList) {
         this.hostBackupFileUuidList = hostBackupFileUuidList;
+    }
+
+    public List<CreateVolumesSnapshotsJobStruct> getFailedSnapshotJobs() {
+        return failedSnapshotJobs;
+    }
+
+    public void setFailedSnapshotJobs(List<CreateVolumesSnapshotsJobStruct> failedSnapshotJobs) {
+        this.failedSnapshotJobs = failedSnapshotJobs;
+    }
+
+    public ErrorCode getPartialError() {
+        return partialError;
+    }
+
+    public void setPartialError(ErrorCode partialError) {
+        this.partialError = partialError;
     }
 }

--- a/header/src/main/java/org/zstack/header/storage/snapshot/CreateVolumesSnapshotReply.java
+++ b/header/src/main/java/org/zstack/header/storage/snapshot/CreateVolumesSnapshotReply.java
@@ -1,5 +1,6 @@
 package org.zstack.header.storage.snapshot;
 
+import org.zstack.header.errorcode.ErrorCode;
 import org.zstack.header.message.MessageReply;
 
 import java.util.List;
@@ -10,6 +11,8 @@ import java.util.List;
 public class CreateVolumesSnapshotReply extends MessageReply {
     private List<VolumeSnapshotInventory> inventories;
     private List<String> hostBackupFileUuidList;
+    private List<CreateVolumesSnapshotsJobStruct> failedSnapshotJobs;
+    private ErrorCode partialError;
 
     public List<VolumeSnapshotInventory> getInventories() {
         return inventories;
@@ -25,5 +28,21 @@ public class CreateVolumesSnapshotReply extends MessageReply {
 
     public void setHostBackupFileUuidList(List<String> hostBackupFileUuidList) {
         this.hostBackupFileUuidList = hostBackupFileUuidList;
+    }
+
+    public List<CreateVolumesSnapshotsJobStruct> getFailedSnapshotJobs() {
+        return failedSnapshotJobs;
+    }
+
+    public void setFailedSnapshotJobs(List<CreateVolumesSnapshotsJobStruct> failedSnapshotJobs) {
+        this.failedSnapshotJobs = failedSnapshotJobs;
+    }
+
+    public ErrorCode getPartialError() {
+        return partialError;
+    }
+
+    public void setPartialError(ErrorCode partialError) {
+        this.partialError = partialError;
     }
 }

--- a/header/src/main/java/org/zstack/header/volume/APICreateVolumeSnapshotGroupMsg.java
+++ b/header/src/main/java/org/zstack/header/volume/APICreateVolumeSnapshotGroupMsg.java
@@ -119,6 +119,11 @@ public class APICreateVolumeSnapshotGroupMsg extends APICreateMessage implements
     }
 
     @Override
+    public boolean isAllowPartialSuccess() {
+        return true;
+    }
+
+    @Override
     public List<APIAuditor.Result> multiAudit(APIMessage msg, APIEvent rsp) {
         APICreateVolumeSnapshotGroupMsg cmsg = (APICreateVolumeSnapshotGroupMsg) msg;
         List<APIAuditor.Result> res = new ArrayList<>();
@@ -127,6 +132,9 @@ public class APICreateVolumeSnapshotGroupMsg extends APICreateMessage implements
 
             List<VolumeSnapshotGroupRefInventory> volumeSnapshotRefs = ((APICreateVolumeSnapshotGroupEvent) rsp).getInventory().getVolumeSnapshotRefs();
             volumeSnapshotRefs.forEach(it -> {
+                if (it.isSnapshotDeleted()) {
+                    return;
+                }
                 res.add(new APIAuditor.Result(it.getVolumeSnapshotUuid(), VolumeSnapshotVO.class));
             });
         }

--- a/header/src/main/java/org/zstack/header/volume/CreateVolumeSnapshotGroupMessage.java
+++ b/header/src/main/java/org/zstack/header/volume/CreateVolumeSnapshotGroupMessage.java
@@ -19,6 +19,10 @@ public interface CreateVolumeSnapshotGroupMessage {
         return SnapshotBackendOperation.FILE_CREATION;
     }
 
+    default boolean isAllowPartialSuccess() {
+        return false;
+    }
+
     void setVmInstance(VmInstanceInventory inventory);
     VmInstanceInventory getVmInstance();
 }

--- a/storage/src/main/java/org/zstack/storage/snapshot/group/VolumeSnapshotGroupBase.java
+++ b/storage/src/main/java/org/zstack/storage/snapshot/group/VolumeSnapshotGroupBase.java
@@ -224,6 +224,12 @@ public class VolumeSnapshotGroupBase implements VolumeSnapshotGroup {
         if (snapshots.size() < self.getSnapshotCount()) {
             logger.debug(String.format("skip snapshots not belong to origin vm[uuid:%s]", self.getVmInstanceUuid()));
         }
+        if (snapshots.isEmpty()) {
+            vmHostFileManager.cleanVmHostBackupFile(self.getUuid());
+            dbf.remove(self);
+            bus.reply(msg, reply);
+            return;
+        }
 
         SimpleFlowChain.of("delete-volume-snapshot-group")
             .then("delete-volume-snapshots", (trigger) ->

--- a/storage/src/main/java/org/zstack/storage/volume/VolumeBase.java
+++ b/storage/src/main/java/org/zstack/storage/volume/VolumeBase.java
@@ -3094,6 +3094,7 @@ public class VolumeBase extends AbstractVolume implements Volume {
         List<CreateVolumesSnapshotsJobStruct> volumesSnapshotsJobs = new ArrayList<>();
         cmsg.setAccountUuid(msg.getSession().getAccountUuid());
         cmsg.setBackupHostFileIfNeeded(true);
+        cmsg.setAllowPartialSuccess(msg.isAllowPartialSuccess());
 
         VmInstanceInventory vm = msg.getVmInstance();
         Map<String, VolumeInventory> vols = vm.getAllVolumes().stream()
@@ -3116,6 +3117,7 @@ public class VolumeBase extends AbstractVolume implements Volume {
         cmsg.setConsistentType(msg.getConsistentType());
 
         List<VolumeSnapshotInventory> inventories = new ArrayList<>();
+        List<CreateVolumesSnapshotsJobStruct> failedSnapshotJobs = new ArrayList<>();
         List<String> hostBackupFileUuidList = new ArrayList<>();
         AtomicReference<VolumeSnapshotGroupVO> groupRef = new AtomicReference<>(null);
         String resourceUuid = msg.getResourceUuid() == null ? getUuid() : msg.getResourceUuid();
@@ -3131,7 +3133,16 @@ public class VolumeBase extends AbstractVolume implements Volume {
                             return;
                         }
                         CreateVolumesSnapshotReply r = reply.castReply();
-                        inventories.addAll(r.getInventories());
+                        if (!CollectionUtils.isEmpty(r.getInventories())) {
+                            inventories.addAll(r.getInventories());
+                        }
+                        if (!CollectionUtils.isEmpty(r.getFailedSnapshotJobs())) {
+                            failedSnapshotJobs.addAll(r.getFailedSnapshotJobs());
+                        }
+                        if (r.getPartialError() != null) {
+                            logger.warn(String.format("created volume snapshot group[uuid:%s] with %s failed snapshot jobs, partial error: %s",
+                                    resourceUuid, failedSnapshotJobs.size(), r.getPartialError().getReadableDetails()));
+                        }
                         if (!CollectionUtils.isEmpty(r.getHostBackupFileUuidList())) {
                             hostBackupFileUuidList.addAll(r.getHostBackupFileUuidList());
                         }
@@ -3142,6 +3153,8 @@ public class VolumeBase extends AbstractVolume implements Volume {
             .then(Flow.of("persist-snapshot-group")
                 .handle(trigger -> {
                     List<VolumeSnapshotGroupRefVO> refs = new ArrayList<>();
+                    Map<String, VolumeSnapshotInventory> invByVolumeUuid = inventories.stream()
+                            .collect(Collectors.toMap(VolumeSnapshotInventory::getVolumeUuid, inv -> inv, (oldValue, newValue) -> oldValue));
                     VolumeSnapshotGroupVO group = new VolumeSnapshotGroupVO();
                     group.setUuid(resourceUuid);
                     group.setSnapshotCount(cmsg.getVolumeSnapshotJobs().size());
@@ -3149,17 +3162,28 @@ public class VolumeBase extends AbstractVolume implements Volume {
                     group.setDescription(msg.getDescription());
                     group.setVmInstanceUuid(vm.getUuid());
                     group.setAccountUuid(msg.getSession().getAccountUuid());
-                    for (VolumeSnapshotInventory inv : inventories) {
+                    for (CreateVolumesSnapshotsJobStruct job : cmsg.getVolumeSnapshotJobs()) {
+                        VolumeInventory vol = vols.get(job.getVolumeUuid());
+                        VolumeSnapshotInventory inv = invByVolumeUuid.get(job.getVolumeUuid());
                         VolumeSnapshotGroupRefVO ref = new VolumeSnapshotGroupRefVO();
-                        ref.setVolumeUuid(inv.getVolumeUuid());
-                        ref.setVolumeName(vols.get(inv.getVolumeUuid()).getName());
-                        ref.setVolumeType(inv.getVolumeType());
+                        ref.setVolumeUuid(job.getVolumeUuid());
+                        ref.setVolumeName(vol.getName());
+                        ref.setVolumeType(inv == null ? vol.getType() : inv.getVolumeType());
                         ref.setVolumeSnapshotGroupUuid(group.getUuid());
-                        ref.setVolumeSnapshotUuid(inv.getUuid());
-                        ref.setVolumeSnapshotName(inv.getName());
-                        ref.setVolumeSnapshotInstallPath(inv.getPrimaryStorageInstallPath());
-                        ref.setDeviceId(vols.get(inv.getVolumeUuid()).getDeviceId());
-                        ref.setVolumeLastAttachDate(vols.get(inv.getVolumeUuid()).getLastAttachDate());
+                        if (inv == null) {
+                            ref.setVolumeSnapshotUuid(job.getVolumeSnapshotStruct() == null ?
+                                    job.getResourceUuid() : job.getVolumeSnapshotStruct().getCurrent().getUuid());
+                            ref.setVolumeSnapshotName(job.getName());
+                            ref.setVolumeSnapshotInstallPath(job.getVolumeSnapshotStruct() == null ?
+                                    null : job.getVolumeSnapshotStruct().getCurrent().getPrimaryStorageInstallPath());
+                            ref.setSnapshotDeleted(true);
+                        } else {
+                            ref.setVolumeSnapshotUuid(inv.getUuid());
+                            ref.setVolumeSnapshotName(inv.getName());
+                            ref.setVolumeSnapshotInstallPath(inv.getPrimaryStorageInstallPath());
+                        }
+                        ref.setDeviceId(vol.getDeviceId());
+                        ref.setVolumeLastAttachDate(vol.getLastAttachDate());
                         refs.add(ref);
                     }
 


### PR DESCRIPTION
## Summary
ZSV-9792 addresses single-volume snapshot residue after snapshot group creation fails. The create API can now persist an incomplete but deletable snapshot group instead of losing the cleanup entry.

## Changes
- Add partial-success fields to batched snapshot create messages and replies.
- Enable partial success for APICreateVolumeSnapshotGroupMsg only.
- Persist group refs for all requested volumes; failed refs are marked snapshotDeleted=true while retaining volume and snapshot metadata.
- Prevent creating a VM from an incomplete snapshot group.
- Delete all-deleted snapshot groups cleanly.

## Validation Summary
Core zstack modules compiled successfully in local checks. Whitespace checks passed. Premium integration verification is covered by the paired premium MR; local premium case execution was blocked by HTTP Nexus dependency resolution for 5.1.0 artifacts.

## Records
Troubleshoot records are stored under the ZSV-9792 topic directory in the root workspace.

Resolves: ZSV-9792

sync from gitlab !10350