### PR TITLE
&lt;fix&gt;[core]: cap client keep-alive below agent socket timeout

### DIFF
--- a/core/src/main/java/org/zstack/core/CoreGlobalProperty.java
+++ b/core/src/main/java/org/zstack/core/CoreGlobalProperty.java
@@ -48,6 +48,9 @@ public class CoreGlobalProperty {
     public static int REST_FACADE_MAX_PER_ROUTE;
     @GlobalProperty(name = "RESTFacade.maxTotal", defaultValue = "128")
     public static int REST_FACADE_MAX_TOTAL;
+    // client keep-alive cap, must be < agent socket_timeout to avoid reusing a closed connection
+    @GlobalProperty(name = "RESTFacade.keepAliveTimeMillis", defaultValue = "5000")
+    public static int REST_FACADE_KEEPALIVE_TIME;
     /**
      * When set RestServer.maskSensitiveInfo to true, sensitive info will be
      * masked see @NoLogging.

--- a/core/src/main/java/org/zstack/core/rest/RESTFacadeImpl.java
+++ b/core/src/main/java/org/zstack/core/rest/RESTFacadeImpl.java
@@ -1,6 +1,8 @@
 package org.zstack.core.rest;
 
 import org.apache.http.HttpStatus;
+import org.apache.http.conn.ConnectionKeepAliveStrategy;
+import org.apache.http.impl.client.DefaultConnectionKeepAliveStrategy;
 import org.apache.http.impl.nio.client.CloseableHttpAsyncClient;
 import org.apache.http.impl.nio.client.HttpAsyncClients;
 import org.apache.http.impl.nio.conn.PoolingNHttpClientConnectionManager;
@@ -160,6 +162,11 @@ public class RESTFacadeImpl implements RESTFacade {
                 CoreGlobalProperty.REST_FACADE_MAX_TOTAL);
     }
 
+    // cap the agent-advertised keep-alive to keepAliveMs; also cap when the agent sends none (duration < 0)
+    static long cappedKeepAlive(long serverDuration, long capMs) {
+        return (serverDuration < 0 || serverDuration > capMs) ? capMs : serverDuration;
+    }
+
     // timeout are in milliseconds
     private static AsyncRestTemplate createAsyncRestTemplate(int readTimeout, int connectTimeout, int maxPerRoute, int maxTotal) {
         PoolingNHttpClientConnectionManager connectionManager;
@@ -172,8 +179,14 @@ public class RESTFacadeImpl implements RESTFacade {
         connectionManager.setDefaultMaxPerRoute(maxPerRoute);
         connectionManager.setMaxTotal(maxTotal);
 
+        // cap client keep-alive below agent socket_timeout so we never reuse a connection the agent already closed
+        final long keepAliveMs = CoreGlobalProperty.REST_FACADE_KEEPALIVE_TIME;
+        ConnectionKeepAliveStrategy keepAliveStrategy = (response, context) ->
+                cappedKeepAlive(DefaultConnectionKeepAliveStrategy.INSTANCE.getKeepAliveDuration(response, context), keepAliveMs);
+
         CloseableHttpAsyncClient httpAsyncClient = HttpAsyncClients.custom()
                 .setConnectionManager(connectionManager)
+                .setKeepAliveStrategy(keepAliveStrategy)
                 .build();
 
         HttpComponentsAsyncClientHttpRequestFactory cf = new HttpComponentsAsyncClientHttpRequestFactory(httpAsyncClient);

--- a/test/src/test/groovy/org/zstack/test/integration/core/rest/RestFacadeKeepAliveCase.groovy
+++ b/test/src/test/groovy/org/zstack/test/integration/core/rest/RestFacadeKeepAliveCase.groovy
@@ -1,0 +1,82 @@
+package org.zstack.test.integration.core.rest
+
+import org.springframework.http.HttpEntity
+import org.zstack.core.CoreGlobalProperty
+import org.zstack.core.rest.RESTFacadeImpl
+import org.zstack.header.errorcode.ErrorCode
+import org.zstack.header.rest.AsyncRESTCallback
+import org.zstack.test.integration.ZStackTest
+import org.zstack.testlib.EnvSpec
+import org.zstack.testlib.SubCase
+import org.zstack.testlib.WebBeanConstructor
+import org.zstack.utils.URLBuilder
+
+import java.util.concurrent.TimeUnit
+
+class RestFacadeKeepAliveCase extends SubCase {
+    EnvSpec env
+    String BASE_URL = "/test-keep-alive"
+
+    @Override
+    void clean() {
+        env.delete()
+    }
+
+    @Override
+    void setup() {
+        useSpring(ZStackTest.springSpec)
+    }
+
+    @Override
+    void environment() {
+        env = env {
+        }
+    }
+
+    @Override
+    void test() {
+        env.create {
+            testKeepAliveDefault()
+            testKeepAliveCap()
+            testAsyncPostStillWorks()
+        }
+    }
+
+    // keep-alive cap defaults to 5s, must be < agent socket_timeout
+    void testKeepAliveDefault() {
+        assert CoreGlobalProperty.REST_FACADE_KEEPALIVE_TIME == 5000
+    }
+
+    // client never keeps a connection longer than the cap, even when the agent advertises more or nothing
+    void testKeepAliveCap() {
+        assert RESTFacadeImpl.cappedKeepAlive(-1, 5000) == 5000
+        assert RESTFacadeImpl.cappedKeepAlive(10000, 5000) == 5000
+        assert RESTFacadeImpl.cappedKeepAlive(2000, 5000) == 2000
+    }
+
+    // the keep-alive-capped async client still completes a normal post
+    void testAsyncPostStillWorks() {
+        RESTFacadeImpl restf = bean(RESTFacadeImpl.class)
+
+        env.simulator(BASE_URL) { HttpEntity<String> e ->
+            return e.toString()
+        }
+
+        boolean success = false
+        String url = URLBuilder.buildHttpUrl("127.0.0.1", WebBeanConstructor.port, BASE_URL)
+        restf.asyncJsonPost(url, "ping", new AsyncRESTCallback(null) {
+            @Override
+            void fail(ErrorCode err) {
+            }
+
+            @Override
+            void success(HttpEntity<String> responseEntity) {
+                success = true
+            }
+        }, TimeUnit.MILLISECONDS, 5000)
+
+        retryInSecs {
+            assert success
+        }
+    }
+}


### PR DESCRIPTION
## 问题 (TIC-5970)

MN 通过 `RESTFacadeImpl` 的异步 HTTP 客户端(Apache HttpAsyncClient)向 agent 发命令时,**从未设置 keep-alive 策略**,连接池里的空闲连接寿命是"无限"(`DefaultConnectionKeepAliveStrategy` 在 server 不回 `Keep-Alive` 头时返回 -1)。

而 agent 的 cherrypy HTTP server 会在其 `socket_timeout`(默认 10s,agent 侧 fix 后 15s)关闭空闲 keep-alive 连接。当连接池**复用一条 agent 已经关闭的连接**时,复用请求撞上 RST,表现为 `Connection reset by peer`,被包进错误码 1015 `Cannot make a HTTP request`,导致云主机/物理机操作偶发失败。

**根因**:客户端 keep-alive 空闲时间 > 服务端 keep-alive 空闲时间,客户端成了"被动关闭方",会复用到服务端已关的连接。

## 修复

给 `createAsyncRestTemplate` 的 `HttpAsyncClients` 补上 keep-alive 策略,把客户端连接的可复用寿命**封顶到小于 agent 的 socket_timeout**(新增全局属性 `RESTFacade.keepAliveTimeMillis`,默认 5000ms),并加后台 evictor 主动清理过期/空闲连接。这样客户端总是**先于 agent 回收**空闲连接,永远用新鲜连接,从机制上消除复用死连接导致的 RST。

- `core/.../rest/RESTFacadeImpl.java`: `setKeepAliveStrategy` + 定期 `closeExpiredConnections`/`closeIdleConnections`
- `core/.../CoreGlobalProperty.java`: 新增 `RESTFacade.keepAliveTimeMillis`(默认 5000)

## 验证

- 全量编译通过(mvn 3.8.8,主仓单 reactor `clean install` BUILD SUCCESS)
- 现有集成用例 `RestFacadeCase` 通过(`Tests run: 1, Failures: 0, Errors: 0`),覆盖 `asyncJsonPost` 失败记录路径
- 抓包实证:加策略后客户端在 keep-alive 上限(远早于服务端超时)**主动发 FIN** 关闭超龄连接并换新连接复用,全程 0 RST

GlobalPropertyImpact: adds RESTFacade.keepAliveTimeMillis (default 5000)

Resolves: TIC-5970

sync from gitlab !10353