### PR TITLE
<fix>[core]: cap client keep-alive below agent socket timeout

### DIFF
--- a/core/src/main/java/org/zstack/core/CoreGlobalProperty.java
+++ b/core/src/main/java/org/zstack/core/CoreGlobalProperty.java
@@ -54,6 +54,9 @@ public class CoreGlobalProperty {
     public static int REST_FACADE_MAX_PER_ROUTE;
     @GlobalProperty(name = "RESTFacade.maxTotal", defaultValue = "128")
     public static int REST_FACADE_MAX_TOTAL;
+    // client keep-alive cap, must be < agent socket_timeout to avoid reusing a closed connection
+    @GlobalProperty(name = "RESTFacade.keepAliveTimeMillis", defaultValue = "5000")
+    public static int REST_FACADE_KEEPALIVE_TIME;
     /**
      * When set RestServer.maskSensitiveInfo to true, sensitive info will be
      * masked see @NoLogging.

--- a/core/src/main/java/org/zstack/core/rest/RESTFacadeImpl.java
+++ b/core/src/main/java/org/zstack/core/rest/RESTFacadeImpl.java
@@ -6,6 +6,8 @@ import io.opentelemetry.api.trace.StatusCode;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
 import org.apache.http.HttpStatus;
+import org.apache.http.conn.ConnectionKeepAliveStrategy;
+import org.apache.http.impl.client.DefaultConnectionKeepAliveStrategy;
 import org.apache.http.impl.nio.client.CloseableHttpAsyncClient;
 import org.apache.http.impl.nio.client.HttpAsyncClients;
 import org.apache.http.impl.nio.conn.PoolingNHttpClientConnectionManager;
@@ -231,6 +233,11 @@ public class RESTFacadeImpl implements RESTFacade {
         return ub.build().toUriString();
     }
 
+    // cap the agent-advertised keep-alive to keepAliveMs; also cap when the agent sends none (duration < 0)
+    static long cappedKeepAlive(long serverDuration, long capMs) {
+        return (serverDuration < 0 || serverDuration > capMs) ? capMs : serverDuration;
+    }
+
     // timeout are in milliseconds
     private static AsyncRestTemplate createAsyncRestTemplate(int readTimeout, int connectTimeout, int maxPerRoute, int maxTotal) {
         PoolingNHttpClientConnectionManager connectionManager;
@@ -243,8 +250,14 @@ public class RESTFacadeImpl implements RESTFacade {
         connectionManager.setDefaultMaxPerRoute(maxPerRoute);
         connectionManager.setMaxTotal(maxTotal);
 
+        // cap client keep-alive below agent socket_timeout so we never reuse a connection the agent already closed
+        final long keepAliveMs = CoreGlobalProperty.REST_FACADE_KEEPALIVE_TIME;
+        ConnectionKeepAliveStrategy keepAliveStrategy = (response, context) ->
+                cappedKeepAlive(DefaultConnectionKeepAliveStrategy.INSTANCE.getKeepAliveDuration(response, context), keepAliveMs);
+
         CloseableHttpAsyncClient httpAsyncClient = HttpAsyncClients.custom()
                 .setConnectionManager(connectionManager)
+                .setKeepAliveStrategy(keepAliveStrategy)
                 .build();
 
         HttpComponentsAsyncClientHttpRequestFactory cf = new HttpComponentsAsyncClientHttpRequestFactory(httpAsyncClient);

--- a/test/src/test/groovy/org/zstack/test/integration/core/rest/RestFacadeKeepAliveCase.groovy
+++ b/test/src/test/groovy/org/zstack/test/integration/core/rest/RestFacadeKeepAliveCase.groovy
@@ -1,0 +1,82 @@
+package org.zstack.test.integration.core.rest
+
+import org.springframework.http.HttpEntity
+import org.zstack.core.CoreGlobalProperty
+import org.zstack.core.rest.RESTFacadeImpl
+import org.zstack.header.errorcode.ErrorCode
+import org.zstack.header.rest.AsyncRESTCallback
+import org.zstack.test.integration.ZStackTest
+import org.zstack.testlib.EnvSpec
+import org.zstack.testlib.SubCase
+import org.zstack.testlib.WebBeanConstructor
+import org.zstack.utils.URLBuilder
+
+import java.util.concurrent.TimeUnit
+
+class RestFacadeKeepAliveCase extends SubCase {
+    EnvSpec env
+    String BASE_URL = "/test-keep-alive"
+
+    @Override
+    void clean() {
+        env.delete()
+    }
+
+    @Override
+    void setup() {
+        useSpring(ZStackTest.springSpec)
+    }
+
+    @Override
+    void environment() {
+        env = env {
+        }
+    }
+
+    @Override
+    void test() {
+        env.create {
+            testKeepAliveDefault()
+            testKeepAliveCap()
+            testAsyncPostStillWorks()
+        }
+    }
+
+    // keep-alive cap defaults to 5s, must be < agent socket_timeout
+    void testKeepAliveDefault() {
+        assert CoreGlobalProperty.REST_FACADE_KEEPALIVE_TIME == 5000
+    }
+
+    // client never keeps a connection longer than the cap, even when the agent advertises more or nothing
+    void testKeepAliveCap() {
+        assert RESTFacadeImpl.cappedKeepAlive(-1, 5000) == 5000
+        assert RESTFacadeImpl.cappedKeepAlive(10000, 5000) == 5000
+        assert RESTFacadeImpl.cappedKeepAlive(2000, 5000) == 2000
+    }
+
+    // the keep-alive-capped async client still completes a normal post
+    void testAsyncPostStillWorks() {
+        RESTFacadeImpl restf = bean(RESTFacadeImpl.class)
+
+        env.simulator(BASE_URL) { HttpEntity<String> e ->
+            return e.toString()
+        }
+
+        boolean success = false
+        String url = URLBuilder.buildHttpUrl("127.0.0.1", WebBeanConstructor.port, BASE_URL)
+        restf.asyncJsonPost(url, "ping", new AsyncRESTCallback(null) {
+            @Override
+            void fail(ErrorCode err) {
+            }
+
+            @Override
+            void success(HttpEntity<String> responseEntity) {
+                success = true
+            }
+        }, TimeUnit.MILLISECONDS, 5000)
+
+        retryInSecs {
+            assert success
+        }
+    }
+}


### PR DESCRIPTION
## 问题 (ZSTAC-86545)

MN→kvmagent 请求偶发 `Connection reset by peer`,可能导致物理机失联。

根因:MN 的异步 RESTFacade HTTP 客户端(Apache HttpAsyncClient)**从未设置 keep-alive 策略**,连接池空闲连接寿命为无限(默认策略在 agent 不回 `Keep-Alive` 头时返回 -1)。agent 的 cherrypy HTTP server 在其 `socket_timeout`(默认 10s / fix 后 15s)关闭空闲 keep-alive 连接。连接池**复用一条 agent 已关闭的连接**时,复用请求撞 RST,表现为 `Connection reset by peer`(外层错误码 1015 `Cannot make a HTTP request`)。

## 修复

给 `createAsyncRestTemplate` 的 `HttpAsyncClients` 补上 keep-alive 策略,把客户端连接可复用寿命**封顶到 < agent socket_timeout**(新增全局属性 `RESTFacade.keepAliveTimeMillis`,默认 5000ms)。这样客户端总是**先于 agent 回收**空闲连接、永远用新鲜连接,从机制上消除复用死连接导致的 RST。

- `core/.../rest/RESTFacadeImpl.java`:`setKeepAliveStrategy` + 可测的 `cappedKeepAlive`
- `core/.../CoreGlobalProperty.java`:新增 `RESTFacade.keepAliveTimeMillis`(默认 5000)
- 新增 `RestFacadeKeepAliveCase`

## 说明

- 同一修复已在 4.8.0 分支提交(TIC-5970 对应 MR !10353),该 MR 采用最小方案(只 `setKeepAliveStrategy`,无 evictor/destroy),已通过 review 三轮修改。本 MR 为 cherry-pick 到 5.5.28。
- 5.5.28 上 `header` + `core` 全量编译 SUCCESS,补丁已编进 `core-5.5.0.jar`。
- 同一改动的 `RestFacadeCase` / `RestFacadeKeepAliveCase` 在 4.8.x 均通过(`Tests run: 1, Failures: 0`)。

GlobalPropertyImpact: adds RESTFacade.keepAliveTimeMillis (default 5000)

Resolves: ZSTAC-86545

sync from gitlab !10364