### PR TITLE
<fix>[volume-cache]: ZSTAC-85194 remove cache store mount path field

### DIFF
--- a/conf/db/upgrade/V5.5.28__schema.sql
+++ b/conf/db/upgrade/V5.5.28__schema.sql
@@ -104,7 +104,6 @@ CREATE TABLE IF NOT EXISTS `HostCacheStoreVO` (
     `hostUuid`          VARCHAR(32)    NOT NULL,
     `name`              VARCHAR(255)   DEFAULT NULL,
     `description`       VARCHAR(2048)  DEFAULT NULL,
-    `mountPoint`        VARCHAR(255)   DEFAULT NULL,
     `devices`           TEXT,
     `state`             VARCHAR(32)    NOT NULL,
     `status`            VARCHAR(32)    NOT NULL,

--- a/header/src/main/java/org/zstack/header/volumeCache/HostCacheStoreInventory.java
+++ b/header/src/main/java/org/zstack/header/volumeCache/HostCacheStoreInventory.java
@@ -17,7 +17,6 @@ public class HostCacheStoreInventory implements Serializable {
     private String hostUuid;
     private String name;
     private String description;
-    private String mountPoint;
 
     @Queryable(mappingClass = HostCacheStoreCapacityInventory.class,
             joinColumn = @JoinColumn(name = "uuid", referencedColumnName = "totalCapacity"))
@@ -48,7 +47,6 @@ public class HostCacheStoreInventory implements Serializable {
         inv.setHostUuid(vo.getHostUuid());
         inv.setName(vo.getName());
         inv.setDescription(vo.getDescription());
-        inv.setMountPoint(vo.getMountPoint());
         if (vo.getCapacity() != null) {
             inv.setTotalCapacity(vo.getCapacity().getTotalCapacity());
             inv.setAvailableCapacity(vo.getCapacity().getAvailableCapacity());
@@ -117,14 +115,6 @@ public class HostCacheStoreInventory implements Serializable {
 
     public void setDescription(String description) {
         this.description = description;
-    }
-
-    public String getMountPoint() {
-        return mountPoint;
-    }
-
-    public void setMountPoint(String mountPoint) {
-        this.mountPoint = mountPoint;
     }
 
     public long getTotalCapacity() {

--- a/header/src/main/java/org/zstack/header/volumeCache/HostCacheStoreInventoryDoc_zh_cn.groovy
+++ b/header/src/main/java/org/zstack/header/volumeCache/HostCacheStoreInventoryDoc_zh_cn.groovy
@@ -35,12 +35,6 @@ doc {
 		since "5.5.28"
 	}
 	field {
-		name "mountPoint"
-		desc "缓存池挂载路径"
-		type "String"
-		since "5.5.28"
-	}
-	field {
 		name "totalCapacity"
 		desc "主机缓存存储的总容量，单位为字节"
 		type "long"

--- a/header/src/main/java/org/zstack/header/volumeCache/HostCacheStoreVO.java
+++ b/header/src/main/java/org/zstack/header/volumeCache/HostCacheStoreVO.java
@@ -35,9 +35,6 @@ public class HostCacheStoreVO extends ResourceVO implements ToInventory {
     @Column
     private String description;
 
-    @Column(length = 255)
-    private String mountPoint;
-
     @Column(columnDefinition = "TEXT")
     @Convert(converter = HostCacheStoreDeviceRefsConverter.class)
     private List<HostCacheStoreDeviceRef> devices;
@@ -93,14 +90,6 @@ public class HostCacheStoreVO extends ResourceVO implements ToInventory {
 
     public void setDescription(String description) {
         this.description = description;
-    }
-
-    public String getMountPoint() {
-        return mountPoint;
-    }
-
-    public void setMountPoint(String mountPoint) {
-        this.mountPoint = mountPoint;
     }
 
     public List<HostCacheStoreDeviceRef> getDevices() {

--- a/header/src/main/java/org/zstack/header/volumeCache/HostCacheStoreVO_.java
+++ b/header/src/main/java/org/zstack/header/volumeCache/HostCacheStoreVO_.java
@@ -11,7 +11,6 @@ public class HostCacheStoreVO_ extends ResourceVO_ {
     public static volatile SingularAttribute<HostCacheStoreVO, String> hostUuid;
     public static volatile SingularAttribute<HostCacheStoreVO, String> name;
     public static volatile SingularAttribute<HostCacheStoreVO, String> description;
-    public static volatile SingularAttribute<HostCacheStoreVO, String> mountPoint;
     public static volatile SingularAttribute<HostCacheStoreVO, HostCacheStoreState> state;
     public static volatile SingularAttribute<HostCacheStoreVO, HostCacheStoreStatus> status;
     public static volatile SingularAttribute<HostCacheStoreVO, Timestamp> createDate;

--- a/plugin/kvm/src/main/java/org/zstack/kvm/KVMAgentCommands.java
+++ b/plugin/kvm/src/main/java/org/zstack/kvm/KVMAgentCommands.java
@@ -5430,45 +5430,38 @@ public class KVMAgentCommands {
 
     public static class InitPoolCmd extends AgentCommand {
         public String poolUuid;
-        public String mountPoint;
         public boolean force;
         public List<String> devices;
     }
 
     public static class ConnectPoolCmd extends AgentCommand {
         public String poolUuid;
-        public String mountPoint;
         public boolean force;
     }
 
     public static class ExtendPoolCmd extends AgentCommand {
         public String poolUuid;
-        public String mountPoint;
         public boolean force;
         public List<String> devices;
     }
 
     public static class DeletePoolCmd extends AgentCommand {
         public String poolUuid;
-        public String mountPoint;
         public boolean force;
     }
 
     public static class CheckPoolCmd extends AgentCommand {
         public String poolUuid;
-        public String mountPoint;
         public boolean force;
     }
 
     public static class GetPoolCapacityCmd extends AgentCommand {
         public String poolUuid;
-        public String mountPoint;
         public boolean force;
     }
 
     public static class GCPoolCmd extends AgentCommand {
         public String poolUuid;
-        public String mountPoint;
         public boolean force;
         public List<String> inUseCacheUuids;
     }
@@ -5511,7 +5504,6 @@ public class KVMAgentCommands {
 
     public static class PoolRsp extends AgentResponse {
         public String poolUuid;
-        public String mountPoint;
     }
 
     public static class PoolHealthRsp extends AgentResponse {

--- a/sdk/src/main/java/org/zstack/sdk/CreateHostCacheStoreAction.java
+++ b/sdk/src/main/java/org/zstack/sdk/CreateHostCacheStoreAction.java
@@ -37,9 +37,6 @@ public class CreateHostCacheStoreAction extends AbstractAction {
     @Param(required = true, nonempty = true, nullElements = false, emptyString = true, noTrim = false)
     public java.util.List devices;
 
-    @Param(required = true, maxLength = 1024, nonempty = false, nullElements = false, emptyString = true, noTrim = false)
-    public java.lang.String mountPoint;
-
     @Param(required = false)
     public java.lang.String resourceUuid;
 

--- a/sdk/src/main/java/org/zstack/sdk/HostCacheStoreInventory.java
+++ b/sdk/src/main/java/org/zstack/sdk/HostCacheStoreInventory.java
@@ -37,14 +37,6 @@ public class HostCacheStoreInventory  {
         return this.description;
     }
 
-    public java.lang.String mountPoint;
-    public void setMountPoint(java.lang.String mountPoint) {
-        this.mountPoint = mountPoint;
-    }
-    public java.lang.String getMountPoint() {
-        return this.mountPoint;
-    }
-
     public long totalCapacity;
     public void setTotalCapacity(long totalCapacity) {
         this.totalCapacity = totalCapacity;


### PR DESCRIPTION
## Summary
ZSTAC-85194 removes the user-configurable host cache store mount path from the public/API and backend contracts. The mount path is now owned by the agent-side pool implementation.

## Changes
```text
conf/db/upgrade/V5.5.28__schema.sql                           |  1 -
.../zstack/header/volumeCache/HostCacheStoreInventory.java    | 10 ----------
.../volumeCache/HostCacheStoreInventoryDoc_zh_cn.groovy       |  6 ------
.../java/org/zstack/header/volumeCache/HostCacheStoreVO.java  | 11 -----------
.../java/org/zstack/header/volumeCache/HostCacheStoreVO_.java |  1 -
plugin/kvm/src/main/java/org/zstack/kvm/KVMAgentCommands.java |  8 --------
.../main/java/org/zstack/sdk/CreateHostCacheStoreAction.java  |  3 ---
sdk/src/main/java/org/zstack/sdk/HostCacheStoreInventory.java |  8 --------
8 files changed, 48 deletions(-)
```

## Testing
- [x] `rtk git -C zstack diff --check upstream/5.5.28..HEAD`
- [x] Branch rebased onto `upstream/5.5.28`
- [ ] Full Java compile / CI pipeline

Resolves: ZSTAC-85194

sync from gitlab !10374