### PR TITLE
[5.4.10][ZSTAC-86350] <fix>[identity]: restrict APIQueryAccountMsg to admin-only in RBAC

### DIFF
--- a/header/src/main/java/org/zstack/header/identity/RBACInfo.java
+++ b/header/src/main/java/org/zstack/header/identity/RBACInfo.java
@@ -12,6 +12,7 @@ public class RBACInfo implements RBACDescription {
                 .name("identity")
                 .adminOnlyAPIs(
                         APICreateAccountMsg.class,
+                        APIQueryAccountMsg.class,
                         APIShareResourceMsg.class,
                         APIRevokeResourceSharingMsg.class,
                         APIUpdateQuotaMsg.class,

--- a/test/src/test/groovy/org/zstack/test/unittest/identity/TestAPIQueryAccountMsgRBACCase.java
+++ b/test/src/test/groovy/org/zstack/test/unittest/identity/TestAPIQueryAccountMsgRBACCase.java
@@ -1,0 +1,43 @@
+package org.zstack.test.unittest.identity;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.zstack.header.identity.APIQueryAccountMsg;
+import org.zstack.header.identity.RBACInfo;
+import org.zstack.header.identity.rbac.RBAC;
+
+public class TestAPIQueryAccountMsgRBACCase {
+
+    @Before
+    public void setUp() {
+        RBAC.permissions.clear();
+    }
+
+    @Test
+    public void testAPIQueryAccountMsgIsAdminOnly() {
+        RBACInfo rbacInfo = new RBACInfo();
+        rbacInfo.permissions();
+
+        boolean isAdminOnly = RBAC.isAdminOnlyAPI(APIQueryAccountMsg.class.getName());
+        Assert.assertTrue(
+                "APIQueryAccountMsg should be admin-only to prevent privilege escalation, " +
+                "but it is currently accessible to normal IAM users via the wildcard normalAPIs pattern",
+                isAdminOnly
+        );
+    }
+
+    @Test
+    public void testAPIQueryAccountMsgNotInNormalAPIs() {
+        RBACInfo rbacInfo = new RBACInfo();
+        rbacInfo.permissions();
+
+        String apiName = APIQueryAccountMsg.class.getName();
+        boolean isInNormalOnly = RBAC.permissions.stream()
+                .anyMatch(p -> p.getNormalAPIs().contains(apiName) && !p.getAdminOnlyAPIs().contains(apiName));
+        Assert.assertFalse(
+                "APIQueryAccountMsg should NOT be accessible as a normal API",
+                isInNormalOnly
+        );
+    }
+}


### PR DESCRIPTION
## Root Cause
`RBACInfo.java` defines identity APIs with `normalAPIs("org.zstack.header.identity.**")`. On 5.4.10, `APIQueryAccountMsg` was not listed in `adminOnlyAPIs`, so low-privilege IAM users could get this account query API through the wildcard normal permission.

## Solution
Backport the ZSTAC-83960 / MR !9533 fix to 5.4.10:
- Add `APIQueryAccountMsg.class` to the identity `adminOnlyAPIs` list.
- Add `TestAPIQueryAccountMsgRBACCase` to guard the RBAC classification.

## Testing
- [x] RED source gate before fix: `APIQueryAccountMsg.class` missing from the `adminOnlyAPIs` block, exit code 1.
- [x] GREEN source gate after fix: `APIQueryAccountMsg.class` present in the `adminOnlyAPIs` block, exit code 0.
- [x] `git diff --check`
- [ ] `mvn -f test/pom.xml -Dtest=org.zstack.test.unittest.identity.TestAPIQueryAccountMsgRBACCase test -DfailIfNoTests=false` blocked locally: missing `org.zstack:*:5.4.0` artifacts in local Maven repository.
- [ ] `mvn compile -pl header -am -Dmaven.test.skip=true` blocked locally: JDK17 lacks JAXB classes required by this 5.4.10 branch (`javax.xml.bind.annotation.adapters.XmlAdapter`).

## Jira
Resolves: ZSTAC-86350
Ref: ZSTAC-83960, ZSTAC-86027

sync from gitlab !10380