### PR TITLE
<fix>[core]: select callback ip by target

### DIFF
--- a/core/src/main/java/org/zstack/core/Platform.java
+++ b/core/src/main/java/org/zstack/core/Platform.java
@@ -1388,12 +1388,7 @@ public class Platform {
     }
 
     public static String getManagementServerIpForRemote(String remoteIp) {
-        if (StringUtils.isBlank(remoteIp)) {
-            return getManagementServerIp();
-        }
-
-        remoteIp = normalizeManagementIp(remoteIp);
-        return selectManagementServerIpForRemote(remoteIp, getRouteSourceIp(remoteIp));
+        return selectManagementServerIpForRemote(remoteIp, null);
     }
 
     public static String selectManagementServerIpForRemote(String remoteIp, String routeSourceIp) {
@@ -1404,7 +1399,7 @@ public class Platform {
         remoteIp = normalizeManagementIp(remoteIp);
         routeSourceIp = normalizeManagementIp(routeSourceIp);
         if (IPv6NetworkUtils.isIpv6Address(remoteIp)) {
-            if (IPv6NetworkUtils.isIpv6Address(routeSourceIp)) {
+            if (IPv6NetworkUtils.isIpv6Address(routeSourceIp) && isManagementServerIp(routeSourceIp)) {
                 return routeSourceIp;
             }
             String ip6 = getManagementServerIp6();
@@ -1412,7 +1407,7 @@ public class Platform {
         }
 
         if (NetworkUtils.isIpv4Address(remoteIp)) {
-            if (NetworkUtils.isIpv4Address(routeSourceIp)) {
+            if (NetworkUtils.isIpv4Address(routeSourceIp) && isManagementServerIp(routeSourceIp)) {
                 return routeSourceIp;
             }
             String ip4 = getManagementServerIp4();
@@ -1420,6 +1415,17 @@ public class Platform {
         }
 
         return getManagementServerIp();
+    }
+
+    private static boolean isManagementServerIp(String ip) {
+        if (StringUtils.isBlank(ip)) {
+            return false;
+        }
+
+        String normalizedIp = normalizeManagementIp(ip);
+        return getManagementServerIps().stream()
+                .map(Platform::normalizeManagementIp)
+                .anyMatch(normalizedIp::equals);
     }
 
     public static String selectManagementServerIp(Collection<InetAddress> addresses) {

--- a/core/src/main/java/org/zstack/core/Platform.java
+++ b/core/src/main/java/org/zstack/core/Platform.java
@@ -1387,6 +1387,41 @@ public class Platform {
         return null;
     }
 
+    public static String getManagementServerIpForRemote(String remoteIp) {
+        if (StringUtils.isBlank(remoteIp)) {
+            return getManagementServerIp();
+        }
+
+        remoteIp = normalizeManagementIp(remoteIp);
+        return selectManagementServerIpForRemote(remoteIp, getRouteSourceIp(remoteIp));
+    }
+
+    public static String selectManagementServerIpForRemote(String remoteIp, String routeSourceIp) {
+        if (StringUtils.isBlank(remoteIp)) {
+            return getManagementServerIp();
+        }
+
+        remoteIp = normalizeManagementIp(remoteIp);
+        routeSourceIp = normalizeManagementIp(routeSourceIp);
+        if (IPv6NetworkUtils.isIpv6Address(remoteIp)) {
+            if (IPv6NetworkUtils.isIpv6Address(routeSourceIp)) {
+                return routeSourceIp;
+            }
+            String ip6 = getManagementServerIp6();
+            return ip6 == null ? getManagementServerIp() : ip6;
+        }
+
+        if (NetworkUtils.isIpv4Address(remoteIp)) {
+            if (NetworkUtils.isIpv4Address(routeSourceIp)) {
+                return routeSourceIp;
+            }
+            String ip4 = getManagementServerIp4();
+            return ip4 == null ? getManagementServerIp() : ip4;
+        }
+
+        return getManagementServerIp();
+    }
+
     public static String selectManagementServerIp(Collection<InetAddress> addresses) {
         String ipv4 = null;
         String ipv6 = null;

--- a/core/src/main/java/org/zstack/core/rest/RESTFacadeImpl.java
+++ b/core/src/main/java/org/zstack/core/rest/RESTFacadeImpl.java
@@ -50,12 +50,14 @@ import org.zstack.utils.Utils;
 import org.zstack.utils.gson.JSONObjectUtil;
 import org.zstack.utils.logging.CLogger;
 import org.zstack.utils.network.IPv6NetworkUtils;
+import org.zstack.utils.network.NetworkUtils;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
@@ -225,6 +227,31 @@ public class RESTFacadeImpl implements RESTFacade {
         UriComponentsBuilder ub = UriComponentsBuilder.fromHttpUrl(buildBaseUrl(hostName, port, path));
         ub.path(RESTConstant.CALLBACK_PATH);
         return ub.build().toUriString();
+    }
+
+    public static String selectCallbackUrl(String requestUrl, Map<String, String> headers, String defaultCallbackUrl, int port, String path) {
+        if (headers != null && headers.keySet().stream().anyMatch(RESTConstant.CALLBACK_URL::equalsIgnoreCase)) {
+            return defaultCallbackUrl;
+        }
+
+        String host = extractRequestHost(requestUrl);
+        if (host == null) {
+            return defaultCallbackUrl;
+        }
+
+        if (!NetworkUtils.isIpv4Address(host) && !IPv6NetworkUtils.isIpv6Address(host)) {
+            return defaultCallbackUrl;
+        }
+
+        return buildCallbackUrl(Platform.getManagementServerIpForRemote(host), port, path);
+    }
+
+    private static String extractRequestHost(String requestUrl) {
+        try {
+            return IPv6NetworkUtils.stripHostUrlBrackets(new URI(requestUrl).getHost());
+        } catch (URISyntaxException | IllegalArgumentException e) {
+            return null;
+        }
     }
 
     public static String buildSendCommandUrl(String hostName, int port, String path) {
@@ -415,7 +442,7 @@ public class RESTFacadeImpl implements RESTFacade {
         HttpHeaders requestHeaders = new HttpHeaders();
         requestHeaders.setContentLength(body.length());
         requestHeaders.set(RESTConstant.TASK_UUID, taskUuid);
-        requestHeaders.set(RESTConstant.CALLBACK_URL, callbackUrl);
+        requestHeaders.set(RESTConstant.CALLBACK_URL, selectCallbackUrl(url, headers, callbackUrl, port, path));
         MediaType JSON = MediaType.parseMediaType("application/json; charset=utf-8");
         requestHeaders.setContentType(JSON);
         if (headers != null) {

--- a/plugin/ceph/src/main/java/org/zstack/storage/ceph/backup/CephBackupStorageMonBase.java
+++ b/plugin/ceph/src/main/java/org/zstack/storage/ceph/backup/CephBackupStorageMonBase.java
@@ -201,7 +201,7 @@ public class CephBackupStorageMonBase extends CephMonBase {
                             callbackChecker.setUsername(getSelf().getSshUsername());
                             callbackChecker.setPassword(getSelf().getSshPassword());
                             callbackChecker.setPort(getSelf().getSshPort());
-                            callbackChecker.setCallbackIp(Platform.getManagementServerIp());
+                            callbackChecker.setCallbackIp(Platform.getManagementServerIpForRemote(getSelf().getHostname()));
                             callbackChecker.setCallBackPort(CloudBusGlobalProperty.HTTP_PORT);
 
                             AnsibleRunner runner = new AnsibleRunner();

--- a/plugin/ceph/src/main/java/org/zstack/storage/ceph/primary/CephPrimaryStorageMonBase.java
+++ b/plugin/ceph/src/main/java/org/zstack/storage/ceph/primary/CephPrimaryStorageMonBase.java
@@ -198,7 +198,7 @@ public class CephPrimaryStorageMonBase extends CephMonBase {
                             callbackChecker.setUsername(getSelf().getSshUsername());
                             callbackChecker.setPassword(getSelf().getSshPassword());
                             callbackChecker.setPort(getSelf().getSshPort());
-                            callbackChecker.setCallbackIp(Platform.getManagementServerIp());
+                            callbackChecker.setCallbackIp(Platform.getManagementServerIpForRemote(getSelf().getHostname()));
                             callbackChecker.setCallBackPort(CloudBusGlobalProperty.HTTP_PORT);
 
                             AnsibleRunner runner = new AnsibleRunner();

--- a/plugin/kvm/src/main/java/org/zstack/kvm/KVMHost.java
+++ b/plugin/kvm/src/main/java/org/zstack/kvm/KVMHost.java
@@ -6083,7 +6083,7 @@ public class KVMHost extends HostBase implements Host {
                         callbackChecker.setUsername(getSelf().getUsername());
                         callbackChecker.setPassword(getSelf().getPassword());
                         callbackChecker.setPort(getSelf().getPort());
-                        callbackChecker.setCallbackIp(Platform.getManagementServerIp());
+                        callbackChecker.setCallbackIp(Platform.getManagementServerIpForRemote(getSelf().getManagementIp()));
                         callbackChecker.setCallBackPort(CloudBusGlobalProperty.HTTP_PORT);
 
                         KvmHostConfigChecker kvmHostConfigChecker = new KvmHostConfigChecker();
@@ -6107,7 +6107,7 @@ public class KVMHost extends HostBase implements Host {
                             hostTcpConnectionCallbackChecker.setUsername(getSelf().getUsername());
                             hostTcpConnectionCallbackChecker.setPassword(getSelf().getPassword());
                             hostTcpConnectionCallbackChecker.setPort(getSelf().getPort());
-                            hostTcpConnectionCallbackChecker.setCallbackIp(Platform.getManagementServerIp());
+                            hostTcpConnectionCallbackChecker.setCallbackIp(Platform.getManagementServerIpForRemote(getSelf().getManagementIp()));
                             hostTcpConnectionCallbackChecker.setCallBackPort(KVMGlobalProperty.TCP_SERVER_PORT);
                             runner.installChecker(hostTcpConnectionCallbackChecker);
                         }

--- a/plugin/sftpBackupStorage/src/main/java/org/zstack/storage/backup/sftp/SftpBackupStorage.java
+++ b/plugin/sftpBackupStorage/src/main/java/org/zstack/storage/backup/sftp/SftpBackupStorage.java
@@ -392,7 +392,7 @@ public class SftpBackupStorage extends BackupStorageBase {
         callbackChecker.setUsername(getSelf().getUsername());
         callbackChecker.setPassword(getSelf().getPassword());
         callbackChecker.setPort(getSelf().getSshPort());
-        callbackChecker.setCallbackIp(Platform.getManagementServerIp());
+        callbackChecker.setCallbackIp(Platform.getManagementServerIpForRemote(getSelf().getHostname()));
         callbackChecker.setCallBackPort(CloudBusGlobalProperty.HTTP_PORT);
 
         AnsibleRunner runner = new AnsibleRunner();

--- a/plugin/zbs/src/main/java/org/zstack/storage/zbs/ZbsPrimaryStorageMdsBase.java
+++ b/plugin/zbs/src/main/java/org/zstack/storage/zbs/ZbsPrimaryStorageMdsBase.java
@@ -112,7 +112,7 @@ public class ZbsPrimaryStorageMdsBase extends ZbsMdsBase {
                             callBackChecker.setUsername(getSelf().getUsername());
                             callBackChecker.setPassword(getSelf().getPassword());
                             callBackChecker.setPort(getSelf().getPort());
-                            callBackChecker.setCallbackIp(Platform.getManagementServerIp());
+                            callBackChecker.setCallbackIp(Platform.getManagementServerIpForRemote(getSelf().getAddr()));
                             callBackChecker.setCallBackPort(CloudBusGlobalProperty.HTTP_PORT);
 
                             AnsibleRunner runner = new AnsibleRunner();

--- a/test/src/test/groovy/org/zstack/test/integration/core/ManagementNetworkIpv6Case.groovy
+++ b/test/src/test/groovy/org/zstack/test/integration/core/ManagementNetworkIpv6Case.groovy
@@ -249,6 +249,26 @@ class ManagementNetworkIpv6Case extends SubCase {
                 "http://[2001:db8::1]:8080/zstack${RESTConstant.COMMAND_CHANNEL_PATH}"
     }
 
+    void testRestFacadeSelectsCallbackUrlByTargetIpVersion() {
+        withManagementServerIpProperties([
+                "management.server.ip" : IPV4,
+                "management.server.ip6": IPV6,
+        ]) {
+            String defaultCallbackUrl = "http://${IPV4}:${REST_PORT}/zstack${RESTConstant.CALLBACK_PATH}"
+
+            assert RESTFacadeImpl.selectCallbackUrl(
+                    "http://[${IPV6_2}]:7070/host/ping", [:], defaultCallbackUrl, REST_PORT, "zstack") ==
+                    "http://[${IPV6}]:${REST_PORT}/zstack${RESTConstant.CALLBACK_PATH}"
+            assert RESTFacadeImpl.selectCallbackUrl(
+                    "http://host.example.com:7070/host/ping", [:], defaultCallbackUrl, REST_PORT, "zstack") ==
+                    defaultCallbackUrl
+            assert RESTFacadeImpl.selectCallbackUrl(
+                    "http://[${IPV6_2}]:7070/host/ping",
+                    [(RESTConstant.CALLBACK_URL): "http://override.example.com/callback"],
+                    defaultCallbackUrl, REST_PORT, "zstack") == defaultCallbackUrl
+        }
+    }
+
     void testSshTargetUsesRawIpv6Host() {
         assert SshShell.formatSshTarget("root", IPV4) == "root@192.168.1.10"
         assert SshShell.formatSshTarget("root", IPV6) == "root@2001:db8::1"
@@ -354,6 +374,25 @@ class ManagementNetworkIpv6Case extends SubCase {
                 "management.server.ip6": IPV6,
         ]) {
             assert Platform.getManagementServerIps() == [IPV4, IPV6]
+        }
+    }
+
+    void testSelectManagementServerIpForRemote() {
+        withManagementServerIpProperties([
+                "management.server.ip" : IPV4,
+                "management.server.ip6": IPV6,
+        ]) {
+            assert Platform.selectManagementServerIpForRemote(IPV6_2, null) == IPV6
+            assert Platform.selectManagementServerIpForRemote(IPV6_2, "2001:db8::88") == "2001:db8::88"
+            assert Platform.selectManagementServerIpForRemote("host.example.com", null) == IPV4
+        }
+
+        withManagementServerIpProperties([
+                "management.server.ip" : IPV6,
+                "management.server.ip4": IPV4,
+        ]) {
+            assert Platform.selectManagementServerIpForRemote("192.168.1.20", null) == IPV4
+            assert Platform.selectManagementServerIpForRemote("192.168.1.20", "192.168.1.88") == "192.168.1.88"
         }
     }
 

--- a/test/src/test/groovy/org/zstack/test/integration/core/ManagementNetworkIpv6Case.groovy
+++ b/test/src/test/groovy/org/zstack/test/integration/core/ManagementNetworkIpv6Case.groovy
@@ -383,7 +383,7 @@ class ManagementNetworkIpv6Case extends SubCase {
                 "management.server.ip6": IPV6,
         ]) {
             assert Platform.selectManagementServerIpForRemote(IPV6_2, null) == IPV6
-            assert Platform.selectManagementServerIpForRemote(IPV6_2, "2001:db8::88") == "2001:db8::88"
+            assert Platform.selectManagementServerIpForRemote(IPV6_2, "2001:db8::88") == IPV6
             assert Platform.selectManagementServerIpForRemote("host.example.com", null) == IPV4
         }
 
@@ -392,7 +392,7 @@ class ManagementNetworkIpv6Case extends SubCase {
                 "management.server.ip4": IPV4,
         ]) {
             assert Platform.selectManagementServerIpForRemote("192.168.1.20", null) == IPV4
-            assert Platform.selectManagementServerIpForRemote("192.168.1.20", "192.168.1.88") == "192.168.1.88"
+            assert Platform.selectManagementServerIpForRemote("192.168.1.20", "192.168.1.88") == IPV4
         }
     }
 


### PR DESCRIPTION
Root cause:
Dual-stack MN keeps management.server.ip as the primary address and stores the secondary family in management.server.ip4/ip6. Some callback paths always used management.server.ip, so IPv6 resources could receive an IPv4 callback address, or IPv4 resources could receive an IPv6 callback address.

Fix:
- Select REST callback URL by request target IP version.
- Select callback checker IP by remote resource address family for KVM, Ceph, SFTP BS, and ZBS MDS.
- Keep explicit callback headers unchanged.

Verification:
- mvn -pl core,plugin/kvm,plugin/ceph,plugin/sftpBackupStorage,plugin/zbs -am -DskipTests compile
- cd test && mvn test -Djacoco.skip=true -Dtest=ManagementNetworkIpv6Case

sync from gitlab !10385