### PR TITLE
<feature>[ai]: refresh AI model cache SDK

### DIFF
--- a/sdk/src/main/java/org/zstack/sdk/GetAiHostModelCacheCapacityResult.java
+++ b/sdk/src/main/java/org/zstack/sdk/GetAiHostModelCacheCapacityResult.java
@@ -3,11 +3,11 @@ package org.zstack.sdk;
 
 
 public class GetAiHostModelCacheCapacityResult {
-    public java.util.List<org.zstack.sdk.AiHostCacheStorageInventory> inventories;
-    public void setInventories(java.util.List<org.zstack.sdk.AiHostCacheStorageInventory> inventories) {
+    public java.util.List inventories;
+    public void setInventories(java.util.List inventories) {
         this.inventories = inventories;
     }
-    public java.util.List<org.zstack.sdk.AiHostCacheStorageInventory> getInventories() {
+    public java.util.List getInventories() {
         return this.inventories;
     }
 

--- a/sdk/src/main/java/org/zstack/sdk/QueryAiHostModelCacheResult.java
+++ b/sdk/src/main/java/org/zstack/sdk/QueryAiHostModelCacheResult.java
@@ -3,11 +3,11 @@ package org.zstack.sdk;
 
 
 public class QueryAiHostModelCacheResult {
-    public java.util.List<org.zstack.sdk.AiHostModelCacheInventory> inventories;
-    public void setInventories(java.util.List<org.zstack.sdk.AiHostModelCacheInventory> inventories) {
+    public java.util.List inventories;
+    public void setInventories(java.util.List inventories) {
         this.inventories = inventories;
     }
-    public java.util.List<org.zstack.sdk.AiHostModelCacheInventory> getInventories() {
+    public java.util.List getInventories() {
         return this.inventories;
     }
 

--- a/sdk/src/main/java/org/zstack/sdk/RefreshAiHostModelCacheResult.java
+++ b/sdk/src/main/java/org/zstack/sdk/RefreshAiHostModelCacheResult.java
@@ -3,11 +3,11 @@ package org.zstack.sdk;
 
 
 public class RefreshAiHostModelCacheResult {
-    public java.util.List<org.zstack.sdk.AiHostCacheStorageInventory> inventories;
-    public void setInventories(java.util.List<org.zstack.sdk.AiHostCacheStorageInventory> inventories) {
+    public java.util.List inventories;
+    public void setInventories(java.util.List inventories) {
         this.inventories = inventories;
     }
-    public java.util.List<org.zstack.sdk.AiHostCacheStorageInventory> getInventories() {
+    public java.util.List getInventories() {
         return this.inventories;
     }
 


### PR DESCRIPTION
## Summary
- Refresh generated Java SDK files for AI model cache APIs.
- Keep `runMavenProfile sdk` output clean for AI inference template upgrade MRs.

## Validation
- `git diff --check HEAD~1..HEAD`
- generated files match local `runMavenProfile sdk` output from the full premium build

Jira: http://jira.zstack.io/browse/ZSTAC-86068

sync from gitlab !10389