### PR TITLE
<fix>[volume-cache]: pass cache devices on delete

### DIFF
--- a/plugin/kvm/src/main/java/org/zstack/kvm/KVMAgentCommands.java
+++ b/plugin/kvm/src/main/java/org/zstack/kvm/KVMAgentCommands.java
@@ -5452,6 +5452,7 @@ public class KVMAgentCommands {
         public String poolUuid;
         public String mountPoint;
         public boolean force;
+        public List<String> devices;
     }
 
     public static class CheckPoolCmd extends AgentCommand {


### PR DESCRIPTION
## Summary
Resolves: ZSTAC-85952

Add cache device paths to `DeletePoolCmd` so HostCacheStore can send persisted devices to kvmagent delete operations for exact LVM filter cleanup.

## Changes
- Add `devices` to `KVMAgentCommands.DeletePoolCmd`.
- Keep `ConnectPoolCmd` unchanged; connect/reconnect no longer appends LVM filter entries.

## Testing
- [x] `git -C zstack diff --check upstream/5.5.28..HEAD`
- [x] `ZSTACK_MAVEN_CACHE_FULL_BUILD_THRESHOLD=0 rtk scripts/backend-build-container/container-run --base 5.5.28 --mr zstack:10388 --mr premium:14558 --mr zstack-utility:7417 test-premium --package premium/test-premium HostCacheStoreLifecycleCase`

## Related MRs
- premium: pending new MR
- zstack-utility: pending new MR

sync from gitlab !10392