### PR TITLE
<feature>[ai]: refresh SDK for vLLM template upgrade

### DIFF
--- a/sdk/src/main/java/org/zstack/sdk/GetAiHostModelCacheCapacityResult.java
+++ b/sdk/src/main/java/org/zstack/sdk/GetAiHostModelCacheCapacityResult.java
@@ -3,11 +3,11 @@ package org.zstack.sdk;
 
 
 public class GetAiHostModelCacheCapacityResult {
-    public java.util.List<org.zstack.sdk.AiHostCacheStorageInventory> inventories;
-    public void setInventories(java.util.List<org.zstack.sdk.AiHostCacheStorageInventory> inventories) {
+    public java.util.List inventories;
+    public void setInventories(java.util.List inventories) {
         this.inventories = inventories;
     }
-    public java.util.List<org.zstack.sdk.AiHostCacheStorageInventory> getInventories() {
+    public java.util.List getInventories() {
         return this.inventories;
     }
 

--- a/sdk/src/main/java/org/zstack/sdk/QueryAiHostModelCacheResult.java
+++ b/sdk/src/main/java/org/zstack/sdk/QueryAiHostModelCacheResult.java
@@ -3,11 +3,11 @@ package org.zstack.sdk;
 
 
 public class QueryAiHostModelCacheResult {
-    public java.util.List<org.zstack.sdk.AiHostModelCacheInventory> inventories;
-    public void setInventories(java.util.List<org.zstack.sdk.AiHostModelCacheInventory> inventories) {
+    public java.util.List inventories;
+    public void setInventories(java.util.List inventories) {
         this.inventories = inventories;
     }
-    public java.util.List<org.zstack.sdk.AiHostModelCacheInventory> getInventories() {
+    public java.util.List getInventories() {
         return this.inventories;
     }
 

--- a/sdk/src/main/java/org/zstack/sdk/RefreshAiHostModelCacheResult.java
+++ b/sdk/src/main/java/org/zstack/sdk/RefreshAiHostModelCacheResult.java
@@ -3,11 +3,11 @@ package org.zstack.sdk;
 
 
 public class RefreshAiHostModelCacheResult {
-    public java.util.List<org.zstack.sdk.AiHostCacheStorageInventory> inventories;
-    public void setInventories(java.util.List<org.zstack.sdk.AiHostCacheStorageInventory> inventories) {
+    public java.util.List inventories;
+    public void setInventories(java.util.List inventories) {
         this.inventories = inventories;
     }
-    public java.util.List<org.zstack.sdk.AiHostCacheStorageInventory> getInventories() {
+    public java.util.List getInventories() {
         return this.inventories;
     }
 


### PR DESCRIPTION
## Summary
- Refresh generated Java SDK files for AI model cache APIs.
- Linked with premium vLLM/vLLM-Ascend template upgrade MR: http://dev.zstack.io:9080/zstackio/premium/-/merge_requests/14544

## Validation
- `git diff --check HEAD~1..HEAD`
- generated files match local `runMavenProfile sdk` output from the full premium build

Jira: http://jira.zstack.io/browse/ZSTAC-86068

sync from gitlab !10391