### PR TITLE
ZSTAC-86444 backport external-storage split-brain guard

### DIFF
--- a/header/src/main/java/org/zstack/header/storage/addon/primary/PrimaryStorageNodeSvc.java
+++ b/header/src/main/java/org/zstack/header/storage/addon/primary/PrimaryStorageNodeSvc.java
@@ -13,7 +13,7 @@ public interface PrimaryStorageNodeSvc {
 
     void deactivate(String installPath, String protocol, ActiveVolumeClient client, Completion comp);
 
-    void blacklist(String installPath, String protocol, HostInventory h, Completion comp);
+    void blacklist(String installPath, String protocol, HostInventory h);
 
     String getActivePath(BaseVolumeInfo v, HostInventory h, boolean shareable);
     BaseVolumeInfo getActiveVolumeInfo(String activePath, HostInventory h, boolean shareable);

--- a/plugin/expon/src/main/java/org/zstack/expon/ExponStorageController.java
+++ b/plugin/expon/src/main/java/org/zstack/expon/ExponStorageController.java
@@ -614,14 +614,13 @@ public class ExponStorageController implements PrimaryStorageControllerSvc, Prim
     }
 
     @Override
-    public void blacklist(String installPath, String protocol, HostInventory h, Completion comp) {
+    public void blacklist(String installPath, String protocol, HostInventory h) {
         logger.debug(String.format("blacklisting volume[path: %s, protocol:%s] on host[uuid:%s, ip:%s]",
                 installPath, protocol, h.getUuid(), h.getManagementIp()));
 
         UssGatewayModule uss = getUssGateway(VolumeProtocol.valueOf(protocol), h.getManagementIp());
         VolumeModule exponVol = apiHelper.getVolume(getVolIdFromPath(installPath));
         apiHelper.addVolumePathToBlacklist(buildExponVolumeBoundPath(uss, exponVol.getVolumeName()));
-        comp.success();
     }
 
     @Override

--- a/plugin/externalStorage/src/main/java/org/zstack/externalStorage/primary/kvm/ExternalPrimaryStorageKvmFactory.java
+++ b/plugin/externalStorage/src/main/java/org/zstack/externalStorage/primary/kvm/ExternalPrimaryStorageKvmFactory.java
@@ -334,6 +334,7 @@ public class ExternalPrimaryStorageKvmFactory implements KVMHostConnectExtension
     @Override
     public void beforeStartVmOnKvm(KVMHostInventory host, VmInstanceSpec spec, KVMAgentCommands.StartVmCmd cmd) {
         List<VolumeInventory> vols = getManagerExclusiveVolume(spec);
+        ErrorCode[] deactivateErr = new ErrorCode[1];
 
         for (VolumeInventory vol : vols) {
             PrimaryStorageNodeSvc nodeSvc = extPsFactory.getNodeSvc(vol.getPrimaryStorageUuid());
@@ -359,20 +360,31 @@ public class ExternalPrimaryStorageKvmFactory implements KVMHostConnectExtension
                                 clientHost.getUuid(), clientHost.getManagementIp(),
                                 host.getUuid(), host.getManagementIp()));
 
+                        deactivateErr[0] = null;
                         nodeSvc.deactivate(vol.getInstallPath(), vol.getProtocol(), client, new Completion(null) {
                             @Override
                             public void success() {
+                                boolean stillActive = nodeSvc.getActiveClients(vol.getInstallPath(), vol.getProtocol()).stream()
+                                        .anyMatch(c -> client.getManagerIp().equals(c.getManagerIp()));
+                                if (stillActive) {
+                                    deactivateErr[0] = operr("deactivate reported success but volume[uuid:%s, installPath:%s] is still active on host[uuid:%s, ip:%s]",
+                                            vol.getUuid(), vol.getInstallPath(), clientHost.getUuid(), clientHost.getManagementIp());
+                                    return;
+                                }
                                 logger.info(String.format("successfully deactivate volume[uuid:%s, installPath:%s] on host[uuid:%s, ip:%s]",
                                         vol.getUuid(), vol.getInstallPath(), clientHost.getUuid(), clientHost.getManagementIp()));
                             }
 
                             @Override
                             public void fail(ErrorCode errorCode) {
-                                logger.warn(String.format("failed to deactivate volume[uuid:%s, installPath:%s] on host[uuid:%s, ip:%s], add it to blacklist",
-                                        vol.getUuid(), vol.getInstallPath(), clientHost.getUuid(), clientHost.getManagementIp()));
-                                nodeSvc.blacklist(vol.getInstallPath(), vol.getProtocol(), HostInventory.valueOf(clientHost), new NopeCompletion());
+                                deactivateErr[0] = errorCode;
                             }
                         });
+                        if (deactivateErr[0] != null) {
+                            logger.warn(String.format("failed to deactivate volume[uuid:%s, installPath:%s] on host[uuid:%s, ip:%s]: %s, add it to blacklist",
+                                    vol.getUuid(), vol.getInstallPath(), clientHost.getUuid(), clientHost.getManagementIp(), deactivateErr[0].getDetails()));
+                            nodeSvc.blacklist(vol.getInstallPath(), vol.getProtocol(), HostInventory.valueOf(clientHost));
+                        }
                     }
                 }
             });

--- a/plugin/xinfini/src/main/java/org/zstack/xinfini/XInfiniApiHelper.java
+++ b/plugin/xinfini/src/main/java/org/zstack/xinfini/XInfiniApiHelper.java
@@ -472,6 +472,11 @@ public class XInfiniApiHelper {
         } else {
             retryUtilResourceDeleted(gReq, GetBdcBdevResponse.class);
         }
+
+        if (!call(gReq, GetBdcBdevResponse.class).resourceIsDeleted()) {
+            throw new OperationFailureException(operr("bdev[id:%s] still exists after deletion polling on bdc[id:%s], " +
+                    "the old storage client may still hold the volume", bdevId, bdcId));
+        }
     }
 
     public VolumeModule rollbackSnapshot(int volId, int snapId) {

--- a/plugin/xinfini/src/main/java/org/zstack/xinfini/XInfiniStorageController.java
+++ b/plugin/xinfini/src/main/java/org/zstack/xinfini/XInfiniStorageController.java
@@ -202,18 +202,23 @@ public class XInfiniStorageController implements PrimaryStorageControllerSvc, Pr
     public void deactivate(String installPath, String protocol, HostInventory h, Completion comp) {
         logger.debug(String.format("deactivating volume[path: %s, protocol:%s] on host[uuid:%s, ip:%s]",
                 installPath, protocol, h.getUuid(), h.getManagementIp()));
-        if (VolumeProtocol.Vhost.toString().equals(protocol)) {
-            deactivateVhost(installPath, h);
-            comp.success();
-            return;
-        } else if (VolumeProtocol.iSCSI.toString().equals(protocol)) {
-            // iscsi target is shared by all hosts, we cannot control one volume on one host for now.
-            deactivateIscsi(installPath, h);
-            comp.success();
+        try {
+            if (VolumeProtocol.Vhost.toString().equals(protocol)) {
+                deactivateVhost(installPath, h);
+            } else if (VolumeProtocol.iSCSI.toString().equals(protocol)) {
+                // iscsi target is shared by all hosts, we cannot control one volume on one host for now.
+                deactivateIscsi(installPath, h);
+            } else {
+                comp.fail(operr("not supported protocol[%s] for deactivate", protocol));
+                return;
+            }
+        } catch (Exception e) {
+            comp.fail(operr("failed to deactivate volume[path:%s, protocol:%s] on host[uuid:%s, ip:%s]: %s",
+                    installPath, protocol, h.getUuid(), h.getManagementIp(), e.getMessage()));
             return;
         }
 
-        comp.fail(operr("not supported protocol[%s] for deactivate", protocol));
+        comp.success();
     }
 
     private void deactivateIscsi(String installPath, HostInventory h) {
@@ -255,7 +260,7 @@ public class XInfiniStorageController implements PrimaryStorageControllerSvc, Pr
             return;
         }
 
-        retry(() -> apiHelper.deleteBdcBdev(bdev.getSpec().getId(), bdc.getSpec().getId()));
+        retryOrThrow(() -> apiHelper.deleteBdcBdev(bdev.getSpec().getId(), bdc.getSpec().getId()));
     }
 
     @Override
@@ -271,9 +276,10 @@ public class XInfiniStorageController implements PrimaryStorageControllerSvc, Pr
     }
 
     @Override
-    public void blacklist(String installPath, String protocol, HostInventory h, Completion comp) {
-        // todo
-        comp.success();
+    public void blacklist(String installPath, String protocol, HostInventory h) {
+        throw new OperationFailureException(operr("xinfini does not support volume path isolation yet, " +
+                        "abort starting VM on host[uuid:%s, ip:%s] to prevent split-brain on volume[path:%s, protocol:%s]",
+                h.getUuid(), h.getManagementIp(), installPath, protocol));
     }
 
     @Override
@@ -1038,16 +1044,33 @@ public class XInfiniStorageController implements PrimaryStorageControllerSvc, Pr
 
 
     private void retry(Runnable r, int retry) {
-        while (retry-- > 0) {
+        try {
+            retryOrThrow(r, retry);
+        } catch (RuntimeException ignored) {
+        }
+    }
+
+    private void retryOrThrow(Runnable r) {
+        retryOrThrow(r, 3);
+    }
+
+    private void retryOrThrow(Runnable r, int retry) {
+        RuntimeException lastError = null;
+        for (int i = 0; i < retry; i++) {
             try {
                 r.run();
                 return;
-            } catch (Exception e) {
+            } catch (RuntimeException e) {
+                lastError = e;
                 logger.warn("runnable failed, try ", e);
                 try {
                     TimeUnit.SECONDS.sleep(3);
                 } catch (InterruptedException ignore) {}
             }
+        }
+
+        if (lastError != null) {
+            throw lastError;
         }
     }
 }

--- a/plugin/zbs/src/main/java/org/zstack/storage/zbs/ZbsStorageController.java
+++ b/plugin/zbs/src/main/java/org/zstack/storage/zbs/ZbsStorageController.java
@@ -145,8 +145,7 @@ public class ZbsStorageController implements PrimaryStorageControllerSvc, Primar
     }
 
     @Override
-    public void blacklist(String installPath, String protocol, HostInventory h, Completion comp) {
-        comp.success();
+    public void blacklist(String installPath, String protocol, HostInventory h) {
     }
 
     @Override


### PR DESCRIPTION
Root cause:

VM start on a new host could continue after the old storage client failed to deactivate or silently remained attached. On xinfini Vhost volumes this can leave the old QEMU and new QEMU using the same bdev.

Fix:

- Report xinfini deactivate and bdev-delete failures instead of swallowing them.
- Verify the bdev is really deleted after deletion polling.
- Re-query active clients after deactivate reports success and fall back to blacklist when the old client is still active.
- Make `PrimaryStorageNodeSvc.blacklist` synchronous so blacklist failures propagate out of `beforeStartVmOnKvm` and abort VM start.
- Adapt xinfini, expon and zbs blacklist implementations to the new signature.

Verification:

- `git diff --check`
- `mvn -pl header,plugin/externalStorage,plugin/xinfini,plugin/expon,plugin/zbs -am -DskipTests compile`

Notes:

- Backported behavior from `2ad18a5ad1`, `57fe48cd27`, `e2d4f68bc4`.
- Source integration test changes were not forced into this MR because the target 5.4.10 test file layout differs and the pick conflicts as modify/delete.

Jira: ZSTAC-86444
Related: ZSTAC-85124

sync from gitlab !10399