### PR TITLE
<fix>[search]: stabilize paginated query order

### DIFF
--- a/search/src/main/java/org/zstack/query/MysqlQueryBuilderImpl3.java
+++ b/search/src/main/java/org/zstack/query/MysqlQueryBuilderImpl3.java
@@ -729,7 +729,15 @@ public class MysqlQueryBuilderImpl3 implements Component, QueryBuilder, GlobalAp
                             throw new IllegalArgumentException(String.format("illegal sortBy[%s], entity[%s] doesn't have this field", msg.getSortBy(), info.entityClass.getName()));
                         }
 
-                        ret = String.format("%s order by %s.%s %s", ret, entityName, msg.getSortBy(), msg.getSortDirection().toUpperCase());
+                        String orderBy = String.format("order by %s.%s %s", entityName, msg.getSortBy(), msg.getSortDirection().toUpperCase());
+                        if (info.primaryKey != null && !msg.getSortBy().equals(info.primaryKey)) {
+                            orderBy += String.format(", %s.%s ASC", entityName, info.primaryKey);
+                        }
+                        ret = String.format("%s %s", ret, orderBy);
+                    } else if (msg.getStart() != null || msg.getLimit() != null) {
+                        if (info.primaryKey != null) {
+                            ret = String.format("%s order by %s.%s ASC", ret, entityName, info.primaryKey);
+                        }
                     }
 
                     if (msg.getGroupBy() != null) {

--- a/search/src/main/java/org/zstack/query/QueryFacadeImpl.java
+++ b/search/src/main/java/org/zstack/query/QueryFacadeImpl.java
@@ -30,6 +30,7 @@ import org.zstack.header.search.SearchConstant;
 import org.zstack.utils.*;
 import org.zstack.utils.gson.JSONObjectUtil;
 import org.zstack.utils.logging.CLogger;
+import org.zstack.core.db.EntityMetadata;
 import org.zstack.zql.ZQL;
 import org.zstack.zql.ZQLContext;
 import org.zstack.zql.ZQLQueryReturn;
@@ -482,7 +483,17 @@ public class QueryFacadeImpl extends AbstractService implements QueryFacade, Glo
         }
 
         if (msg.getSortBy() != null) {
-            sb.add(String.format("order by %s %s", msg.getSortBy(), msg.getSortDirection()));
+            String orderBy = String.format("order by %s %s", msg.getSortBy(), msg.getSortDirection());
+            String pkFieldName = getPrimaryKeyFieldNameSafely(targetInventoryClass);
+            if (pkFieldName != null && !msg.getSortBy().equals(pkFieldName)) {
+                orderBy += String.format(", %s asc", pkFieldName);
+            }
+            sb.add(orderBy);
+        } else if (!msg.isCount() && (msg.getLimit() != null || msg.getStart() != null)) {
+            String pkFieldName = getPrimaryKeyFieldNameSafely(targetInventoryClass);
+            if (pkFieldName != null) {
+                sb.add(String.format("order by %s asc", pkFieldName));
+            }
         }
 
         if (msg.getLimit() != null) {
@@ -512,6 +523,24 @@ public class QueryFacadeImpl extends AbstractService implements QueryFacade, Glo
         }
 
         return result;
+    }
+
+    private String getPrimaryKeyFieldNameSafely(Class inventoryClass) {
+        try {
+            ZQLMetadata.InventoryMetadata meta = ZQLMetadata.findInventoryMetadata(
+                    ZQL.queryTargetNameFromInventoryClass(inventoryClass));
+            Class voClass = meta.inventoryAnnotation.mappingVOClass();
+            Field pkField = EntityMetadata.getPrimaryKeyField(voClass);
+            String pkName = pkField.getName();
+            if (!meta.selfInventoryFieldNames.contains(pkName)) {
+                return null;
+            }
+            return pkName;
+        } catch (Exception e) {
+            logger.trace(String.format("cannot resolve PK for %s, skip pagination tiebreaker: %s",
+                    inventoryClass.getSimpleName(), e.getMessage()));
+            return null;
+        }
     }
 
     private QueryBelongFilter validateFilterNameAndGetExp(String filterName) {


### PR DESCRIPTION
Backport ZSTAC-74748 pagination tiebreaker from 5.5.6/5.5.28 to 5.4.10.

Paginated LIMIT/OFFSET queries can return duplicate resources when the requested sort field has duplicate values. This appends the primary key as a deterministic tiebreaker in both ZQL and legacy HQL query paths, while skipping hidden PK fields that ZQL cannot order by.

Source MR: http://dev.zstack.io:9080/zstackio/zstack/-/merge_requests/9139
Source commits: 284d04988a, b1156d87cc

Verification:
- Docker CI image: `./runMavenProfile premium` passed, 140/140, total 15:29.
- Log: `/tmp/zstac86475-premium-docker-build.log`

Resolves: ZSTAC-86475

sync from gitlab !10375