### PR TITLE
<fix>[sdk]: expose AI business gateway offering sdk

### DIFF
--- a/sdk/src/main/java/SourceClassMap.java
+++ b/sdk/src/main/java/SourceClassMap.java
@@ -11,6 +11,7 @@ public class SourceClassMap {
 			put("org.zstack.accessKey.AccessKeyState", "org.zstack.sdk.AccessKeyState");
 			put("org.zstack.accessKey.AccessKeyType", "org.zstack.sdk.AccessKeyType");
 			put("org.zstack.ai.NginxRedirectRule", "org.zstack.sdk.NginxRedirectRule");
+			put("org.zstack.ai.entity.AIBusinessGatewayOfferingInventory", "org.zstack.sdk.AIBusinessGatewayOfferingInventory");
 			put("org.zstack.ai.entity.AiHostCacheStorageInventory", "org.zstack.sdk.AiHostCacheStorageInventory");
 			put("org.zstack.ai.entity.AiHostCacheStorageStatus", "org.zstack.sdk.AiHostCacheStorageStatus");
 			put("org.zstack.ai.entity.AiHostModelCacheFailureCode", "org.zstack.sdk.AiHostModelCacheFailureCode");
@@ -921,6 +922,7 @@ public class SourceClassMap {
 
     public final static HashMap<String, String> dstToSrcMapping = new HashMap() {
         {
+			put("org.zstack.sdk.AIBusinessGatewayOfferingInventory", "org.zstack.ai.entity.AIBusinessGatewayOfferingInventory");
 			put("org.zstack.sdk.AccessControlListEntryInventory", "org.zstack.header.acl.AccessControlListEntryInventory");
 			put("org.zstack.sdk.AccessControlListInventory", "org.zstack.header.acl.AccessControlListInventory");
 			put("org.zstack.sdk.AccessControlRuleInventory", "org.zstack.loginControl.entity.AccessControlRuleInventory");

--- a/sdk/src/main/java/org/zstack/sdk/AIBusinessGatewayOfferingInventory.java
+++ b/sdk/src/main/java/org/zstack/sdk/AIBusinessGatewayOfferingInventory.java
@@ -1,0 +1,103 @@
+package org.zstack.sdk;
+
+
+
+public class AIBusinessGatewayOfferingInventory  {
+
+    public java.lang.String uuid;
+    public void setUuid(java.lang.String uuid) {
+        this.uuid = uuid;
+    }
+    public java.lang.String getUuid() {
+        return this.uuid;
+    }
+
+    public java.lang.String name;
+    public void setName(java.lang.String name) {
+        this.name = name;
+    }
+    public java.lang.String getName() {
+        return this.name;
+    }
+
+    public java.lang.String description;
+    public void setDescription(java.lang.String description) {
+        this.description = description;
+    }
+    public java.lang.String getDescription() {
+        return this.description;
+    }
+
+    public java.lang.String imageUuid;
+    public void setImageUuid(java.lang.String imageUuid) {
+        this.imageUuid = imageUuid;
+    }
+    public java.lang.String getImageUuid() {
+        return this.imageUuid;
+    }
+
+    public java.lang.String instanceOfferingUuid;
+    public void setInstanceOfferingUuid(java.lang.String instanceOfferingUuid) {
+        this.instanceOfferingUuid = instanceOfferingUuid;
+    }
+    public java.lang.String getInstanceOfferingUuid() {
+        return this.instanceOfferingUuid;
+    }
+
+    public java.lang.String managementNetworkUuid;
+    public void setManagementNetworkUuid(java.lang.String managementNetworkUuid) {
+        this.managementNetworkUuid = managementNetworkUuid;
+    }
+    public java.lang.String getManagementNetworkUuid() {
+        return this.managementNetworkUuid;
+    }
+
+    public java.lang.String businessNetworkUuid;
+    public void setBusinessNetworkUuid(java.lang.String businessNetworkUuid) {
+        this.businessNetworkUuid = businessNetworkUuid;
+    }
+    public java.lang.String getBusinessNetworkUuid() {
+        return this.businessNetworkUuid;
+    }
+
+    public java.lang.String developerAccessNetworkUuid;
+    public void setDeveloperAccessNetworkUuid(java.lang.String developerAccessNetworkUuid) {
+        this.developerAccessNetworkUuid = developerAccessNetworkUuid;
+    }
+    public java.lang.String getDeveloperAccessNetworkUuid() {
+        return this.developerAccessNetworkUuid;
+    }
+
+    public int agentPort;
+    public void setAgentPort(int agentPort) {
+        this.agentPort = agentPort;
+    }
+    public int getAgentPort() {
+        return this.agentPort;
+    }
+
+    public int listenerPort;
+    public void setListenerPort(int listenerPort) {
+        this.listenerPort = listenerPort;
+    }
+    public int getListenerPort() {
+        return this.listenerPort;
+    }
+
+    public java.sql.Timestamp createDate;
+    public void setCreateDate(java.sql.Timestamp createDate) {
+        this.createDate = createDate;
+    }
+    public java.sql.Timestamp getCreateDate() {
+        return this.createDate;
+    }
+
+    public java.sql.Timestamp lastOpDate;
+    public void setLastOpDate(java.sql.Timestamp lastOpDate) {
+        this.lastOpDate = lastOpDate;
+    }
+    public java.sql.Timestamp getLastOpDate() {
+        return this.lastOpDate;
+    }
+
+}

--- a/sdk/src/main/java/org/zstack/sdk/AddAIBusinessGatewayOfferingAction.java
+++ b/sdk/src/main/java/org/zstack/sdk/AddAIBusinessGatewayOfferingAction.java
@@ -4,7 +4,7 @@ import java.util.HashMap;
 import java.util.Map;
 import org.zstack.sdk.*;
 
-public class AddModelCenterBusinessNetworkProfileAction extends AbstractAction {
+public class AddAIBusinessGatewayOfferingAction extends AbstractAction {
 
     private static final HashMap<String, Parameter> parameterMap = new HashMap<>();
 
@@ -12,15 +12,15 @@ public class AddModelCenterBusinessNetworkProfileAction extends AbstractAction {
 
     public static class Result {
         public ErrorCode error;
-        public org.zstack.sdk.AddModelCenterBusinessNetworkProfileResult value;
+        public org.zstack.sdk.AddAIBusinessGatewayOfferingResult value;
 
         public Result throwExceptionIfError() {
             if (error != null) {
                 throw new ApiException(
-                    String.format("error[code: %s, description: %s, details: %s, globalErrorCode: %s]", error.code, error.description, error.details, error.globalErrorCode)    
+                    String.format("error[code: %s, description: %s, details: %s, globalErrorCode: %s]", error.code, error.description, error.details, error.globalErrorCode)
                 );
             }
-            
+
             return this;
         }
     }
@@ -32,55 +32,25 @@ public class AddModelCenterBusinessNetworkProfileAction extends AbstractAction {
     public java.lang.String description;
 
     @Param(required = true, nonempty = false, nullElements = false, emptyString = true, noTrim = false)
-    public java.lang.String modelCenterUuid;
+    public java.lang.String imageUuid;
 
     @Param(required = true, nonempty = false, nullElements = false, emptyString = true, noTrim = false)
-    public java.lang.String zoneUuid;
-
-    @Param(required = false, nonempty = false, nullElements = false, emptyString = true, noTrim = false)
-    public java.lang.String clusterUuid;
-
-    @Param(required = false, nonempty = false, nullElements = false, emptyString = true, noTrim = false)
-    public java.lang.String nativeClusterUuid;
-
-    @Param(required = true, validValues = {"VirtualMachine","Container"}, nonempty = false, nullElements = false, emptyString = true, noTrim = false)
-    public java.lang.String backendType;
+    public java.lang.String instanceOfferingUuid;
 
     @Param(required = true, nonempty = false, nullElements = false, emptyString = true, noTrim = false)
-    public java.lang.String modelServiceNetworkUuid;
+    public java.lang.String managementNetworkUuid;
+
+    @Param(required = false, nonempty = false, nullElements = false, emptyString = true, noTrim = false)
+    public java.lang.String businessNetworkUuid;
 
     @Param(required = false, nonempty = false, nullElements = false, emptyString = true, noTrim = false)
     public java.lang.String developerAccessNetworkUuid;
 
-    @Param(required = false, nonempty = false, nullElements = false, emptyString = true, noTrim = false)
-    public java.lang.String storageNetworkUuid;
-
-    @Param(required = false, nonempty = false, nullElements = false, emptyString = true, noTrim = false)
-    public java.lang.String containerNetwork;
-
-    @Param(required = false, nonempty = false, nullElements = false, emptyString = true, noTrim = false)
-    public java.lang.String containerDeveloperAccessNetwork;
-
-    @Param(required = false, nonempty = false, nullElements = false, emptyString = true, noTrim = false)
-    public java.lang.String containerStorageNetwork;
-
-    @Param(required = false, nonempty = false, nullElements = false, emptyString = true, noTrim = false)
-    public java.lang.Boolean defaultProfile;
-
-    @Param(required = false, validValues = {"Enabled","Disabled","Error"}, nonempty = false, nullElements = false, emptyString = true, noTrim = false)
-    public java.lang.String status;
-
-    @Param(required = false, nonempty = false, nullElements = false, emptyString = true, noTrim = false)
-    public java.lang.String gatewayScheme;
-
-    @Param(required = false, nonempty = false, nullElements = false, emptyString = true, noTrim = false)
-    public java.lang.String gatewayAddress;
+    @Param(required = false, nonempty = false, nullElements = false, emptyString = true, numberRange = {1L,65535L}, noTrim = false)
+    public java.lang.Integer agentPort;
 
     @Param(required = false, nonempty = false, nullElements = false, emptyString = true, numberRange = {1L,65535L}, noTrim = false)
-    public java.lang.Integer gatewayPort;
-
-    @Param(required = false, nonempty = false, nullElements = false, emptyString = true, noTrim = false)
-    public java.lang.String gatewayManagementAddress;
+    public java.lang.Integer listenerPort;
 
     @Param(required = false)
     public java.lang.String resourceUuid;
@@ -119,9 +89,9 @@ public class AddModelCenterBusinessNetworkProfileAction extends AbstractAction {
             ret.error = res.error;
             return ret;
         }
-        
-        org.zstack.sdk.AddModelCenterBusinessNetworkProfileResult value = res.getResult(org.zstack.sdk.AddModelCenterBusinessNetworkProfileResult.class);
-        ret.value = value == null ? new org.zstack.sdk.AddModelCenterBusinessNetworkProfileResult() : value; 
+
+        org.zstack.sdk.AddAIBusinessGatewayOfferingResult value = res.getResult(org.zstack.sdk.AddAIBusinessGatewayOfferingResult.class);
+        ret.value = value == null ? new org.zstack.sdk.AddAIBusinessGatewayOfferingResult() : value;
 
         return ret;
     }
@@ -151,7 +121,7 @@ public class AddModelCenterBusinessNetworkProfileAction extends AbstractAction {
     protected RestInfo getRestInfo() {
         RestInfo info = new RestInfo();
         info.httpMethod = "POST";
-        info.path = "/ai/model-center-business-network-profiles";
+        info.path = "/ai/business-gateway-offerings";
         info.needSession = true;
         info.needPoll = true;
         info.parameterName = "params";

--- a/sdk/src/main/java/org/zstack/sdk/AddAIBusinessGatewayOfferingResult.java
+++ b/sdk/src/main/java/org/zstack/sdk/AddAIBusinessGatewayOfferingResult.java
@@ -1,0 +1,14 @@
+package org.zstack.sdk;
+
+import org.zstack.sdk.AIBusinessGatewayOfferingInventory;
+
+public class AddAIBusinessGatewayOfferingResult {
+    public AIBusinessGatewayOfferingInventory inventory;
+    public void setInventory(AIBusinessGatewayOfferingInventory inventory) {
+        this.inventory = inventory;
+    }
+    public AIBusinessGatewayOfferingInventory getInventory() {
+        return this.inventory;
+    }
+
+}

--- a/sdk/src/main/java/org/zstack/sdk/DeleteAIBusinessGatewayOfferingAction.java
+++ b/sdk/src/main/java/org/zstack/sdk/DeleteAIBusinessGatewayOfferingAction.java
@@ -1,0 +1,104 @@
+package org.zstack.sdk;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.zstack.sdk.*;
+
+public class DeleteAIBusinessGatewayOfferingAction extends AbstractAction {
+
+    private static final HashMap<String, Parameter> parameterMap = new HashMap<>();
+
+    private static final HashMap<String, Parameter> nonAPIParameterMap = new HashMap<>();
+
+    public static class Result {
+        public ErrorCode error;
+        public org.zstack.sdk.DeleteAIBusinessGatewayOfferingResult value;
+
+        public Result throwExceptionIfError() {
+            if (error != null) {
+                throw new ApiException(
+                    String.format("error[code: %s, description: %s, details: %s, globalErrorCode: %s]", error.code, error.description, error.details, error.globalErrorCode)
+                );
+            }
+
+            return this;
+        }
+    }
+
+    @Param(required = true, nonempty = false, nullElements = false, emptyString = true, noTrim = false)
+    public java.lang.String uuid;
+
+    @Param(required = false)
+    public java.lang.String deleteMode = "Permissive";
+
+    @Param(required = false)
+    public java.util.List systemTags;
+
+    @Param(required = false)
+    public java.util.List userTags;
+
+    @Param(required = false)
+    public String sessionId;
+
+    @Param(required = false)
+    public String accessKeyId;
+
+    @Param(required = false)
+    public String accessKeySecret;
+
+    @Param(required = false)
+    public String requestIp;
+
+    @NonAPIParam
+    public long timeout = -1;
+
+    @NonAPIParam
+    public long pollingInterval = -1;
+
+
+    private Result makeResult(ApiResult res) {
+        Result ret = new Result();
+        if (res.error != null) {
+            ret.error = res.error;
+            return ret;
+        }
+
+        org.zstack.sdk.DeleteAIBusinessGatewayOfferingResult value = res.getResult(org.zstack.sdk.DeleteAIBusinessGatewayOfferingResult.class);
+        ret.value = value == null ? new org.zstack.sdk.DeleteAIBusinessGatewayOfferingResult() : value;
+
+        return ret;
+    }
+
+    public Result call() {
+        ApiResult res = ZSClient.call(this);
+        return makeResult(res);
+    }
+
+    public void call(final Completion<Result> completion) {
+        ZSClient.call(this, new InternalCompletion() {
+            @Override
+            public void complete(ApiResult res) {
+                completion.complete(makeResult(res));
+            }
+        });
+    }
+
+    protected Map<String, Parameter> getParameterMap() {
+        return parameterMap;
+    }
+
+    protected Map<String, Parameter> getNonAPIParameterMap() {
+        return nonAPIParameterMap;
+    }
+
+    protected RestInfo getRestInfo() {
+        RestInfo info = new RestInfo();
+        info.httpMethod = "DELETE";
+        info.path = "/ai/business-gateway-offerings/{uuid}";
+        info.needSession = true;
+        info.needPoll = true;
+        info.parameterName = "";
+        return info;
+    }
+
+}

--- a/sdk/src/main/java/org/zstack/sdk/DeleteAIBusinessGatewayOfferingResult.java
+++ b/sdk/src/main/java/org/zstack/sdk/DeleteAIBusinessGatewayOfferingResult.java
@@ -1,0 +1,7 @@
+package org.zstack.sdk;
+
+
+
+public class DeleteAIBusinessGatewayOfferingResult {
+
+}

--- a/sdk/src/main/java/org/zstack/sdk/GetAiHostModelCacheCapacityResult.java
+++ b/sdk/src/main/java/org/zstack/sdk/GetAiHostModelCacheCapacityResult.java
@@ -3,11 +3,11 @@ package org.zstack.sdk;
 
 
 public class GetAiHostModelCacheCapacityResult {
-    public java.util.List<org.zstack.sdk.AiHostCacheStorageInventory> inventories;
-    public void setInventories(java.util.List<org.zstack.sdk.AiHostCacheStorageInventory> inventories) {
+    public java.util.List inventories;
+    public void setInventories(java.util.List inventories) {
         this.inventories = inventories;
     }
-    public java.util.List<org.zstack.sdk.AiHostCacheStorageInventory> getInventories() {
+    public java.util.List getInventories() {
         return this.inventories;
     }
 

--- a/sdk/src/main/java/org/zstack/sdk/QueryAiHostModelCacheResult.java
+++ b/sdk/src/main/java/org/zstack/sdk/QueryAiHostModelCacheResult.java
@@ -3,11 +3,11 @@ package org.zstack.sdk;
 
 
 public class QueryAiHostModelCacheResult {
-    public java.util.List<org.zstack.sdk.AiHostModelCacheInventory> inventories;
-    public void setInventories(java.util.List<org.zstack.sdk.AiHostModelCacheInventory> inventories) {
+    public java.util.List inventories;
+    public void setInventories(java.util.List inventories) {
         this.inventories = inventories;
     }
-    public java.util.List<org.zstack.sdk.AiHostModelCacheInventory> getInventories() {
+    public java.util.List getInventories() {
         return this.inventories;
     }
 

--- a/sdk/src/main/java/org/zstack/sdk/RefreshAiHostModelCacheResult.java
+++ b/sdk/src/main/java/org/zstack/sdk/RefreshAiHostModelCacheResult.java
@@ -3,11 +3,11 @@ package org.zstack.sdk;
 
 
 public class RefreshAiHostModelCacheResult {
-    public java.util.List<org.zstack.sdk.AiHostCacheStorageInventory> inventories;
-    public void setInventories(java.util.List<org.zstack.sdk.AiHostCacheStorageInventory> inventories) {
+    public java.util.List inventories;
+    public void setInventories(java.util.List inventories) {
         this.inventories = inventories;
     }
-    public java.util.List<org.zstack.sdk.AiHostCacheStorageInventory> getInventories() {
+    public java.util.List getInventories() {
         return this.inventories;
     }
 

--- a/sdk/src/main/java/org/zstack/sdk/UpdateAIBusinessGatewayOfferingAction.java
+++ b/sdk/src/main/java/org/zstack/sdk/UpdateAIBusinessGatewayOfferingAction.java
@@ -1,0 +1,128 @@
+package org.zstack.sdk;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.zstack.sdk.*;
+
+public class UpdateAIBusinessGatewayOfferingAction extends AbstractAction {
+
+    private static final HashMap<String, Parameter> parameterMap = new HashMap<>();
+
+    private static final HashMap<String, Parameter> nonAPIParameterMap = new HashMap<>();
+
+    public static class Result {
+        public ErrorCode error;
+        public org.zstack.sdk.UpdateAIBusinessGatewayOfferingResult value;
+
+        public Result throwExceptionIfError() {
+            if (error != null) {
+                throw new ApiException(
+                    String.format("error[code: %s, description: %s, details: %s, globalErrorCode: %s]", error.code, error.description, error.details, error.globalErrorCode)
+                );
+            }
+
+            return this;
+        }
+    }
+
+    @Param(required = true, nonempty = false, nullElements = false, emptyString = true, noTrim = false)
+    public java.lang.String uuid;
+
+    @Param(required = false, maxLength = 255, nonempty = false, nullElements = false, emptyString = true, noTrim = false)
+    public java.lang.String name;
+
+    @Param(required = false, maxLength = 2048, nonempty = false, nullElements = false, emptyString = true, noTrim = false)
+    public java.lang.String description;
+
+    @Param(required = false, nonempty = false, nullElements = false, emptyString = true, noTrim = false)
+    public java.lang.String imageUuid;
+
+    @Param(required = false, nonempty = false, nullElements = false, emptyString = true, noTrim = false)
+    public java.lang.String instanceOfferingUuid;
+
+    @Param(required = false, nonempty = false, nullElements = false, emptyString = true, noTrim = false)
+    public java.lang.String managementNetworkUuid;
+
+    @Param(required = false, nonempty = false, nullElements = false, emptyString = true, noTrim = false)
+    public java.lang.String businessNetworkUuid;
+
+    @Param(required = false, nonempty = false, nullElements = false, emptyString = true, noTrim = false)
+    public java.lang.String developerAccessNetworkUuid;
+
+    @Param(required = false, nonempty = false, nullElements = false, emptyString = true, numberRange = {1L,65535L}, noTrim = false)
+    public java.lang.Integer agentPort;
+
+    @Param(required = false, nonempty = false, nullElements = false, emptyString = true, numberRange = {1L,65535L}, noTrim = false)
+    public java.lang.Integer listenerPort;
+
+    @Param(required = false)
+    public java.util.List systemTags;
+
+    @Param(required = false)
+    public java.util.List userTags;
+
+    @Param(required = false)
+    public String sessionId;
+
+    @Param(required = false)
+    public String accessKeyId;
+
+    @Param(required = false)
+    public String accessKeySecret;
+
+    @Param(required = false)
+    public String requestIp;
+
+    @NonAPIParam
+    public long timeout = -1;
+
+    @NonAPIParam
+    public long pollingInterval = -1;
+
+
+    private Result makeResult(ApiResult res) {
+        Result ret = new Result();
+        if (res.error != null) {
+            ret.error = res.error;
+            return ret;
+        }
+
+        org.zstack.sdk.UpdateAIBusinessGatewayOfferingResult value = res.getResult(org.zstack.sdk.UpdateAIBusinessGatewayOfferingResult.class);
+        ret.value = value == null ? new org.zstack.sdk.UpdateAIBusinessGatewayOfferingResult() : value;
+
+        return ret;
+    }
+
+    public Result call() {
+        ApiResult res = ZSClient.call(this);
+        return makeResult(res);
+    }
+
+    public void call(final Completion<Result> completion) {
+        ZSClient.call(this, new InternalCompletion() {
+            @Override
+            public void complete(ApiResult res) {
+                completion.complete(makeResult(res));
+            }
+        });
+    }
+
+    protected Map<String, Parameter> getParameterMap() {
+        return parameterMap;
+    }
+
+    protected Map<String, Parameter> getNonAPIParameterMap() {
+        return nonAPIParameterMap;
+    }
+
+    protected RestInfo getRestInfo() {
+        RestInfo info = new RestInfo();
+        info.httpMethod = "PUT";
+        info.path = "/ai/business-gateway-offerings/{uuid}";
+        info.needSession = true;
+        info.needPoll = true;
+        info.parameterName = "updateAIBusinessGatewayOffering";
+        return info;
+    }
+
+}

--- a/sdk/src/main/java/org/zstack/sdk/UpdateAIBusinessGatewayOfferingResult.java
+++ b/sdk/src/main/java/org/zstack/sdk/UpdateAIBusinessGatewayOfferingResult.java
@@ -1,0 +1,14 @@
+package org.zstack.sdk;
+
+import org.zstack.sdk.AIBusinessGatewayOfferingInventory;
+
+public class UpdateAIBusinessGatewayOfferingResult {
+    public AIBusinessGatewayOfferingInventory inventory;
+    public void setInventory(AIBusinessGatewayOfferingInventory inventory) {
+        this.inventory = inventory;
+    }
+    public AIBusinessGatewayOfferingInventory getInventory() {
+        return this.inventory;
+    }
+
+}


### PR DESCRIPTION
Pair SDK generation with premium lazy AI gateway implementation.

Premium MR: http://dev.zstack.io:9080/zstackio/premium/-/merge_requests/14602

Changes:
- Add generated AI business gateway offering SDK action/result/inventory classes.
- Add SourceClassMap mapping for AIBusinessGatewayOfferingInventory.
- Carry generated profile/cache SDK deltas from ./runMavenProfile sdk.

Verification:
- In premium: mvn -pl plugin-premium/ai -DskipTests install
- In zstack: ./runMavenProfile sdk
- In zstack: ./runMavenProfile docpremium

Not tested:
- Full runtime ModelCenterBusinessNetworkCase in local deploydb environment.

sync from gitlab !10419