### PR TITLE
fix[zbs]: fail attach when host deploy failure ratio reaches threshold (ZSTAC-86222)

### DIFF
--- a/plugin/zbs/src/main/java/org/zstack/storage/zbs/ZbsStorageController.java
+++ b/plugin/zbs/src/main/java/org/zstack/storage/zbs/ZbsStorageController.java
@@ -399,15 +399,16 @@ public class ZbsStorageController implements PrimaryStorageControllerSvc, Primar
                                 @Override
                                 public void run(MessageReply reply) {
                                     if (!reply.isSuccess()) {
-                                        logger.warn(String.format("failed to prepare vhost target env on host[%s]: %s",
-                                                h.getUuid(), reply.getError().getDetails()));
-                                    } else {
-                                        AgentResponse rsp = reply.<KVMHostAsyncHttpCallReply>castReply().toResponse(AgentResponse.class);
-                                        if (!rsp.isSuccess()) {
-                                            logger.warn(String.format("failed to prepare vhost target env on host[%s]: %s",
-                                                    h.getUuid(), rsp.getError()));
-                                        }
+                                        trigger.fail(reply.getError());
+                                        return;
                                     }
+
+                                    AgentResponse rsp = reply.<KVMHostAsyncHttpCallReply>castReply().toResponse(AgentResponse.class);
+                                    if (!rsp.isSuccess()) {
+                                        trigger.fail(operr(ORG_ZSTACK_STORAGE_ZBS_10011, rsp.getError()));
+                                        return;
+                                    }
+
                                     trigger.next();
                                 }
                             });
@@ -437,9 +438,7 @@ public class ZbsStorageController implements PrimaryStorageControllerSvc, Primar
 
                                 @Override
                                 public void fail(ErrorCode errorCode) {
-                                    logger.warn(String.format("failed to deploy vhost target on host[%s]: %s",
-                                            h.getUuid(), errorCode.getDetails()));
-                                    trigger.next();
+                                    trigger.fail(errorCode);
                                 }
                             });
                         }

--- a/storage/src/main/java/org/zstack/storage/addon/primary/ExternalPrimaryStorage.java
+++ b/storage/src/main/java/org/zstack/storage/addon/primary/ExternalPrimaryStorage.java
@@ -62,6 +62,7 @@ import org.zstack.utils.gson.JSONObjectUtil;
 import org.zstack.utils.logging.CLogger;
 
 import java.util.*;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -136,6 +137,10 @@ public class ExternalPrimaryStorage extends PrimaryStorageBase {
                 .select(PrimaryStorageOutputProtocolRefVO_.outputProtocol)
                 .listValues();
 
+        int totalHosts = hostInventories.size();
+        double threshold = ExternalPrimaryStorageGlobalConfig.ATTACH_HOST_DEPLOY_FAILURE_RATIO_THRESHOLD.value(Double.class);
+        AtomicInteger failedCount = new AtomicInteger();
+
         // the next attach or reconnect to overwrite.
         new While<>(hostInventories).each((host, compl) -> {
             node.deployClient(host, protocols, new Completion(compl) {
@@ -158,8 +163,12 @@ public class ExternalPrimaryStorage extends PrimaryStorageBase {
                     updateHostProtocolStatus(host.getUuid(), statuses, errorCode, new NoErrorCompletion(compl) {
                         @Override
                         public void done() {
-                            compl.addError(errorCode);
-                            compl.allDone();
+                            if ((double) failedCount.incrementAndGet() / totalHosts >= threshold) {
+                                compl.addError(errorCode);
+                                compl.allDone();
+                                return;
+                            }
+                            compl.done();
                         }
                     });
                 }
@@ -170,6 +179,12 @@ public class ExternalPrimaryStorage extends PrimaryStorageBase {
                 if (!errorCodeList.getCauses().isEmpty()) {
                     completion.fail(errorCodeList.getCauses().get(0));
                     return;
+                }
+
+                if (failedCount.get() > 0) {
+                    logger.warn(String.format("attaching primary storage[uuid: %s] to cluster[uuid: %s]: %d of %d hosts failed to deploy client, " +
+                                    "below the failure ratio threshold[%s], continue the attach and let periodic ping self-heal the failed hosts",
+                            self.getUuid(), clusterUuid, failedCount.get(), totalHosts, threshold));
                 }
 
                 activateHeartbeatVolumeForAttach(hostInventories.get(0), completion);

--- a/storage/src/main/java/org/zstack/storage/addon/primary/ExternalPrimaryStorageGlobalConfig.java
+++ b/storage/src/main/java/org/zstack/storage/addon/primary/ExternalPrimaryStorageGlobalConfig.java
@@ -15,4 +15,10 @@ public class ExternalPrimaryStorageGlobalConfig {
     @GlobalConfigDef(defaultValue = "iSCSI", description = "image export protocol of external primary storage")
     @BindResourceConfig({PrimaryStorageVO.class})
     public static GlobalConfig IMAGE_EXPORT_PROTOCOL = new GlobalConfig(CATEGORY, "image.export.protocol");
+
+    @GlobalConfigValidation()
+    @GlobalConfigDef(defaultValue = "0.3", type = Double.class, description = "when attaching external primary storage to a cluster, " +
+            "if the ratio of hosts that fail to deploy the storage client reaches this threshold, the attach fails; " +
+            "otherwise it succeeds and the failed hosts recover through periodic ping self-heal")
+    public static GlobalConfig ATTACH_HOST_DEPLOY_FAILURE_RATIO_THRESHOLD = new GlobalConfig(CATEGORY, "attach.hostDeployFailureRatioThreshold");
 }

--- a/test/src/test/groovy/org/zstack/test/integration/storage/primary/addon/zbs/ZbsVhostAttachDeployFailureCase.groovy
+++ b/test/src/test/groovy/org/zstack/test/integration/storage/primary/addon/zbs/ZbsVhostAttachDeployFailureCase.groovy
@@ -1,0 +1,228 @@
+package org.zstack.test.integration.storage.primary.addon.zbs
+
+import org.springframework.http.HttpEntity
+import org.zstack.core.db.Q
+import org.zstack.header.storage.addon.primary.ExternalPrimaryStorageHostProtocolRefVO
+import org.zstack.header.storage.addon.primary.ExternalPrimaryStorageHostProtocolRefVO_
+import org.zstack.header.storage.backup.UploadImageToRemoteTargetMsg
+import org.zstack.header.storage.backup.UploadImageToRemoteTargetReply
+import org.zstack.header.storage.primary.PrimaryStorageHostStatus
+import org.zstack.core.cloudbus.CloudBus
+import org.zstack.header.volume.VolumeProtocol
+import org.zstack.sdk.ClusterInventory
+import org.zstack.sdk.HostInventory
+import org.zstack.sdk.PrimaryStorageInventory
+import org.zstack.storage.zbs.ZbsConstants
+import org.zstack.storage.zbs.ZbsStorageController
+import org.zstack.test.integration.storage.StorageTest
+import org.zstack.testlib.EnvSpec
+import org.zstack.testlib.SubCase
+import org.zstack.utils.data.SizeUnit
+import org.zstack.utils.gson.JSONObjectUtil
+
+import java.util.concurrent.atomic.AtomicReference
+
+class ZbsVhostAttachDeployFailureCase extends SubCase {
+    EnvSpec env
+    CloudBus bus
+    PrimaryStorageInventory ps
+    ClusterInventory cluster
+    HostInventory kvm1, kvm2
+
+    @Override
+    void clean() {
+        env.delete()
+    }
+
+    @Override
+    void setup() {
+        useSpring(StorageTest.springSpec)
+    }
+
+    @Override
+    void environment() {
+        env = makeEnv {
+            instanceOffering {
+                name = "instanceOffering"
+                memory = SizeUnit.GIGABYTE.toByte(8)
+                cpu = 4
+            }
+
+            sftpBackupStorage {
+                name = "sftp"
+                url = "/sftp"
+                username = "root"
+                password = "password"
+                hostname = "127.0.0.2"
+
+                image {
+                    name = "image"
+                    url = "http://zstack.org/download/test.qcow2"
+                    size = SizeUnit.GIGABYTE.toByte(1)
+                    virtio = true
+                }
+            }
+
+            zone {
+                name = "zone"
+
+                cluster {
+                    name = "cluster"
+                    hypervisorType = "KVM"
+
+                    kvm {
+                        name = "kvm1"
+                        managementIp = "127.0.0.1"
+                        username = "root"
+                        password = "password"
+                    }
+
+                    kvm {
+                        name = "kvm2"
+                        managementIp = "127.0.0.2"
+                        username = "root"
+                        password = "password"
+                    }
+
+                    attachL2Network("l2")
+                }
+
+                l2NoVlanNetwork {
+                    name = "l2"
+                    physicalInterface = "eth0"
+
+                    l3Network {
+                        name = "l3"
+                        ip {
+                            startIp = "192.168.100.10"
+                            endIp = "192.168.100.100"
+                            netmask = "255.255.255.0"
+                            gateway = "192.168.100.1"
+                        }
+                    }
+                }
+
+                externalPrimaryStorage {
+                    name = "zbs-vhost"
+                    identity = "zbs"
+                    defaultOutputProtocol = "Vhost"
+                    config = "{\"mdsUrls\":[\"root:password@127.0.1.1\",\"root:password@127.0.1.2\",\"root:password@127.0.1.3\"],\"logicalPoolName\":\"lpool1\"}"
+                    url = "zbs"
+                }
+
+                attachBackupStorage("sftp")
+            }
+        }
+    }
+
+    @Override
+    void test() {
+        env.create {
+            ps = env.inventoryByName("zbs-vhost") as PrimaryStorageInventory
+            cluster = env.inventoryByName("cluster") as ClusterInventory
+            kvm1 = env.inventoryByName("kvm1") as HostInventory
+            kvm2 = env.inventoryByName("kvm2") as HostInventory
+            bus = bean(CloudBus.class)
+
+            testAttachFailsWhenDeployFailureRatioReachesThreshold()
+            testAttachSucceedsBelowThresholdThenSelfHeals()
+        }
+    }
+
+    // one of two hosts fails vhost deploy -> 50% >= default 0.3 threshold -> attach fails
+    void testAttachFailsWhenDeployFailureRatioReachesThreshold() {
+        AtomicReference<String> failHostIp = new AtomicReference<>("127.0.0.2")
+        registerBaseStubs(failHostIp)
+
+        expect(AssertionError.class) {
+            attachPrimaryStorageToCluster {
+                primaryStorageUuid = ps.uuid
+                clusterUuid = cluster.uuid
+            }
+        }
+    }
+
+    // raise threshold to 0.6 so 50% < 0.6 -> attach succeeds; failed host stays Disconnected then self-heals
+    void testAttachSucceedsBelowThresholdThenSelfHeals() {
+        updateGlobalConfig {
+            category = "externalPrimaryStorage"
+            name = "attach.hostDeployFailureRatioThreshold"
+            value = 0.6
+        }
+
+        AtomicReference<String> failHostIp = new AtomicReference<>("127.0.0.2")
+        registerBaseStubs(failHostIp)
+
+        attachPrimaryStorageToCluster {
+            primaryStorageUuid = ps.uuid
+            clusterUuid = cluster.uuid
+        }
+
+        assert Q.New(ExternalPrimaryStorageHostProtocolRefVO.class)
+                .eq(ExternalPrimaryStorageHostProtocolRefVO_.primaryStorageUuid, ps.uuid)
+                .eq(ExternalPrimaryStorageHostProtocolRefVO_.hostUuid, kvm2.uuid)
+                .eq(ExternalPrimaryStorageHostProtocolRefVO_.protocol, VolumeProtocol.Vhost.toString())
+                .eq(ExternalPrimaryStorageHostProtocolRefVO_.status, PrimaryStorageHostStatus.Disconnected)
+                .isExists() : "failed host must be recorded Disconnected"
+
+        assert Q.New(ExternalPrimaryStorageHostProtocolRefVO.class)
+                .eq(ExternalPrimaryStorageHostProtocolRefVO_.primaryStorageUuid, ps.uuid)
+                .eq(ExternalPrimaryStorageHostProtocolRefVO_.hostUuid, kvm1.uuid)
+                .eq(ExternalPrimaryStorageHostProtocolRefVO_.protocol, VolumeProtocol.Vhost.toString())
+                .eq(ExternalPrimaryStorageHostProtocolRefVO_.status, PrimaryStorageHostStatus.Connected)
+                .isExists() : "healthy host must be Connected"
+
+        failHostIp.set(null)
+        updateGlobalConfig {
+            category = "host"
+            name = "ping.interval"
+            value = 1
+        }
+
+        retryInSecs(30) {
+            assert Q.New(ExternalPrimaryStorageHostProtocolRefVO.class)
+                    .eq(ExternalPrimaryStorageHostProtocolRefVO_.primaryStorageUuid, ps.uuid)
+                    .eq(ExternalPrimaryStorageHostProtocolRefVO_.hostUuid, kvm2.uuid)
+                    .eq(ExternalPrimaryStorageHostProtocolRefVO_.protocol, VolumeProtocol.Vhost.toString())
+                    .eq(ExternalPrimaryStorageHostProtocolRefVO_.status, PrimaryStorageHostStatus.Connected)
+                    .isExists() : "periodic ping did not self-heal the previously failed host"
+        }
+
+        detachPrimaryStorageFromCluster {
+            primaryStorageUuid = ps.uuid
+            clusterUuid = cluster.uuid
+        }
+    }
+
+    void registerBaseStubs(AtomicReference<String> failHostIp) {
+        env.message(UploadImageToRemoteTargetMsg.class) { UploadImageToRemoteTargetMsg msg, CloudBus b ->
+            b.reply(msg, new UploadImageToRemoteTargetReply())
+        }
+
+        env.simulator(ZbsStorageController.PREPARE_VHOST_TARGET_ENV_PATH) { HttpEntity<String> e, EnvSpec spec ->
+            def cmd = JSONObjectUtil.toObject(e.body, ZbsStorageController.PrepareVhostTargetEnvCmd.class)
+            return new ZbsStorageController.AgentResponse()
+        }
+        env.simulator(ZbsStorageController.DEPLOY_VHOST_PATH) { HttpEntity<String> e, EnvSpec spec ->
+            def cmd = JSONObjectUtil.toObject(e.body, ZbsStorageController.DeployVhostCmd.class)
+            if (cmd.hostIp == failHostIp.get()) {
+                throw new RuntimeException("vhost deploy fails on purpose for host ${cmd.hostIp}")
+            }
+            return new ZbsStorageController.AgentResponse()
+        }
+        env.simulator(ZbsStorageController.VHOST_TARGET_HEALTH_PATH) { HttpEntity<String> e, EnvSpec spec ->
+            def rsp = new ZbsStorageController.VhostTargetHealthRsp()
+            rsp.targetRunning = true
+            return rsp
+        }
+        env.afterSimulator(ZbsStorageController.CREATE_VOLUME_PATH) { rsp, HttpEntity<String> e ->
+            def cmd = JSONObjectUtil.toObject(e.body, ZbsStorageController.CreateVolumeCmd)
+            if (cmd.volume == ZbsConstants.ZBS_HEARTBEAT_VOLUME_NAME) {
+                def vrsp = new ZbsStorageController.CreateVolumeRsp()
+                vrsp.installPath = "zbs://${cmd.logicalPool}/${cmd.volume}".toString()
+                return vrsp
+            }
+            return rsp
+        }
+    }
+}

--- a/test/src/test/groovy/org/zstack/test/integration/storage/primary/addon/zbs/ZbsVhostVolumeCase.groovy
+++ b/test/src/test/groovy/org/zstack/test/integration/storage/primary/addon/zbs/ZbsVhostVolumeCase.groovy
@@ -624,6 +624,12 @@ class ZbsVhostVolumeCase extends SubCase {
             value = 1
         }
 
+        updateGlobalConfig {
+            category = "externalPrimaryStorage"
+            name = "attach.hostDeployFailureRatioThreshold"
+            value = 1.1
+        }
+
         attachPrimaryStorageToCluster {
             primaryStorageUuid = ps.uuid
             clusterUuid = cluster.uuid


### PR DESCRIPTION
## 问题（ZSTAC-86222）

vhost-zbs 云主机创建失败。真正根因是 `AttachPrimaryStorageToCluster` 时 vhost target/client deploy 失败（如 `free hugepage: 0`、`docker not installed`），但 `ZbsStorageController.deployClient` 把 vhost deploy / prepare-env 失败**吞掉**（只 `logger.warn` 后 `trigger.next()`），导致 host 被标 Connected、attach 成功，而 vhost 实际没起来——后续创建 VM 才失败。报告人自己也困惑"为什么起 vhost 的服务失败了，但 attach 到集群是成功的"。

## 修复

1. **`ZbsStorageController.deployClient`**：`prepare-vhost-target-env` 和 `deploy-vhost-target` flow 失败时改为 `trigger.fail`（原来吞错误），deploy 失败会真正让 deployClient 失败。
2. **`ExternalPrimaryStorage.attachHook`**：不再任一 host 失败就整体 fail，而是只有**失败 host 比例 ≥ 阈值**才 `completion.fail`；低于阈值则 attach 成功、失败 host 记 Disconnected，由 periodic ping **自愈**重新拉起。
3. 新增 GlobalConfig **`externalPrimaryStorage.attach.hostDeployFailureRatioThreshold`**（默认 `0.3`）。

自愈能力已存在（periodic ping 会重发 DEPLOY_VHOST_PATH 恢复 Disconnected 协议），本 MR 复用之。

## 测试

新增端到端测试 `ZbsVhostAttachDeployFailureCase`（2 host）：
- 1/2 host vhost deploy 失败（50% ≥ 默认 0.3）→ `attachPrimaryStorageToCluster` 抛错失败
- 阈值调至 0.6（50% < 0.6）→ attach 成功，失败 host = Disconnected，healthy host = Connected；开启 ping 后失败 host 自愈为 Connected

本地实跑通过：`Tests run: 1, Failures: 0, Errors: 0`。

Resolves: ZSTAC-86222

sync from gitlab !10424