### PR TITLE
<fix>[build]: include ZCenter platform service dependency

### DIFF
--- a/build/pom.xml
+++ b/build/pom.xml
@@ -153,6 +153,11 @@
                 </dependency>
                 <dependency>
                     <groupId>org.zstack</groupId>
+                    <artifactId>zcenter-platform-service</artifactId>
+                    <version>${project.version}</version>
+                </dependency>
+                <dependency>
+                    <groupId>org.zstack</groupId>
                     <artifactId>search</artifactId>
                     <version>${project.version}</version>
                 </dependency>


### PR DESCRIPTION
Add zcenter-platform-service to premium build war dependencies so the Spring bean imported from premium conf has its implementation class on the MN classpath.

The dependency also brings platform-service-plugin transitively, which provides the shared platform service framework.

Resolves: ZSV-12621

Change-Id: I7a535631323632317a63656e746572646570

sync from gitlab !10436