### PR TITLE
<fix>[ha]: ZSTAC-84992 backport HA pre-fence core to 5.4.10

### DIFF
--- a/compute/src/main/java/org/zstack/compute/vm/VmInstanceBase.java
+++ b/compute/src/main/java/org/zstack/compute/vm/VmInstanceBase.java
@@ -1004,16 +1004,38 @@ public class VmInstanceBase extends AbstractVmInstance {
 
                         logger.debug(String.format("HaStartVmJudger[%s] says the VM[uuid:%s, name:%s] is qualified for HA start, now we are starting it",
                                 judger.getClass(), self.getUuid(), self.getName()));
+                        String hostUuid = self.getHostUuid();
+                        String suspectHostUuid = StringUtils.trimToNull(hostUuid);
+                        String peerHostUuid = StringUtils.trimToNull(msg.getAccessiblePeerHostUuid());
                         UpdateQuery sql = SQL.New(VmInstanceVO.class)
                                 .eq(VmInstanceVO_.uuid, self.getUuid())
                                 .set(VmInstanceVO_.state, VmInstanceState.Stopped)
                                 .set(VmInstanceVO_.hostUuid, null);
 
-                        if (self.getHostUuid() != null) {
-                            sql.set(VmInstanceVO_.lastHostUuid, self.getHostUuid());
+                        if (hostUuid != null) {
+                            sql.set(VmInstanceVO_.lastHostUuid, hostUuid);
                         }
 
                         sql.update();
+                        refreshVO();
+                        if (suspectHostUuid == null) {
+                            logger.debug(String.format("HA-start vm[%s]: skip creating pre-fence tag because suspect host is absent",
+                                    self.getUuid()));
+                        } else if (peerHostUuid == null) {
+                            logger.debug(String.format("HA-start vm[%s]: skip creating pre-fence tag because peer host is absent",
+                                    self.getUuid()));
+                        } else {
+                            Map<String, String> tokens = new HashMap<>();
+                            tokens.put(VmSystemTags.HA_PRE_FENCE_SUSPECT_HOST_UUID_TOKEN, suspectHostUuid);
+                            tokens.put(VmSystemTags.HA_PRE_FENCE_ACCESSIBLE_PEER_HOST_UUID_TOKEN, peerHostUuid);
+
+                            SystemTagCreator creator = VmSystemTags.HA_PRE_FENCE_PENDING.newSystemTagCreator(self.getUuid());
+                            creator.inherent = true;
+                            creator.recreate = true;
+                            creator.ignoreIfExisting = true;
+                            creator.setTagByTokens(tokens);
+                            creator.create();
+                        }
 
                         startVm(msg, new Completion(msg, chain) {
                             @Override
@@ -8984,4 +9006,3 @@ public class VmInstanceBase extends AbstractVmInstance {
         });
     }
 }
-

--- a/compute/src/main/java/org/zstack/compute/vm/VmStartOnHypervisorFlow.java
+++ b/compute/src/main/java/org/zstack/compute/vm/VmStartOnHypervisorFlow.java
@@ -5,17 +5,26 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Configurable;
 import org.zstack.core.cloudbus.CloudBus;
 import org.zstack.core.cloudbus.CloudBusCallBack;
+import org.zstack.core.asyncbatch.While;
 import org.zstack.core.componentloader.PluginRegistry;
+import org.zstack.core.workflow.FlowChainBuilder;
+import org.zstack.header.core.Completion;
+import org.zstack.header.core.WhileDoneCompletion;
 import org.zstack.header.core.workflow.Flow;
+import org.zstack.header.core.workflow.FlowChain;
+import org.zstack.header.core.workflow.FlowDoneHandler;
+import org.zstack.header.core.workflow.FlowErrorHandler;
 import org.zstack.header.core.workflow.FlowRollback;
 import org.zstack.header.core.workflow.FlowTrigger;
+import org.zstack.header.core.workflow.NoRollbackFlow;
+import org.zstack.header.errorcode.ErrorCode;
+import org.zstack.header.errorcode.ErrorCodeList;
 import org.zstack.header.host.HostConstant;
 import org.zstack.header.message.MessageReply;
 import org.zstack.header.vm.*;
 import org.zstack.utils.Utils;
 import org.zstack.utils.logging.CLogger;
 
-import java.util.List;
 import java.util.Map;
 @Configurable(preConstruction = true, autowire = Autowire.BY_TYPE)
 public class VmStartOnHypervisorFlow implements Flow {
@@ -26,34 +35,68 @@ public class VmStartOnHypervisorFlow implements Flow {
     @Autowired
     private PluginRegistry pluginRgty;
 
-    private final List<VmBeforeStartOnHypervisorExtensionPoint> exts = pluginRgty.getExtensionList(VmBeforeStartOnHypervisorExtensionPoint.class);;
-
-    private void fireExtensions(VmInstanceSpec spec) {
-        for (VmBeforeStartOnHypervisorExtensionPoint ext : exts) {
-            ext.beforeStartVmOnHypervisor(spec);
-        }
-    }
-
     @Override
     public void run(final FlowTrigger chain, final Map data) {
         final VmInstanceSpec spec = (VmInstanceSpec) data.get(VmInstanceConstant.Params.VmInstanceSpec.toString());
-
-        fireExtensions(spec);
-
-        StartVmOnHypervisorMsg msg = new StartVmOnHypervisorMsg();
-        msg.setVmSpec(spec);
-        bus.makeTargetServiceIdByResourceUuid(msg, HostConstant.SERVICE_ID, spec.getDestHost().getUuid());
-        bus.send(msg, new CloudBusCallBack(chain) {
+        FlowChain fchain = FlowChainBuilder.newSimpleFlowChain();
+        fchain.setName(String.format("vm-start-on-hypervisor-vm-%s", spec.getVmInventory().getUuid()));
+        fchain.then(new NoRollbackFlow() {
             @Override
-            public void run(MessageReply reply) {
-                if (reply.isSuccess()) {
-                    data.put(VmStartOnHypervisorFlow.class.getName(), true);
-                    chain.next();
-                } else {
-                    chain.fail(reply.getError());
-                }
+            public void run(FlowTrigger trigger, Map d) {
+                new While<>(pluginRgty.getExtensionList(VmBeforeStartOnHypervisorExtensionPoint.class))
+                        .each((ext, comp) -> ext.beforeStartVmOnHypervisor(spec, new Completion(comp) {
+                            @Override
+                            public void success() {
+                                comp.done();
+                            }
+
+                            @Override
+                            public void fail(ErrorCode errorCode) {
+                                comp.addError(errorCode);
+                                comp.done();
+                            }
+                        })).run(new WhileDoneCompletion(trigger) {
+                            @Override
+                            public void done(ErrorCodeList errorCodeList) {
+                                if (errorCodeList.getCauses().size() > 0) {
+                                    trigger.fail(errorCodeList.getCauses().get(0));
+                                } else {
+                                    trigger.next();
+                                }
+                            }
+                        });
             }
         });
+        fchain.then(new NoRollbackFlow() {
+            @Override
+            public void run(FlowTrigger trigger, Map d) {
+                StartVmOnHypervisorMsg msg = new StartVmOnHypervisorMsg();
+                msg.setVmSpec(spec);
+                bus.makeTargetServiceIdByResourceUuid(msg, HostConstant.SERVICE_ID, spec.getDestHost().getUuid());
+                bus.send(msg, new CloudBusCallBack(trigger) {
+                    @Override
+                    public void run(MessageReply reply) {
+                        if (reply.isSuccess()) {
+                            data.put(VmStartOnHypervisorFlow.class.getName(), true);
+                            trigger.next();
+                        } else {
+                            trigger.fail(reply.getError());
+                        }
+                    }
+                });
+            }
+        });
+        fchain.done(new FlowDoneHandler(chain) {
+            @Override
+            public void handle(Map d) {
+                chain.next();
+            }
+        }).error(new FlowErrorHandler(chain) {
+            @Override
+            public void handle(ErrorCode errCode, Map d) {
+                chain.fail(errCode);
+            }
+        }).start();
     }
 
     @Override

--- a/compute/src/main/java/org/zstack/compute/vm/VmSystemTags.java
+++ b/compute/src/main/java/org/zstack/compute/vm/VmSystemTags.java
@@ -310,4 +310,11 @@ public class VmSystemTags {
     public static PatternedSystemTag VM_STATE_PAUSED_AFTER_MIGRATE = new PatternedSystemTag(("vmPausedAfterMigrate"), VmInstanceVO.class);
 
     public static PatternedSystemTag VM_MEMORY_ACCESS_MODE_SHARED = new PatternedSystemTag(("vmMemoryAccessModeShared"), VmInstanceVO.class);
+
+    public static String HA_PRE_FENCE_SUSPECT_HOST_UUID_TOKEN = "suspectHostUuid";
+    public static String HA_PRE_FENCE_ACCESSIBLE_PEER_HOST_UUID_TOKEN = "accessiblePeerHostUuid";
+    public static PatternedSystemTag HA_PRE_FENCE_PENDING =
+            new PatternedSystemTag(String.format("haPreFencePending::{%s}::{%s}",
+                    HA_PRE_FENCE_SUSPECT_HOST_UUID_TOKEN,
+                    HA_PRE_FENCE_ACCESSIBLE_PEER_HOST_UUID_TOKEN), VmInstanceVO.class);
 }

--- a/header/src/main/java/org/zstack/header/vm/HaStartVmInstanceMsg.java
+++ b/header/src/main/java/org/zstack/header/vm/HaStartVmInstanceMsg.java
@@ -12,6 +12,7 @@ public class HaStartVmInstanceMsg extends NeedReplyMessage implements VmInstance
     private String vmInstanceUuid;
     private String judgerClassName;
     private List<String> softAvoidHostUuids;
+    private String accessiblePeerHostUuid;
     private String haReason;
 
     public String getJudgerClassName() {
@@ -28,6 +29,14 @@ public class HaStartVmInstanceMsg extends NeedReplyMessage implements VmInstance
 
     public void setSoftAvoidHostUuids(List<String> softAvoidHostUuids) {
         this.softAvoidHostUuids = softAvoidHostUuids;
+    }
+
+    public String getAccessiblePeerHostUuid() {
+        return accessiblePeerHostUuid;
+    }
+
+    public void setAccessiblePeerHostUuid(String accessiblePeerHostUuid) {
+        this.accessiblePeerHostUuid = accessiblePeerHostUuid;
     }
 
     @Override

--- a/header/src/main/java/org/zstack/header/vm/VmBeforeStartOnHypervisorExtensionPoint.java
+++ b/header/src/main/java/org/zstack/header/vm/VmBeforeStartOnHypervisorExtensionPoint.java
@@ -1,7 +1,14 @@
 package org.zstack.header.vm;
 
+import org.zstack.header.core.Completion;
+
 /**
  */
 public interface VmBeforeStartOnHypervisorExtensionPoint {
-    void beforeStartVmOnHypervisor(VmInstanceSpec spec);
+    default void beforeStartVmOnHypervisor(VmInstanceSpec spec) {}
+
+    default void beforeStartVmOnHypervisor(VmInstanceSpec spec, Completion completion) {
+        beforeStartVmOnHypervisor(spec);
+        completion.success();
+    }
 }


### PR DESCRIPTION
## Summary
Backport the HA pre-fence confirmation fix from ZSTAC-83890 to 5.4.10 for ZSTAC-84992. The change prevents VM HA restart from proceeding before the suspect host is confirmed/fenced, reducing Ceph HA split-brain risk during transient watcher gaps.

## Changes
- Carry `accessiblePeerHostUuid` through HA VM start messages.
- Add `haPreFencePending` VM system tag to mark the HA pre-fence window.
- Allow before-start-on-hypervisor extensions to run asynchronous completion logic before the actual hypervisor start.

## Source
- Source issue: ZSTAC-83890
- Source MR: zstackio/zstack!10056
- Source commit: 6358576e77a5b7fd22b6ab7ed13925fa9c74cd90

## Testing
- [x] `git diff --check upstream/5.4.10..HEAD`
- [x] `mvn -pl compute -am -DskipTests compile`
- [x] `mvn -pl compute -am -DskipTests install`
- [x] Local code review: code-review-kit fallback APPROVED, 0 must-fix
- [ ] CI pipeline

## Notes
This MR is part of a 3-repo backport with premium and zstack-utility. The three MRs should be merged together.

Resolves: ZSTAC-84992

sync from gitlab !10439