### PR TITLE
<fix>[zwatch]: VPC Router CPU alarm use external monitoring

### DIFF
--- a/conf/db/upgrade/V5.4.10__schema.sql
+++ b/conf/db/upgrade/V5.4.10__schema.sql
@@ -5,3 +5,16 @@ CALL CREATE_INDEX('GpuDeviceSpecVO', 'idx_gpu_spec_normalized_model', 'normalize
 UPDATE VolumeSnapshotVO AS sp, PrimaryStorageVO AS ps
 SET sp.primaryStorageInstallPath = REPLACE(sp.primaryStorageInstallPath, '/dev/', 'sharedblock://')
 WHERE sp.primaryStorageUuid = ps.uuid AND ps.type = 'SharedBlock' AND sp.volumeType = 'Memory' AND sp.primaryStorageInstallPath LIKE '/dev/%';
+
+UPDATE `zstack`.`ActiveAlarmTemplateVO`
+SET `metricName` = 'CPUUsedUtilization'
+WHERE `uuid` = 'c9e6cdca107140bea62b4ca919ff9e88'
+  AND `metricName` = 'VRouterCPUAverageUsedUtilization';
+
+UPDATE `zstack`.`AlarmVO`
+SET `metricName` = 'CPUUsedUtilization'
+WHERE `uuid` IN (
+    SELECT `alarmUuid` FROM `zstack`.`ActiveAlarmVO`
+    WHERE `templateUuid` = 'c9e6cdca107140bea62b4ca919ff9e88'
+)
+  AND `metricName` = 'VRouterCPUAverageUsedUtilization';


### PR DESCRIPTION
Backport the VPC router CPU alarm metric migration to 5.4.10.
Move the source 5.5.12 schema change into the 5.4.10 schema file.

JIRA: ZSTAC-86427
Related: ZSTAC-81171
Change-Id: I7778676171646874706164777869707279776172
(cherry picked from commit 0bfbf4544c99462ef85235d83c834b4b9b965780)

sync from gitlab !10440