### PR TITLE
<fix>[core]: avoid grouped queue timer leak

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -187,6 +187,11 @@
             <groupId>io.opentelemetry.semconv</groupId>
             <artifactId>opentelemetry-semconv-incubating</artifactId>
         </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/core/src/main/java/org/zstack/core/thread/GroupedConsumeQueue.java
+++ b/core/src/main/java/org/zstack/core/thread/GroupedConsumeQueue.java
@@ -1,17 +1,26 @@
 package org.zstack.core.thread;
 
+import org.zstack.utils.Utils;
+import org.zstack.utils.logging.CLogger;
+
 import java.util.*;
 import java.util.TimerTask;
 import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Created by MaJin on 2020/5/25.
  */
 public abstract class GroupedConsumeQueue<T> {
-    private Queue<T> itemPool = new LinkedBlockingQueue<>();
-    private Map<String, DelayedQueue<T>> groupedQueue = new HashMap<>();
+    private static final CLogger logger = Utils.getLogger(GroupedConsumeQueue.class);
+    private static final AtomicInteger TIMER_SEQUENCE = new AtomicInteger(0);
 
-    private int maxDelayedTime = 1;
+    private final Queue<T> itemPool = new LinkedBlockingQueue<>();
+    private final Map<String, DelayedQueue<T>> groupedQueue = new HashMap<>();
+    private final Object timerLock = new Object();
+    private Timer timer;
+
+    private volatile int maxDelayedTime = 1;
 
     public GroupedConsumeQueue(int maxDelayedTime) {
         this.maxDelayedTime = maxDelayedTime;
@@ -27,18 +36,34 @@ public abstract class GroupedConsumeQueue<T> {
     }
 
     public void start() {
-        java.util.TimerTask timerTask = new TimerTask() {
-            @Override
-            public void run() {
-                try {
-                    collectItems();
-                } finally {
-                    start();
-                }
+        synchronized (timerLock) {
+            if (timer != null) {
+                return;
             }
-        };
 
-        new Timer().schedule(timerTask, 1000);
+            timer = new Timer(String.format("grouped-consume-queue-%s", TIMER_SEQUENCE.incrementAndGet()), true);
+            timer.schedule(new TimerTask() {
+                @Override
+                public void run() {
+                    try {
+                        collectItems();
+                    } catch (Throwable t) {
+                        logger.warn("failed to collect grouped queue items", t);
+                    }
+                }
+            }, 1000, 1000);
+        }
+    }
+
+    public void stop() {
+        synchronized (timerLock) {
+            if (timer == null) {
+                return;
+            }
+
+            timer.cancel();
+            timer = null;
+        }
     }
 
     public void setMaxDelayedTime(int maxDelayedTime) {

--- a/core/src/test/java/org/zstack/core/thread/GroupedConsumeQueueTest.java
+++ b/core/src/test/java/org/zstack/core/thread/GroupedConsumeQueueTest.java
@@ -1,0 +1,99 @@
+package org.zstack.core.thread;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+public class GroupedConsumeQueueTest {
+    private static final String TIMER_THREAD_PREFIX = "grouped-consume-queue-";
+
+    @Test
+    public void startShouldBeIdempotent() throws Exception {
+        int before = timerThreadCount();
+        GroupedConsumeQueue<String> queue = newQueue(ignored -> {
+        });
+
+        try {
+            for (int i = 0; i < 10; i++) {
+                queue.start();
+            }
+
+            waitUntilTimerThreadCount(before + 1);
+            TimeUnit.MILLISECONDS.sleep(2200);
+            Assert.assertEquals(before + 1, timerThreadCount());
+        } finally {
+            queue.stop();
+        }
+
+        waitUntilTimerThreadCount(before);
+    }
+
+    @Test
+    public void groupedItemsShouldStillBeConsumed() throws Exception {
+        CountDownLatch latch = new CountDownLatch(1);
+        List<String> consumed = Collections.synchronizedList(new ArrayList<>());
+        GroupedConsumeQueue<String> queue = newQueue(items -> {
+            consumed.addAll(items);
+            latch.countDown();
+        });
+
+        try {
+            queue.offer("a-1");
+            queue.offer("a-2");
+            queue.start();
+
+            Assert.assertTrue(latch.await(3, TimeUnit.SECONDS));
+            List<String> sorted = new ArrayList<>(consumed);
+            Collections.sort(sorted);
+            Assert.assertEquals(Arrays.asList("a-1", "a-2"), sorted);
+        } finally {
+            queue.stop();
+        }
+    }
+
+    private GroupedConsumeQueue<String> newQueue(GroupConsumer consumer) {
+        return new GroupedConsumeQueue<String>(1) {
+            @Override
+            protected void consume(List<String> groupedItems) {
+                consumer.consume(groupedItems);
+            }
+
+            @Override
+            protected String getGroupId(String item) {
+                return item.substring(0, 1);
+            }
+        };
+    }
+
+    private int timerThreadCount() {
+        int count = 0;
+        for (Thread thread : Thread.getAllStackTraces().keySet()) {
+            if (thread.isAlive() && thread.getName().startsWith(TIMER_THREAD_PREFIX)) {
+                count++;
+            }
+        }
+        return count;
+    }
+
+    private void waitUntilTimerThreadCount(int expected) throws InterruptedException {
+        long deadline = System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(5);
+        while (System.currentTimeMillis() < deadline) {
+            if (timerThreadCount() == expected) {
+                return;
+            }
+            TimeUnit.MILLISECONDS.sleep(100);
+        }
+
+        Assert.assertEquals(expected, timerThreadCount());
+    }
+
+    private interface GroupConsumer {
+        void consume(List<String> items);
+    }
+}


### PR DESCRIPTION
## Root Cause

`GroupedConsumeQueue.start()` created a new `Timer` on every run and the
scheduled task recursively called `start()` in `finally`. Long-running queue
users leaked Timer threads at a steady rate and could eventually exhaust
native threads, leaving the management node process alive but unresponsive.

The ZWatch rule evaluation backlog observed in ZSTAC-86596 is a real pressure
signal. Resource-granular alarm state can amplify evaluation and DB work, but
the reproducible native thread growth maps directly to `GroupedConsumeQueue`.

## Changes

- Make `GroupedConsumeQueue.start()` idempotent.
- Reuse one daemon `Timer` per queue instance instead of recursively creating
  timers.
- Add `stop()` to cancel the timer.
- Add `GroupedConsumeQueueTest` for idempotent start behavior and grouped
  consumption.

## Verification

- `mvn install -pl core -am -DskipTests -nsu`
- `mvn test -pl core -Dtest=GroupedConsumeQueueTest -DskipJacoco=true -Djacoco.skip=true -nsu`

Attempted integration command:

`mvn test -Dtest=CoreLibraryTest -DsubCaseCollectionStrategy=Designated -DcaseFilePath=/tmp/ZSTAC-86596-cases.txt -DskipJacoco=true -Djacoco.skip=true`

This was blocked before the target case ran because the local `test` module
currently fails during test compilation on unrelated missing symbols, including
`KVMHostUtils.shouldRestartLibvirtdDuringDeploy`,
`ApiResponse.completeFailure`, and `ZbsStorageController.VhostTargetHealthRsp`.

Related: ZSTAC-86596

sync from gitlab !10448