### PR TITLE
ZSTAC-84940 Backport launch command SDK to 5.5.28

### DIFF
--- a/conf/db/upgrade/V5.5.28__schema.sql
+++ b/conf/db/upgrade/V5.5.28__schema.sql
@@ -281,6 +281,7 @@ CALL ADD_COLUMN('ModelVO', 'zoneUuid', 'VARCHAR(32)', 1, NULL);
 CALL ADD_COLUMN('ModelServiceVO', 'zoneUuid', 'VARCHAR(32)', 1, NULL);
 CALL ADD_COLUMN('DatasetVO', 'zoneUuid', 'VARCHAR(32)', 1, NULL);
 CALL ADD_COLUMN('ModelServiceInstanceGroupVO', 'zoneUuid', 'VARCHAR(32)', 1, NULL);
+CALL ADD_COLUMN('ModelServiceInstanceVO', 'launchCommand', 'MEDIUMTEXT', 1, NULL);
 CALL ADD_COLUMN('ZdfsVO', 'metaServerPort', 'INT', 0, 6379);
 
 UPDATE `zstack`.`ModelCenterVO` mc

--- a/sdk/src/main/java/SourceClassMap.java
+++ b/sdk/src/main/java/SourceClassMap.java
@@ -37,6 +37,7 @@ public class SourceClassMap {
 			put("org.zstack.ai.message.ModelCenterServiceInventory$ServiceStatus", "org.zstack.sdk.ServiceStatus");
 			put("org.zstack.ai.message.ModelCenterServiceInventory$ZdfsService", "org.zstack.sdk.ZdfsService");
 			put("org.zstack.ai.message.ModelService", "org.zstack.sdk.ModelService");
+			put("org.zstack.ai.message.ModelServiceInstanceLaunchCommandInventory", "org.zstack.sdk.ModelServiceInstanceLaunchCommandInventory");
 			put("org.zstack.ai.message.ModelServiceLaunchCommandInventory", "org.zstack.sdk.ModelServiceLaunchCommandInventory");
 			put("org.zstack.ai.message.ModelServiceMatchEntry", "org.zstack.sdk.ModelServiceMatchEntry");
 			put("org.zstack.ai.message.ModelServiceMatchEntryName", "org.zstack.sdk.ModelServiceMatchEntryName");
@@ -1311,6 +1312,7 @@ public class SourceClassMap {
 			put("org.zstack.sdk.ModelServiceGroupDatasetRefInventory", "org.zstack.ai.entity.ModelServiceGroupDatasetRefInventory");
 			put("org.zstack.sdk.ModelServiceInstanceGroupInventory", "org.zstack.ai.entity.ModelServiceInstanceGroupInventory");
 			put("org.zstack.sdk.ModelServiceInstanceInventory", "org.zstack.ai.entity.ModelServiceInstanceInventory");
+			put("org.zstack.sdk.ModelServiceInstanceLaunchCommandInventory", "org.zstack.ai.message.ModelServiceInstanceLaunchCommandInventory");
 			put("org.zstack.sdk.ModelServiceInventory", "org.zstack.ai.entity.ModelServiceInventory");
 			put("org.zstack.sdk.ModelServiceLaunchCommandInventory", "org.zstack.ai.message.ModelServiceLaunchCommandInventory");
 			put("org.zstack.sdk.ModelServiceMatchEntry", "org.zstack.ai.message.ModelServiceMatchEntry");

--- a/sdk/src/main/java/SourceClassMap.java
+++ b/sdk/src/main/java/SourceClassMap.java
@@ -37,6 +37,7 @@ public class SourceClassMap {
 			put("org.zstack.ai.message.ModelCenterServiceInventory$ServiceStatus", "org.zstack.sdk.ServiceStatus");
 			put("org.zstack.ai.message.ModelCenterServiceInventory$ZdfsService", "org.zstack.sdk.ZdfsService");
 			put("org.zstack.ai.message.ModelService", "org.zstack.sdk.ModelService");
+			put("org.zstack.ai.message.ModelServiceLaunchCommandInventory", "org.zstack.sdk.ModelServiceLaunchCommandInventory");
 			put("org.zstack.ai.message.ModelServiceMatchEntry", "org.zstack.sdk.ModelServiceMatchEntry");
 			put("org.zstack.ai.message.ModelServiceMatchEntryName", "org.zstack.sdk.ModelServiceMatchEntryName");
 			put("org.zstack.ai.message.ModelServiceMatchStatus", "org.zstack.sdk.ModelServiceMatchStatus");
@@ -1311,6 +1312,7 @@ public class SourceClassMap {
 			put("org.zstack.sdk.ModelServiceInstanceGroupInventory", "org.zstack.ai.entity.ModelServiceInstanceGroupInventory");
 			put("org.zstack.sdk.ModelServiceInstanceInventory", "org.zstack.ai.entity.ModelServiceInstanceInventory");
 			put("org.zstack.sdk.ModelServiceInventory", "org.zstack.ai.entity.ModelServiceInventory");
+			put("org.zstack.sdk.ModelServiceLaunchCommandInventory", "org.zstack.ai.message.ModelServiceLaunchCommandInventory");
 			put("org.zstack.sdk.ModelServiceMatchEntry", "org.zstack.ai.message.ModelServiceMatchEntry");
 			put("org.zstack.sdk.ModelServiceMatchEntryName", "org.zstack.ai.message.ModelServiceMatchEntryName");
 			put("org.zstack.sdk.ModelServiceMatchStatus", "org.zstack.ai.message.ModelServiceMatchStatus");

--- a/sdk/src/main/java/org/zstack/sdk/GetModelServiceLaunchCommandsAction.java
+++ b/sdk/src/main/java/org/zstack/sdk/GetModelServiceLaunchCommandsAction.java
@@ -1,0 +1,98 @@
+package org.zstack.sdk;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.zstack.sdk.*;
+
+public class GetModelServiceLaunchCommandsAction extends AbstractAction {
+
+    private static final HashMap<String, Parameter> parameterMap = new HashMap<>();
+
+    private static final HashMap<String, Parameter> nonAPIParameterMap = new HashMap<>();
+
+    public static class Result {
+        public ErrorCode error;
+        public org.zstack.sdk.GetModelServiceLaunchCommandsResult value;
+
+        public Result throwExceptionIfError() {
+            if (error != null) {
+                throw new ApiException(
+                    String.format("error[code: %s, description: %s, details: %s, globalErrorCode: %s]", error.code, error.description, error.details, error.globalErrorCode)    
+                );
+            }
+            
+            return this;
+        }
+    }
+
+    @Param(required = false, nonempty = false, nullElements = false, emptyString = true, noTrim = false)
+    public java.util.List groupUuids;
+
+    @Param(required = false, nonempty = false, nullElements = false, emptyString = true, noTrim = false)
+    public java.util.List instanceUuids;
+
+    @Param(required = false)
+    public java.util.List systemTags;
+
+    @Param(required = false)
+    public java.util.List userTags;
+
+    @Param(required = false)
+    public String sessionId;
+
+    @Param(required = false)
+    public String accessKeyId;
+
+    @Param(required = false)
+    public String accessKeySecret;
+
+    @Param(required = false)
+    public String requestIp;
+
+
+    private Result makeResult(ApiResult res) {
+        Result ret = new Result();
+        if (res.error != null) {
+            ret.error = res.error;
+            return ret;
+        }
+        
+        org.zstack.sdk.GetModelServiceLaunchCommandsResult value = res.getResult(org.zstack.sdk.GetModelServiceLaunchCommandsResult.class);
+        ret.value = value == null ? new org.zstack.sdk.GetModelServiceLaunchCommandsResult() : value; 
+
+        return ret;
+    }
+
+    public Result call() {
+        ApiResult res = ZSClient.call(this);
+        return makeResult(res);
+    }
+
+    public void call(final Completion<Result> completion) {
+        ZSClient.call(this, new InternalCompletion() {
+            @Override
+            public void complete(ApiResult res) {
+                completion.complete(makeResult(res));
+            }
+        });
+    }
+
+    protected Map<String, Parameter> getParameterMap() {
+        return parameterMap;
+    }
+
+    protected Map<String, Parameter> getNonAPIParameterMap() {
+        return nonAPIParameterMap;
+    }
+
+    protected RestInfo getRestInfo() {
+        RestInfo info = new RestInfo();
+        info.httpMethod = "GET";
+        info.path = "/ai/model-service-launch-commands";
+        info.needSession = true;
+        info.needPoll = false;
+        info.parameterName = "";
+        return info;
+    }
+
+}

--- a/sdk/src/main/java/org/zstack/sdk/GetModelServiceLaunchCommandsAction.java
+++ b/sdk/src/main/java/org/zstack/sdk/GetModelServiceLaunchCommandsAction.java
@@ -26,16 +26,16 @@ public class GetModelServiceLaunchCommandsAction extends AbstractAction {
     }
 
     @Param(required = false, nonempty = false, nullElements = false, emptyString = true, noTrim = false)
-    public java.util.List groupUuids;
+    public java.util.List<String> groupUuids;
 
     @Param(required = false, nonempty = false, nullElements = false, emptyString = true, noTrim = false)
-    public java.util.List instanceUuids;
+    public java.util.List<String> instanceUuids;
 
     @Param(required = false)
-    public java.util.List systemTags;
+    public java.util.List<String> systemTags;
 
     @Param(required = false)
-    public java.util.List userTags;
+    public java.util.List<String> userTags;
 
     @Param(required = false)
     public String sessionId;

--- a/sdk/src/main/java/org/zstack/sdk/GetModelServiceLaunchCommandsAction.java
+++ b/sdk/src/main/java/org/zstack/sdk/GetModelServiceLaunchCommandsAction.java
@@ -26,16 +26,16 @@ public class GetModelServiceLaunchCommandsAction extends AbstractAction {
     }
 
     @Param(required = false, nonempty = false, nullElements = false, emptyString = true, noTrim = false)
-    public java.util.List<String> groupUuids;
+    public java.util.List groupUuids;
 
     @Param(required = false, nonempty = false, nullElements = false, emptyString = true, noTrim = false)
-    public java.util.List<String> instanceUuids;
+    public java.util.List instanceUuids;
 
     @Param(required = false)
-    public java.util.List<String> systemTags;
+    public java.util.List systemTags;
 
     @Param(required = false)
-    public java.util.List<String> userTags;
+    public java.util.List userTags;
 
     @Param(required = false)
     public String sessionId;

--- a/sdk/src/main/java/org/zstack/sdk/GetModelServiceLaunchCommandsResult.java
+++ b/sdk/src/main/java/org/zstack/sdk/GetModelServiceLaunchCommandsResult.java
@@ -1,0 +1,14 @@
+package org.zstack.sdk;
+
+
+
+public class GetModelServiceLaunchCommandsResult {
+    public java.util.List commands;
+    public void setCommands(java.util.List commands) {
+        this.commands = commands;
+    }
+    public java.util.List getCommands() {
+        return this.commands;
+    }
+
+}

--- a/sdk/src/main/java/org/zstack/sdk/GetModelServiceLaunchCommandsResult.java
+++ b/sdk/src/main/java/org/zstack/sdk/GetModelServiceLaunchCommandsResult.java
@@ -3,11 +3,11 @@ package org.zstack.sdk;
 
 
 public class GetModelServiceLaunchCommandsResult {
-    public java.util.List<ModelServiceInstanceLaunchCommandInventory> commands;
-    public void setCommands(java.util.List<ModelServiceInstanceLaunchCommandInventory> commands) {
+    public java.util.List commands;
+    public void setCommands(java.util.List commands) {
         this.commands = commands;
     }
-    public java.util.List<ModelServiceInstanceLaunchCommandInventory> getCommands() {
+    public java.util.List getCommands() {
         return this.commands;
     }
 

--- a/sdk/src/main/java/org/zstack/sdk/GetModelServiceLaunchCommandsResult.java
+++ b/sdk/src/main/java/org/zstack/sdk/GetModelServiceLaunchCommandsResult.java
@@ -3,11 +3,11 @@ package org.zstack.sdk;
 
 
 public class GetModelServiceLaunchCommandsResult {
-    public java.util.List commands;
-    public void setCommands(java.util.List commands) {
+    public java.util.List<ModelServiceInstanceLaunchCommandInventory> commands;
+    public void setCommands(java.util.List<ModelServiceInstanceLaunchCommandInventory> commands) {
         this.commands = commands;
     }
-    public java.util.List getCommands() {
+    public java.util.List<ModelServiceInstanceLaunchCommandInventory> getCommands() {
         return this.commands;
     }
 

--- a/sdk/src/main/java/org/zstack/sdk/ModelServiceInstanceInventory.java
+++ b/sdk/src/main/java/org/zstack/sdk/ModelServiceInstanceInventory.java
@@ -1,5 +1,6 @@
 package org.zstack.sdk;
 
+import org.zstack.sdk.ModelServiceLaunchCommandInventory;
 import org.zstack.sdk.VmInstanceInventory;
 
 public class ModelServiceInstanceInventory  {
@@ -82,6 +83,14 @@ public class ModelServiceInstanceInventory  {
     }
     public java.lang.String getJupyterUrl() {
         return this.jupyterUrl;
+    }
+
+    public ModelServiceLaunchCommandInventory launchCommand;
+    public void setLaunchCommand(ModelServiceLaunchCommandInventory launchCommand) {
+        this.launchCommand = launchCommand;
+    }
+    public ModelServiceLaunchCommandInventory getLaunchCommand() {
+        return this.launchCommand;
     }
 
     public java.lang.String vmInstanceUuid;

--- a/sdk/src/main/java/org/zstack/sdk/ModelServiceInstanceLaunchCommandInventory.java
+++ b/sdk/src/main/java/org/zstack/sdk/ModelServiceInstanceLaunchCommandInventory.java
@@ -1,0 +1,47 @@
+package org.zstack.sdk;
+
+import org.zstack.sdk.ModelServiceLaunchCommandInventory;
+
+public class ModelServiceInstanceLaunchCommandInventory  {
+
+    public java.lang.String instanceUuid;
+    public void setInstanceUuid(java.lang.String instanceUuid) {
+        this.instanceUuid = instanceUuid;
+    }
+    public java.lang.String getInstanceUuid() {
+        return this.instanceUuid;
+    }
+
+    public java.lang.String groupUuid;
+    public void setGroupUuid(java.lang.String groupUuid) {
+        this.groupUuid = groupUuid;
+    }
+    public java.lang.String getGroupUuid() {
+        return this.groupUuid;
+    }
+
+    public java.lang.String instanceName;
+    public void setInstanceName(java.lang.String instanceName) {
+        this.instanceName = instanceName;
+    }
+    public java.lang.String getInstanceName() {
+        return this.instanceName;
+    }
+
+    public java.lang.String status;
+    public void setStatus(java.lang.String status) {
+        this.status = status;
+    }
+    public java.lang.String getStatus() {
+        return this.status;
+    }
+
+    public ModelServiceLaunchCommandInventory launchCommand;
+    public void setLaunchCommand(ModelServiceLaunchCommandInventory launchCommand) {
+        this.launchCommand = launchCommand;
+    }
+    public ModelServiceLaunchCommandInventory getLaunchCommand() {
+        return this.launchCommand;
+    }
+
+}

--- a/sdk/src/main/java/org/zstack/sdk/ModelServiceInstanceLaunchCommandInventory.java
+++ b/sdk/src/main/java/org/zstack/sdk/ModelServiceInstanceLaunchCommandInventory.java
@@ -1,5 +1,7 @@
 package org.zstack.sdk;
 
+import org.zstack.sdk.ModelServiceLaunchCommandInventory;
+
 public class ModelServiceInstanceLaunchCommandInventory  {
 
     public java.lang.String instanceUuid;

--- a/sdk/src/main/java/org/zstack/sdk/ModelServiceInstanceLaunchCommandInventory.java
+++ b/sdk/src/main/java/org/zstack/sdk/ModelServiceInstanceLaunchCommandInventory.java
@@ -1,7 +1,5 @@
 package org.zstack.sdk;
 
-import org.zstack.sdk.ModelServiceLaunchCommandInventory;
-
 public class ModelServiceInstanceLaunchCommandInventory  {
 
     public java.lang.String instanceUuid;

--- a/sdk/src/main/java/org/zstack/sdk/ModelServiceLaunchCommandInventory.java
+++ b/sdk/src/main/java/org/zstack/sdk/ModelServiceLaunchCommandInventory.java
@@ -1,0 +1,119 @@
+package org.zstack.sdk;
+
+
+
+public class ModelServiceLaunchCommandInventory  {
+
+    public java.lang.String adapter;
+    public void setAdapter(java.lang.String adapter) {
+        this.adapter = adapter;
+    }
+    public java.lang.String getAdapter() {
+        return this.adapter;
+    }
+
+    public java.lang.String framework;
+    public void setFramework(java.lang.String framework) {
+        this.framework = framework;
+    }
+    public java.lang.String getFramework() {
+        return this.framework;
+    }
+
+    public java.lang.String modelDir;
+    public void setModelDir(java.lang.String modelDir) {
+        this.modelDir = modelDir;
+    }
+    public java.lang.String getModelDir() {
+        return this.modelDir;
+    }
+
+    public java.lang.String modelId;
+    public void setModelId(java.lang.String modelId) {
+        this.modelId = modelId;
+    }
+    public java.lang.String getModelId() {
+        return this.modelId;
+    }
+
+    public java.lang.Integer backendPort;
+    public void setBackendPort(java.lang.Integer backendPort) {
+        this.backendPort = backendPort;
+    }
+    public java.lang.Integer getBackendPort() {
+        return this.backendPort;
+    }
+
+    public java.lang.String startupMode;
+    public void setStartupMode(java.lang.String startupMode) {
+        this.startupMode = startupMode;
+    }
+    public java.lang.String getStartupMode() {
+        return this.startupMode;
+    }
+
+    public java.lang.String source;
+    public void setSource(java.lang.String source) {
+        this.source = source;
+    }
+    public java.lang.String getSource() {
+        return this.source;
+    }
+
+    public java.lang.String commandLine;
+    public void setCommandLine(java.lang.String commandLine) {
+        this.commandLine = commandLine;
+    }
+    public java.lang.String getCommandLine() {
+        return this.commandLine;
+    }
+
+    public java.util.List commandArgs;
+    public void setCommandArgs(java.util.List commandArgs) {
+        this.commandArgs = commandArgs;
+    }
+    public java.util.List getCommandArgs() {
+        return this.commandArgs;
+    }
+
+    public java.lang.String executedCommand;
+    public void setExecutedCommand(java.lang.String executedCommand) {
+        this.executedCommand = executedCommand;
+    }
+    public java.lang.String getExecutedCommand() {
+        return this.executedCommand;
+    }
+
+    public java.lang.Boolean shell;
+    public void setShell(java.lang.Boolean shell) {
+        this.shell = shell;
+    }
+    public java.lang.Boolean getShell() {
+        return this.shell;
+    }
+
+    public java.lang.Integer pid;
+    public void setPid(java.lang.Integer pid) {
+        this.pid = pid;
+    }
+    public java.lang.Integer getPid() {
+        return this.pid;
+    }
+
+    public java.lang.String logFile;
+    public void setLogFile(java.lang.String logFile) {
+        this.logFile = logFile;
+    }
+    public java.lang.String getLogFile() {
+        return this.logFile;
+    }
+
+    public java.lang.String generatedAt;
+    public void setGeneratedAt(java.lang.String generatedAt) {
+        this.generatedAt = generatedAt;
+    }
+    public java.lang.String getGeneratedAt() {
+        return this.generatedAt;
+    }
+
+}

--- a/testlib/src/main/java/org/zstack/testlib/ApiHelper.groovy
+++ b/testlib/src/main/java/org/zstack/testlib/ApiHelper.groovy
@@ -3695,20 +3695,20 @@ abstract class ApiHelper {
         c.resolveStrategy = Closure.OWNER_FIRST
         c.delegate = a
         c()
-
+        
 
         if (System.getProperty("apipath") != null) {
             if (a.apiId == null) {
                 a.apiId = Platform.uuid
             }
-
+    
             def tracker = new ApiPathTracker(a.apiId)
             def out = errorOut(a.call())
             def path = tracker.getApiPath()
             if (!path.isEmpty()) {
                 Test.apiPaths[a.class.name] = path.join(" --->\n")
             }
-
+        
             return out
         } else {
             return errorOut(a.call())
@@ -46959,20 +46959,20 @@ abstract class ApiHelper {
         c.resolveStrategy = Closure.OWNER_FIRST
         c.delegate = a
         c()
-
+        
 
         if (System.getProperty("apipath") != null) {
             if (a.apiId == null) {
                 a.apiId = Platform.uuid
             }
-
+    
             def tracker = new ApiPathTracker(a.apiId)
             def out = errorOut(a.call())
             def path = tracker.getApiPath()
             if (!path.isEmpty()) {
                 Test.apiPaths[a.class.name] = path.join(" --->\n")
             }
-
+        
             return out
         } else {
             return errorOut(a.call())
@@ -48530,14 +48530,14 @@ abstract class ApiHelper {
             if (a.apiId == null) {
                 a.apiId = Platform.uuid
             }
-
+    
             def tracker = new ApiPathTracker(a.apiId)
             def out = errorOut(a.call())
             def path = tracker.getApiPath()
             if (!path.isEmpty()) {
                 Test.apiPaths[a.class.name] = path.join(" --->\n")
             }
-
+        
             return out
         } else {
             return errorOut(a.call())


### PR DESCRIPTION
Backport the control-plane SDK/API helper pieces for model service launch commands from feature-5.5.28-aios to 5.5.28.

Scope:
- Add ModelServiceInstanceVO.launchCommand schema upgrade.
- Add SDK inventories/actions/results for GetModelServiceLaunchCommands.
- Sync ApiHelper and SourceClassMap generated outputs.

Verification:
- Passed full premium build via verify-case Docker:
  `/home/test/workspace/scripts/verify-case-docker.sh --zstack /home/test/workspace/zstack-5.5.28-launch-commands --premium /home/test/workspace/premium-5.5.28-launch-commands --name verify-zstac84940-5528 --recreate --build`
  Result: BUILD SUCCESS, total time 21:09.
- Passed Groovy case via verify-case Docker:
  `mvn test -Dtest='ModelServiceCase' -Dsurefire.useFile=false -Djacoco.skip=true`
  Result: Tests run: 1, Failures: 0, Errors: 0, Skipped: 0; BUILD SUCCESS, total time 11:20.

Related: ZSTAC-84940, ZSTAC-85373

sync from gitlab !10461