### PR TITLE
<fix>[errorcode]: localize wrapper errors from cause

### DIFF
--- a/core/src/main/java/org/zstack/core/errorcode/GlobalErrorCodeI18nServiceImpl.java
+++ b/core/src/main/java/org/zstack/core/errorcode/GlobalErrorCodeI18nServiceImpl.java
@@ -130,31 +130,88 @@ public class GlobalErrorCodeI18nServiceImpl implements GlobalErrorCodeI18nServic
         }
 
         String resolvedLocale = locale != null ? locale : LocaleUtils.DEFAULT_LOCALE;
+        localizeNestedErrors(error, resolvedLocale);
 
+        String message = null;
         if (error.getGlobalErrorCode() != null) {
-            String message = getLocalizedMessage(error.getGlobalErrorCode(), resolvedLocale, error.getFormatArgs());
-            if (message != null) {
-                error.setMessage(message);
-            }
+            message = getLocalizedMessage(error.getGlobalErrorCode(), resolvedLocale, error.getFormatArgs());
         }
 
-        // guarantee: message is never null
-        if (error.getMessage() == null) {
-            String fallback = error.getDetails() != null ? error.getDetails() : error.getDescription();
-            error.setMessage(fallback != null ? fallback : (error.getCode() != null ? error.getCode() : ""));
+        if (message == null) {
+            message = getLocalizedCauseMessage(error, resolvedLocale);
         }
 
+        if (message == null) {
+            message = error.getDetails() != null ? error.getDetails() : error.getDescription();
+        }
+
+        error.setMessage(message != null ? message : (error.getCode() != null ? error.getCode() : ""));
+    }
+
+    private void localizeNestedErrors(ErrorCode error, String locale) {
         if (error.getCause() != null) {
-            localizeErrorCode(error.getCause(), resolvedLocale);
+            localizeErrorCode(error.getCause(), locale);
         }
 
         if (error instanceof ErrorCodeList) {
             List<ErrorCode> causes = ((ErrorCodeList) error).getCauses();
             if (causes != null) {
                 for (ErrorCode cause : causes) {
-                    localizeErrorCode(cause, resolvedLocale);
+                    if (cause != null) {
+                        localizeErrorCode(cause, locale);
+                    }
                 }
             }
         }
+    }
+
+    private String getLocalizedCauseMessage(ErrorCode error, String locale) {
+        if (hasLocalizedTemplate(error.getCause(), locale) && isNotBlank(error.getCause().getMessage())) {
+            return error.getCause().getMessage();
+        }
+
+        if (error instanceof ErrorCodeList) {
+            List<ErrorCode> causes = ((ErrorCodeList) error).getCauses();
+            if (causes != null) {
+                for (ErrorCode cause : causes) {
+                    if (hasLocalizedTemplate(cause, locale) && isNotBlank(cause.getMessage())) {
+                        return cause.getMessage();
+                    }
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private boolean hasLocalizedTemplate(ErrorCode error, String locale) {
+        if (error == null) {
+            return false;
+        }
+
+        if (error.getGlobalErrorCode() != null && getTemplate(error.getGlobalErrorCode(), locale) != null) {
+            return true;
+        }
+
+        if (hasLocalizedTemplate(error.getCause(), locale)) {
+            return true;
+        }
+
+        if (error instanceof ErrorCodeList) {
+            List<ErrorCode> causes = ((ErrorCodeList) error).getCauses();
+            if (causes != null) {
+                for (ErrorCode cause : causes) {
+                    if (hasLocalizedTemplate(cause, locale)) {
+                        return true;
+                    }
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private boolean isNotBlank(String value) {
+        return value != null && !value.trim().isEmpty();
     }
 }

--- a/test/src/test/groovy/org/zstack/test/integration/rest/ErrorCodeI18nCase.groovy
+++ b/test/src/test/groovy/org/zstack/test/integration/rest/ErrorCodeI18nCase.groovy
@@ -38,6 +38,8 @@ class ErrorCodeI18nCase extends SubCase {
             testServiceFormatsArgs()
             testServiceRecursiveCauseChain()
             testServiceErrorCodeList()
+            testServiceFallbackToLocalizedCauseWhenOuterCodeHasNoTemplate()
+            testServiceKeepsOuterDetailsWhenCauseHasNoTemplate()
             testRestServerSyncApiWithAcceptLanguage()
             testRestServerAsyncApiWithAcceptLanguage()
             testNoAcceptLanguageHeaderFallsBackToEnUS()
@@ -129,6 +131,54 @@ class ErrorCodeI18nCase extends SubCase {
         assert errorList.getMessage().contains("list-uuid")
         assert errorList.getCauses()[0].getMessage().contains("child1-uuid")
         assert errorList.getCauses()[1].getMessage().contains("child2-uuid")
+    }
+
+    void testServiceFallbackToLocalizedCauseWhenOuterCodeHasNoTemplate() {
+        GlobalErrorCodeI18nService i18nService = bean(GlobalErrorCodeI18nService.class)
+
+        ErrorCode cause = new ErrorCode()
+        cause.setCode(SysErrors.OPERATION_ERROR.toString())
+        cause.setDetails("当VM平台为OTHER时，DataVolumes和CDROM的数量不能超过3个，目前为4")
+        cause.setGlobalErrorCode("ORG_ZSTACK_KVM_10080")
+        cause.setFormatArgs(["4"] as String[])
+
+        ErrorCode outer = new ErrorCode()
+        outer.setCode("VM.1001")
+        outer.setDescription("Unable to start a vm")
+        outer.setDetails("当VM平台为OTHER时，DataVolumes和CDROM的数量不能超过3个，目前为4")
+        outer.setGlobalErrorCode("ORG_ZSTACK_COMPUTE_VM_10291")
+        outer.setCause(cause)
+
+        i18nService.localizeErrorCode(outer, "en_US")
+
+        assert outer.getMessage() == cause.getMessage()
+        assert outer.getMessage().contains("When the VM platform is Other")
+        assert !outer.getMessage().contains("当VM平台")
+
+        i18nService.localizeErrorCode(outer, "zh_CN")
+
+        assert outer.getMessage() == cause.getMessage()
+        assert outer.getMessage().contains("虚拟机平台")
+    }
+
+    void testServiceKeepsOuterDetailsWhenCauseHasNoTemplate() {
+        GlobalErrorCodeI18nService i18nService = bean(GlobalErrorCodeI18nService.class)
+
+        ErrorCode cause = new ErrorCode()
+        cause.setCode(SysErrors.OPERATION_ERROR.toString())
+        cause.setDetails("inner raw details")
+        cause.setGlobalErrorCode("UNMAPPED_CAUSE_CODE")
+
+        ErrorCode outer = new ErrorCode()
+        outer.setCode("VM.1001")
+        outer.setDetails("outer raw details")
+        outer.setGlobalErrorCode("UNMAPPED_OUTER_CODE")
+        outer.setCause(cause)
+
+        i18nService.localizeErrorCode(outer, "en_US")
+
+        assert cause.getMessage() == "inner raw details"
+        assert outer.getMessage() == "outer raw details"
     }
 
     void testRestServerSyncApiWithAcceptLanguage() {


### PR DESCRIPTION
## ZSTAC-86593

### Root Cause
The VM start API wraps the KVM failure into `ORG_ZSTACK_COMPUTE_VM_10291`, but that wrapper code has no global i18n template. Error localization previously fell back to the wrapper details before using the localized cause, so REST responses could keep the management-node-localized Chinese text even when `Accept-Language` requested English.

### Changes
| Module | Change |
|--------|--------|
| `core` | Localize nested causes first and reuse the localized cause message when a wrapper code has no i18n template. |
| `test` | Added coverage for an unmapped VM start wrapper over a mapped KVM cause in `en_US` and `zh_CN`. |

### Verification
- Passed: `mvn -Dmaven.repo.local=/home/pandawuu/zstackProject/zstack/worktrees/ZSTAC-86593/.m2/repository -DskipTests -pl core -am install`
- Passed: `GlobalErrorCodeI18nServiceImpl` direct verifier for `en_US` and `zh_CN` wrapper fallback.
- Passed once: `mvn -Dmaven.repo.local=/home/pandawuu/zstackProject/zstack/worktrees/ZSTAC-86593/.m2/repository -Dtest=org.zstack.test.integration.rest.ErrorCodeI18nCase -DfailIfNoTests=false -Dclean -P premium -pl test -am test`
- Later reruns of the same integration test failed before executing test methods due local management-node bootstrap issues (`StaticIpOperator.installStaticIpValidator` NPE / `GlobalConfigFacadeImpl` transaction error, `Tests run: 0`).

Related: ZSTAC-86593

sync from gitlab !10464