### PR TITLE
<fix>[errorcode]: localize error details

### DIFF
--- a/core/src/main/java/org/zstack/core/errorcode/GlobalErrorCodeI18nService.java
+++ b/core/src/main/java/org/zstack/core/errorcode/GlobalErrorCodeI18nService.java
@@ -23,13 +23,14 @@ public interface GlobalErrorCodeI18nService {
     void localizeErrorCode(ErrorCode error, String locale);
 
     /**
-     * Recursively localize an ErrorCode and its cause chain,
+     * Create a copy of an ErrorCode and recursively localize its cause chain,
      * setting both the message and details fields for response payloads.
      *
-     * @param error the ErrorCode to localize
+     * @param error the ErrorCode to copy and localize
      * @param locale the locale key
+     * @return a localized copy, or null if error is null
      */
-    void localizeErrorCodeDetails(ErrorCode error, String locale);
+    ErrorCode localizeErrorCodeDetails(ErrorCode error, String locale);
 
     /**
      * Get the set of available locale keys loaded from JSON files.

--- a/core/src/main/java/org/zstack/core/errorcode/GlobalErrorCodeI18nService.java
+++ b/core/src/main/java/org/zstack/core/errorcode/GlobalErrorCodeI18nService.java
@@ -23,6 +23,15 @@ public interface GlobalErrorCodeI18nService {
     void localizeErrorCode(ErrorCode error, String locale);
 
     /**
+     * Recursively localize an ErrorCode and its cause chain,
+     * setting both the message and details fields for response payloads.
+     *
+     * @param error the ErrorCode to localize
+     * @param locale the locale key
+     */
+    void localizeErrorCodeDetails(ErrorCode error, String locale);
+
+    /**
      * Get the set of available locale keys loaded from JSON files.
      */
     java.util.Set<String> getAvailableLocales();

--- a/core/src/main/java/org/zstack/core/errorcode/GlobalErrorCodeI18nServiceImpl.java
+++ b/core/src/main/java/org/zstack/core/errorcode/GlobalErrorCodeI18nServiceImpl.java
@@ -125,32 +125,48 @@ public class GlobalErrorCodeI18nServiceImpl implements GlobalErrorCodeI18nServic
 
     @Override
     public void localizeErrorCode(ErrorCode error, String locale) {
+        localizeErrorCode(error, locale, false);
+    }
+
+    @Override
+    public void localizeErrorCodeDetails(ErrorCode error, String locale) {
+        localizeErrorCode(error, locale, true);
+    }
+
+    private void localizeErrorCode(ErrorCode error, String locale, boolean localizeDetails) {
         if (error == null) {
             return;
         }
 
         String resolvedLocale = locale != null ? locale : LocaleUtils.DEFAULT_LOCALE;
-        localizeNestedErrors(error, resolvedLocale);
+        localizeNestedErrors(error, resolvedLocale, localizeDetails);
 
         String message = null;
+        boolean localized = false;
         if (error.getGlobalErrorCode() != null) {
             message = getLocalizedMessage(error.getGlobalErrorCode(), resolvedLocale, error.getFormatArgs());
+            localized = message != null;
         }
 
         if (message == null) {
             message = getLocalizedCauseMessage(error, resolvedLocale);
+            localized = message != null;
         }
 
         if (message == null) {
             message = error.getDetails() != null ? error.getDetails() : error.getDescription();
         }
 
-        error.setMessage(message != null ? message : (error.getCode() != null ? error.getCode() : ""));
+        String resolvedMessage = message != null ? message : (error.getCode() != null ? error.getCode() : "");
+        error.setMessage(resolvedMessage);
+        if (localizeDetails && localized) {
+            error.setDetails(resolvedMessage);
+        }
     }
 
-    private void localizeNestedErrors(ErrorCode error, String locale) {
+    private void localizeNestedErrors(ErrorCode error, String locale, boolean localizeDetails) {
         if (error.getCause() != null) {
-            localizeErrorCode(error.getCause(), locale);
+            localizeErrorCode(error.getCause(), locale, localizeDetails);
         }
 
         if (error instanceof ErrorCodeList) {
@@ -158,7 +174,7 @@ public class GlobalErrorCodeI18nServiceImpl implements GlobalErrorCodeI18nServic
             if (causes != null) {
                 for (ErrorCode cause : causes) {
                     if (cause != null) {
-                        localizeErrorCode(cause, locale);
+                        localizeErrorCode(cause, locale, localizeDetails);
                     }
                 }
             }

--- a/core/src/main/java/org/zstack/core/errorcode/GlobalErrorCodeI18nServiceImpl.java
+++ b/core/src/main/java/org/zstack/core/errorcode/GlobalErrorCodeI18nServiceImpl.java
@@ -129,28 +129,38 @@ public class GlobalErrorCodeI18nServiceImpl implements GlobalErrorCodeI18nServic
     }
 
     @Override
-    public void localizeErrorCodeDetails(ErrorCode error, String locale) {
-        localizeErrorCode(error, locale, true);
+    public ErrorCode localizeErrorCodeDetails(ErrorCode error, String locale) {
+        ErrorCode localized = copyErrorCode(error);
+        localizeErrorCode(localized, locale, true);
+        return localized;
     }
 
-    private void localizeErrorCode(ErrorCode error, String locale, boolean localizeDetails) {
+    private LocalizationResult localizeErrorCode(ErrorCode error, String locale, boolean localizeDetails) {
         if (error == null) {
-            return;
+            return LocalizationResult.notLocalized();
         }
 
         String resolvedLocale = locale != null ? locale : LocaleUtils.DEFAULT_LOCALE;
-        localizeNestedErrors(error, resolvedLocale, localizeDetails);
+        LocalizationResult causeResult = localizeErrorCode(error.getCause(), resolvedLocale, localizeDetails);
+        List<LocalizationResult> listCauseResults = localizeListCauses(error, resolvedLocale, localizeDetails);
 
         String message = null;
         boolean localized = false;
+        boolean completelyFormatted = false;
         if (error.getGlobalErrorCode() != null) {
-            message = getLocalizedMessage(error.getGlobalErrorCode(), resolvedLocale, error.getFormatArgs());
-            localized = message != null;
+            String template = getTemplate(error.getGlobalErrorCode(), resolvedLocale);
+            if (template != null) {
+                message = formatTemplate(template, error.getFormatArgs());
+                localized = true;
+                completelyFormatted = isTemplateCompletelyFormatted(template, error.getFormatArgs());
+            }
         }
 
         if (message == null) {
-            message = getLocalizedCauseMessage(error, resolvedLocale);
-            localized = message != null;
+            LocalizationResult nestedResult = getLocalizedCauseResult(causeResult, listCauseResults);
+            message = nestedResult.message;
+            localized = nestedResult.localized;
+            completelyFormatted = nestedResult.completelyFormatted;
         }
 
         if (message == null) {
@@ -159,75 +169,91 @@ public class GlobalErrorCodeI18nServiceImpl implements GlobalErrorCodeI18nServic
 
         String resolvedMessage = message != null ? message : (error.getCode() != null ? error.getCode() : "");
         error.setMessage(resolvedMessage);
-        if (localizeDetails && localized) {
+        if (localizeDetails && localized && completelyFormatted) {
             error.setDetails(resolvedMessage);
         }
+        return new LocalizationResult(resolvedMessage, localized, completelyFormatted);
     }
 
-    private void localizeNestedErrors(ErrorCode error, String locale, boolean localizeDetails) {
-        if (error.getCause() != null) {
-            localizeErrorCode(error.getCause(), locale, localizeDetails);
-        }
-
+    private List<LocalizationResult> localizeListCauses(ErrorCode error, String locale, boolean localizeDetails) {
+        List<LocalizationResult> results = new ArrayList<>();
         if (error instanceof ErrorCodeList) {
             List<ErrorCode> causes = ((ErrorCodeList) error).getCauses();
             if (causes != null) {
                 for (ErrorCode cause : causes) {
-                    if (cause != null) {
-                        localizeErrorCode(cause, locale, localizeDetails);
-                    }
+                    results.add(localizeErrorCode(cause, locale, localizeDetails));
                 }
             }
         }
+        return results;
     }
 
-    private String getLocalizedCauseMessage(ErrorCode error, String locale) {
-        if (hasLocalizedTemplate(error.getCause(), locale) && isNotBlank(error.getCause().getMessage())) {
-            return error.getCause().getMessage();
+    private LocalizationResult getLocalizedCauseResult(LocalizationResult causeResult,
+                                                        List<LocalizationResult> listCauseResults) {
+        if (causeResult.localized && isNotBlank(causeResult.message)) {
+            return causeResult;
         }
 
-        if (error instanceof ErrorCodeList) {
-            List<ErrorCode> causes = ((ErrorCodeList) error).getCauses();
-            if (causes != null) {
-                for (ErrorCode cause : causes) {
-                    if (hasLocalizedTemplate(cause, locale) && isNotBlank(cause.getMessage())) {
-                        return cause.getMessage();
-                    }
-                }
+        for (LocalizationResult result : listCauseResults) {
+            if (result.localized && isNotBlank(result.message)) {
+                return result;
             }
         }
 
-        return null;
+        return LocalizationResult.notLocalized();
     }
 
-    private boolean hasLocalizedTemplate(ErrorCode error, String locale) {
-        if (error == null) {
+    private boolean isTemplateCompletelyFormatted(String template, String[] formatArgs) {
+        try {
+            Object[] args = formatArgs == null ? new Object[0] : formatArgs;
+            String.format(template, args);
+            return true;
+        } catch (IllegalFormatException e) {
             return false;
         }
+    }
 
-        if (error.getGlobalErrorCode() != null && getTemplate(error.getGlobalErrorCode(), locale) != null) {
-            return true;
+    private ErrorCode copyErrorCode(ErrorCode error) {
+        if (error == null) {
+            return null;
         }
 
-        if (hasLocalizedTemplate(error.getCause(), locale)) {
-            return true;
-        }
+        ErrorCode copy = error.copy();
+        copy.setCause(copyErrorCode(error.getCause()));
 
         if (error instanceof ErrorCodeList) {
             List<ErrorCode> causes = ((ErrorCodeList) error).getCauses();
-            if (causes != null) {
+            if (causes == null) {
+                ((ErrorCodeList) copy).setCauses(null);
+            } else {
+                List<ErrorCode> copiedCauses = new ArrayList<>(causes.size());
                 for (ErrorCode cause : causes) {
-                    if (hasLocalizedTemplate(cause, locale)) {
-                        return true;
-                    }
+                    copiedCauses.add(copyErrorCode(cause));
                 }
+                ((ErrorCodeList) copy).setCauses(copiedCauses);
             }
         }
 
-        return false;
+        return copy;
     }
 
     private boolean isNotBlank(String value) {
         return value != null && !value.trim().isEmpty();
+    }
+
+    private static class LocalizationResult {
+        private final String message;
+        private final boolean localized;
+        private final boolean completelyFormatted;
+
+        private LocalizationResult(String message, boolean localized, boolean completelyFormatted) {
+            this.message = message;
+            this.localized = localized;
+            this.completelyFormatted = completelyFormatted;
+        }
+
+        private static LocalizationResult notLocalized() {
+            return new LocalizationResult(null, false, false);
+        }
     }
 }

--- a/core/src/main/java/org/zstack/core/rest/RESTApiController.java
+++ b/core/src/main/java/org/zstack/core/rest/RESTApiController.java
@@ -47,7 +47,7 @@ public class RESTApiController {
                 return;
             }
             String locale = resolveLocale(req);
-            localizeRestAPIResponse(apiRsp, locale);
+            localizeRestAPIResponse(apiRsp, locale, hasAcceptLanguage(req));
             rsp.setCharacterEncoding("UTF-8");
             PrintWriter writer = rsp.getWriter();
             String res = JSONObjectUtil.toJsonString(apiRsp);
@@ -59,7 +59,8 @@ public class RESTApiController {
         }
     }
 
-    private String handleByMessageType(String body, String clientIp, String clientBrowser, String locale) {
+    private String handleByMessageType(String body, String clientIp, String clientBrowser, String locale,
+                                       boolean localizeDetails) {
         APIMessage amsg = null;
         try {
             amsg = (APIMessage) RESTApiDecoder.loads(body);
@@ -75,7 +76,7 @@ public class RESTApiController {
         } else {
             rsp = restApi.send(amsg);
         }
-        localizeRestAPIResponse(rsp, locale);
+        localizeRestAPIResponse(rsp, locale, localizeDetails);
         return JSONObjectUtil.toJsonString(rsp);
     }
 
@@ -86,7 +87,8 @@ public class RESTApiController {
         String clientBrowser = HttpServletRequestUtils.getClientBrowser(request);
         String locale = resolveLocale(request);
         try {
-            String ret = handleByMessageType(entity.getBody(), clientIp, clientBrowser, locale);
+            String ret = handleByMessageType(entity.getBody(), clientIp, clientBrowser, locale,
+                    hasAcceptLanguage(request));
             response.setStatus(HttpStatus.SC_OK);
             response.setCharacterEncoding("UTF-8");
             PrintWriter writer = response.getWriter();
@@ -106,7 +108,12 @@ public class RESTApiController {
         return LocaleUtils.resolveLocale(acceptLanguage, i18nService.getAvailableLocales());
     }
 
-    private void localizeRestAPIResponse(RestAPIResponse rsp, String locale) {
+    private boolean hasAcceptLanguage(HttpServletRequest req) {
+        String acceptLanguage = req.getHeader("Accept-Language");
+        return acceptLanguage != null && !acceptLanguage.trim().isEmpty();
+    }
+
+    private void localizeRestAPIResponse(RestAPIResponse rsp, String locale, boolean localizeDetails) {
         if (rsp == null || rsp.getResult() == null || locale == null) {
             return;
         }
@@ -116,13 +123,21 @@ public class RESTApiController {
             if (msg instanceof MessageReply) {
                 MessageReply reply = (MessageReply) msg;
                 if (!reply.isSuccess() && reply.getError() != null) {
-                    i18nService.localizeErrorCodeDetails(reply.getError(), locale);
+                    if (localizeDetails) {
+                        reply.setError(i18nService.localizeErrorCodeDetails(reply.getError(), locale));
+                    } else {
+                        i18nService.localizeErrorCode(reply.getError(), locale);
+                    }
                     rsp.setResult(RESTApiDecoder.dump(reply));
                 }
             } else if (msg instanceof APIEvent) {
                 APIEvent evt = (APIEvent) msg;
                 if (!evt.isSuccess() && evt.getError() != null) {
-                    i18nService.localizeErrorCodeDetails(evt.getError(), locale);
+                    if (localizeDetails) {
+                        evt.setError(i18nService.localizeErrorCodeDetails(evt.getError(), locale));
+                    } else {
+                        i18nService.localizeErrorCode(evt.getError(), locale);
+                    }
                     rsp.setResult(RESTApiDecoder.dump(evt));
                 }
             }

--- a/core/src/main/java/org/zstack/core/rest/RESTApiController.java
+++ b/core/src/main/java/org/zstack/core/rest/RESTApiController.java
@@ -116,13 +116,13 @@ public class RESTApiController {
             if (msg instanceof MessageReply) {
                 MessageReply reply = (MessageReply) msg;
                 if (!reply.isSuccess() && reply.getError() != null) {
-                    i18nService.localizeErrorCode(reply.getError(), locale);
+                    i18nService.localizeErrorCodeDetails(reply.getError(), locale);
                     rsp.setResult(RESTApiDecoder.dump(reply));
                 }
             } else if (msg instanceof APIEvent) {
                 APIEvent evt = (APIEvent) msg;
                 if (!evt.isSuccess() && evt.getError() != null) {
-                    i18nService.localizeErrorCode(evt.getError(), locale);
+                    i18nService.localizeErrorCodeDetails(evt.getError(), locale);
                     rsp.setResult(RESTApiDecoder.dump(evt));
                 }
             }

--- a/rest/src/main/java/org/zstack/rest/RestServer.java
+++ b/rest/src/main/java/org/zstack/rest/RestServer.java
@@ -408,11 +408,15 @@ public class RestServer implements Component, CloudBusEventListener {
 
             writeResponse(response, w, ret.getResult());
         } else {
-            // Localize with webhook caller's locale. Platform.err only prepares
-            // the internal message; response details are localized here.
             String locale = resolveLocale();
-            i18nService.localizeErrorCodeDetails(evt.getError(), locale);
-            response.setError(evt.getError());
+            if (isDetailsLocalizationRequested()) {
+                response.setError(i18nService.localizeErrorCodeDetails(evt.getError(), locale));
+            } else {
+                if (!LocaleUtils.DEFAULT_LOCALE.equals(locale)) {
+                    i18nService.localizeErrorCode(evt.getError(), locale);
+                }
+                response.setError(evt.getError());
+            }
         }
 
         String body = CloudBusGson.toJsonForHttpResponse(response);
@@ -979,7 +983,11 @@ public class RestServer implements Component, CloudBusEventListener {
         String locale = resolveLocale();
         rsp.setHeader("Content-Language", toLanguageTag(locale));
         if (response.getError() != null) {
-            i18nService.localizeErrorCodeDetails(response.getError(), locale);
+            if (isDetailsLocalizationRequested()) {
+                response.setError(i18nService.localizeErrorCodeDetails(response.getError(), locale));
+            } else {
+                i18nService.localizeErrorCode(response.getError(), locale);
+            }
             response.completeFailure(apiId, locale);
         }
     }
@@ -1489,6 +1497,11 @@ public class RestServer implements Component, CloudBusEventListener {
         }
         String acceptLanguage = info.headers.getFirst("Accept-Language");
         return LocaleUtils.resolveLocale(acceptLanguage, i18nService.getAvailableLocales());
+    }
+
+    private boolean isDetailsLocalizationRequested() {
+        RequestInfo info = requestInfo.get();
+        return info != null && StringUtils.isNotBlank(info.headers.getFirst("Accept-Language"));
     }
 
     private void sendReplyResponse(MessageReply reply, Api api, HttpServletResponse rsp, String apiId) throws IOException, IllegalAccessException, NoSuchMethodException, InvocationTargetException {

--- a/rest/src/main/java/org/zstack/rest/RestServer.java
+++ b/rest/src/main/java/org/zstack/rest/RestServer.java
@@ -408,11 +408,10 @@ public class RestServer implements Component, CloudBusEventListener {
 
             writeResponse(response, w, ret.getResult());
         } else {
-            // localize with webhook caller's locale (message already populated by Platform.err)
+            // Localize with webhook caller's locale. Platform.err only prepares
+            // the internal message; response details are localized here.
             String locale = resolveLocale();
-            if (!LocaleUtils.DEFAULT_LOCALE.equals(locale)) {
-                i18nService.localizeErrorCode(evt.getError(), locale);
-            }
+            i18nService.localizeErrorCodeDetails(evt.getError(), locale);
             response.setError(evt.getError());
         }
 
@@ -980,7 +979,7 @@ public class RestServer implements Component, CloudBusEventListener {
         String locale = resolveLocale();
         rsp.setHeader("Content-Language", toLanguageTag(locale));
         if (response.getError() != null) {
-            i18nService.localizeErrorCode(response.getError(), locale);
+            i18nService.localizeErrorCodeDetails(response.getError(), locale);
             response.completeFailure(apiId, locale);
         }
     }

--- a/test/src/test/groovy/org/zstack/test/integration/rest/ErrorCodeI18nCase.groovy
+++ b/test/src/test/groovy/org/zstack/test/integration/rest/ErrorCodeI18nCase.groovy
@@ -36,13 +36,15 @@ class ErrorCodeI18nCase extends SubCase {
             testServiceLocalizesEnUS()
             testServiceFallbackToEnUS()
             testServiceFormatsArgs()
+            testServiceKeepsRawDetailsWhenFormatArgsAreMissing()
             testServiceRecursiveCauseChain()
             testServiceErrorCodeList()
             testServiceFallbackToLocalizedCauseWhenOuterCodeHasNoTemplate()
             testServiceKeepsOuterDetailsWhenCauseHasNoTemplate()
             testRestServerSyncApiWithAcceptLanguage()
             testRestServerAsyncApiWithAcceptLanguage()
-            testNoAcceptLanguageHeaderFallsBackToEnUS()
+            testAsyncWebhookWithoutAcceptLanguageKeepsRawDetails()
+            testSyncApiWithoutAcceptLanguageKeepsRawDetails()
         }
     }
 
@@ -157,23 +159,42 @@ class ErrorCodeI18nCase extends SubCase {
         assert cause.getDetails().contains("当VM平台")
         assert outer.getDetails().contains("当VM平台")
 
-        i18nService.localizeErrorCodeDetails(outer, "en_US")
+        ErrorCode enLocalized = i18nService.localizeErrorCodeDetails(outer, "en_US")
 
-        assert outer.getMessage() == cause.getMessage()
-        assert outer.getMessage().contains("When the VM platform is Other")
-        assert cause.getDetails() == cause.getMessage()
-        assert outer.getDetails() == outer.getMessage()
-        assert !cause.getDetails().contains("当VM平台")
-        assert !outer.getDetails().contains("当VM平台")
+        assert enLocalized.getMessage() == enLocalized.getCause().getMessage()
+        assert enLocalized.getMessage().contains("When the VM platform is Other")
+        assert enLocalized.getCause().getDetails() == enLocalized.getCause().getMessage()
+        assert enLocalized.getDetails() == enLocalized.getMessage()
+        assert !enLocalized.getCause().getDetails().contains("当VM平台")
+        assert !enLocalized.getDetails().contains("当VM平台")
+        assert cause.getDetails().contains("当VM平台")
+        assert outer.getDetails().contains("当VM平台")
 
-        i18nService.localizeErrorCodeDetails(outer, "zh_CN")
+        ErrorCode zhLocalized = i18nService.localizeErrorCodeDetails(outer, "zh_CN")
 
-        assert outer.getMessage() == cause.getMessage()
-        assert outer.getMessage().contains("虚拟机平台")
-        assert cause.getDetails() == cause.getMessage()
-        assert outer.getDetails() == outer.getMessage()
-        assert cause.getDetails().contains("虚拟机平台")
-        assert outer.getDetails().contains("虚拟机平台")
+        assert zhLocalized.getMessage() == zhLocalized.getCause().getMessage()
+        assert zhLocalized.getMessage().contains("虚拟机平台")
+        assert zhLocalized.getCause().getDetails() == zhLocalized.getCause().getMessage()
+        assert zhLocalized.getDetails() == zhLocalized.getMessage()
+        assert zhLocalized.getCause().getDetails().contains("虚拟机平台")
+        assert zhLocalized.getDetails().contains("虚拟机平台")
+        assert cause.getDetails().contains("当VM平台")
+        assert outer.getDetails().contains("当VM平台")
+    }
+
+    void testServiceKeepsRawDetailsWhenFormatArgsAreMissing() {
+        GlobalErrorCodeI18nService i18nService = bean(GlobalErrorCodeI18nService.class)
+
+        ErrorCode error = new ErrorCode()
+        error.setCode(SysErrors.OPERATION_ERROR.toString())
+        error.setDetails("concrete raw details")
+        error.setGlobalErrorCode("ORG_ZSTACK_STORAGE_PRIMARY_10039")
+
+        ErrorCode localized = i18nService.localizeErrorCodeDetails(error, "en_US")
+
+        assert localized.getMessage() == "no primary storage[uuid:%s] exists"
+        assert localized.getDetails() == "concrete raw details"
+        assert error.getDetails() == "concrete raw details"
     }
 
     void testServiceKeepsOuterDetailsWhenCauseHasNoTemplate() {
@@ -284,57 +305,58 @@ class ErrorCodeI18nCase extends SubCase {
                 }
 
                 // Async API returns 202 with location header for job polling
-                if (postCode == 202) {
-                    Map postResponse = JSONObjectUtil.toObject(postBody, LinkedHashMap.class)
-                    String location = postResponse.get("location") as String
-                    assert location != null
+                assert postCode == 202
+                Map postResponse = JSONObjectUtil.toObject(postBody, LinkedHashMap.class)
+                String location = postResponse.get("location") as String
+                assert location != null
 
-                    // Poll the job with Accept-Language header
-                    retryInSecs(5) {
-                        String jobUrl = location.startsWith("http") ? location : "http://127.0.0.1:${WebBeanConstructor.port}${location}"
-                        HttpURLConnection jobConn = (HttpURLConnection) new URL(jobUrl).openConnection()
-                        try {
-                            jobConn.setRequestMethod("GET")
-                            jobConn.setRequestProperty("Authorization", "OAuth ${sessionId}")
-                            jobConn.setRequestProperty("Accept-Language", "zh-CN")
+                String jobUrl = location.startsWith("http") ? location : "http://127.0.0.1:${WebBeanConstructor.port}${location}"
 
-                            int jobCode = jobConn.getResponseCode()
-                            String jobBody
-                            if (jobCode >= 400) {
-                                jobBody = jobConn.getErrorStream()?.text ?: ""
-                            } else {
-                                jobBody = jobConn.getInputStream()?.text ?: ""
-                            }
+                // Poll the job with Accept-Language header
+                retryInSecs(5) {
+                    HttpURLConnection jobConn = (HttpURLConnection) new URL(jobUrl).openConnection()
+                    try {
+                        jobConn.setRequestMethod("GET")
+                        jobConn.setRequestProperty("Authorization", "OAuth ${sessionId}")
+                        jobConn.setRequestProperty("Accept-Language", "zh-CN")
 
-                            // Job should be done (503 for error)
-                            assert jobCode == 503
-                            Map jobResponse = JSONObjectUtil.toObject(jobBody, LinkedHashMap.class)
-                            Map jobError = jobResponse.get("error") as Map
-                            assert jobError != null
-                            String jobMessage = jobError.get("message") as String
-                            assert jobMessage != null
-                            assert jobMessage.contains("未找到主存储")
-                            assert jobMessage.contains("test-async-uuid")
-                            String jobDetails = jobError.get("details") as String
-                            assert jobDetails != null
-                            assert jobDetails.contains("未找到主存储")
-                            assert jobDetails.contains("test-async-uuid")
-                        } finally {
-                            jobConn.disconnect()
+                        int jobCode = jobConn.getResponseCode()
+                        String jobBody
+                        if (jobCode >= 400) {
+                            jobBody = jobConn.getErrorStream()?.text ?: ""
+                        } else {
+                            jobBody = jobConn.getInputStream()?.text ?: ""
                         }
+
+                        // Job should be done (503 for error)
+                        assert jobCode == 503
+                        Map jobResponse = JSONObjectUtil.toObject(jobBody, LinkedHashMap.class)
+                        Map jobError = jobResponse.get("error") as Map
+                        assert jobError != null
+                        String jobMessage = jobError.get("message") as String
+                        assert jobMessage != null
+                        assert jobMessage.contains("未找到主存储")
+                        assert jobMessage.contains("test-async-uuid")
+                        String jobDetails = jobError.get("details") as String
+                        assert jobDetails != null
+                        assert jobDetails.contains("未找到主存储")
+                        assert jobDetails.contains("test-async-uuid")
+                    } finally {
+                        jobConn.disconnect()
                     }
-                } else {
-                    // If returned directly (e.g. 503), check the error
-                    assert postCode == 503
-                    Map directResponse = JSONObjectUtil.toObject(postBody, LinkedHashMap.class)
-                    Map directError = directResponse.get("error") as Map
-                    assert directError != null
-                    String directMessage = directError.get("message") as String
-                    assert directMessage != null
-                    assert directMessage.contains("未找到主存储")
-                    String directDetails = directError.get("details") as String
-                    assert directDetails != null
-                    assert directDetails.contains("未找到主存储")
+                }
+
+                HttpURLConnection rawJobConn = (HttpURLConnection) new URL(jobUrl).openConnection()
+                try {
+                    rawJobConn.setRequestMethod("GET")
+                    rawJobConn.setRequestProperty("Authorization", "OAuth ${sessionId}")
+
+                    assert rawJobConn.getResponseCode() == 503
+                    Map rawJobResponse = JSONObjectUtil.toObject(rawJobConn.getErrorStream().text, LinkedHashMap.class)
+                    Map rawJobError = rawJobResponse.get("error") as Map
+                    assert rawJobError.get("details") == "no primary storage[uuid:test-async-uuid] exists"
+                } finally {
+                    rawJobConn.disconnect()
                 }
             } finally {
                 postConn.disconnect()
@@ -344,11 +366,11 @@ class ErrorCodeI18nCase extends SubCase {
         }
     }
 
-    void testNoAcceptLanguageHeaderFallsBackToEnUS() {
+    void testSyncApiWithoutAcceptLanguageKeepsRawDetails() {
         // Intercept APIQueryZoneMsg and return error with known globalErrorCode
         ErrorCode mockError = new ErrorCode()
         mockError.setCode(SysErrors.INTERNAL.toString())
-        mockError.setDetails("no primary storage[uuid:test-no-lang] exists")
+        mockError.setDetails("raw sync details")
         mockError.setGlobalErrorCode("ORG_ZSTACK_STORAGE_PRIMARY_10039")
         mockError.setFormatArgs(["test-no-lang"] as String[])
 
@@ -386,11 +408,35 @@ class ErrorCodeI18nCase extends SubCase {
                 assert message.contains("test-no-lang")
                 String details = error.get("details") as String
                 assert details != null
-                assert details.contains("no primary storage")
-                assert details.contains("test-no-lang")
+                assert details == "raw sync details"
             } finally {
                 conn.disconnect()
             }
+        } finally {
+            env.cleanMessageHandlers()
+        }
+    }
+
+    void testAsyncWebhookWithoutAcceptLanguageKeepsRawDetails() {
+        ErrorCode asyncError = new ErrorCode()
+        asyncError.setCode(SysErrors.INTERNAL.toString())
+        asyncError.setDetails("raw webhook details")
+        asyncError.setGlobalErrorCode("ORG_ZSTACK_STORAGE_PRIMARY_10039")
+        asyncError.setFormatArgs(["test-webhook-no-lang"] as String[])
+
+        env.message(org.zstack.header.zone.APICreateZoneMsg.class) { msg, bus ->
+            bus.replyErrorByMessageType(msg, asyncError)
+        }
+
+        try {
+            org.zstack.sdk.CreateZoneAction action = new org.zstack.sdk.CreateZoneAction()
+            action.sessionId = adminSession()
+            action.name = "test-webhook-no-lang"
+
+            org.zstack.sdk.CreateZoneAction.Result result = action.call()
+
+            assert result.error != null
+            assert result.error.details == "raw webhook details"
         } finally {
             env.cleanMessageHandlers()
         }

--- a/test/src/test/groovy/org/zstack/test/integration/rest/ErrorCodeI18nCase.groovy
+++ b/test/src/test/groovy/org/zstack/test/integration/rest/ErrorCodeI18nCase.groovy
@@ -154,11 +154,26 @@ class ErrorCodeI18nCase extends SubCase {
         assert outer.getMessage() == cause.getMessage()
         assert outer.getMessage().contains("When the VM platform is Other")
         assert !outer.getMessage().contains("当VM平台")
+        assert cause.getDetails().contains("当VM平台")
+        assert outer.getDetails().contains("当VM平台")
 
-        i18nService.localizeErrorCode(outer, "zh_CN")
+        i18nService.localizeErrorCodeDetails(outer, "en_US")
+
+        assert outer.getMessage() == cause.getMessage()
+        assert outer.getMessage().contains("When the VM platform is Other")
+        assert cause.getDetails() == cause.getMessage()
+        assert outer.getDetails() == outer.getMessage()
+        assert !cause.getDetails().contains("当VM平台")
+        assert !outer.getDetails().contains("当VM平台")
+
+        i18nService.localizeErrorCodeDetails(outer, "zh_CN")
 
         assert outer.getMessage() == cause.getMessage()
         assert outer.getMessage().contains("虚拟机平台")
+        assert cause.getDetails() == cause.getMessage()
+        assert outer.getDetails() == outer.getMessage()
+        assert cause.getDetails().contains("虚拟机平台")
+        assert outer.getDetails().contains("虚拟机平台")
     }
 
     void testServiceKeepsOuterDetailsWhenCauseHasNoTemplate() {
@@ -179,6 +194,8 @@ class ErrorCodeI18nCase extends SubCase {
 
         assert cause.getMessage() == "inner raw details"
         assert outer.getMessage() == "outer raw details"
+        assert cause.getDetails() == "inner raw details"
+        assert outer.getDetails() == "outer raw details"
     }
 
     void testRestServerSyncApiWithAcceptLanguage() {
@@ -219,6 +236,10 @@ class ErrorCodeI18nCase extends SubCase {
                 String message = error.get("message") as String
                 assert message.contains("未找到主存储")
                 assert message.contains("test-sync-uuid")
+                String details = error.get("details") as String
+                assert details != null
+                assert details.contains("未找到主存储")
+                assert details.contains("test-sync-uuid")
             } finally {
                 conn.disconnect()
             }
@@ -294,6 +315,10 @@ class ErrorCodeI18nCase extends SubCase {
                             assert jobMessage != null
                             assert jobMessage.contains("未找到主存储")
                             assert jobMessage.contains("test-async-uuid")
+                            String jobDetails = jobError.get("details") as String
+                            assert jobDetails != null
+                            assert jobDetails.contains("未找到主存储")
+                            assert jobDetails.contains("test-async-uuid")
                         } finally {
                             jobConn.disconnect()
                         }
@@ -307,6 +332,9 @@ class ErrorCodeI18nCase extends SubCase {
                     String directMessage = directError.get("message") as String
                     assert directMessage != null
                     assert directMessage.contains("未找到主存储")
+                    String directDetails = directError.get("details") as String
+                    assert directDetails != null
+                    assert directDetails.contains("未找到主存储")
                 }
             } finally {
                 postConn.disconnect()
@@ -356,6 +384,10 @@ class ErrorCodeI18nCase extends SubCase {
                 assert message != null
                 assert message.contains("no primary storage")
                 assert message.contains("test-no-lang")
+                String details = error.get("details") as String
+                assert details != null
+                assert details.contains("no primary storage")
+                assert details.contains("test-no-lang")
             } finally {
                 conn.disconnect()
             }


### PR DESCRIPTION
## Root Cause

`GlobalErrorCodeI18nServiceImpl.localizeErrorCode()` only wrote localized text to `error.message`. `error.details` kept the original raw text, so English API responses and event/alarm paths that read details could still show Chinese.

## Fix

When an `ErrorCode` is localized from its own i18n template or a localized cause, copy the resolved localized message into `details` as well. Unmapped errors keep their original raw details.

## Verification

- PASSED: `mvn -Dtest=GlobalErrorCodeI18nServiceImplTest test` from `core/`
- PASSED: `git -c core.whitespace=blank-at-eol,blank-at-eof,space-before-tab,cr-at-eol diff --check`
- BLOCKED: `mvn -Dtest=TestCaseStabilityTest -Dcases=org.zstack.test.integration.rest.ErrorCodeI18nCase -Dtimes=1 test` from `test/`
  - Blocked at `testCompile` by existing ZBS test missing classes: `ZbsStorageController.CreateVhostBdevRsp` and `ZbsStorageController.VhostTargetHealthRsp`

Related: ZSTAC-86593

sync from gitlab !10476