### PR TITLE
<fix>[conf]: add IAM2 SCIM relation intent schema

### DIFF
--- a/conf/db/upgrade/V5.5.28__schema.sql
+++ b/conf/db/upgrade/V5.5.28__schema.sql
@@ -384,3 +384,27 @@ CREATE TABLE IF NOT EXISTS `zstack`.`ExternalPrimaryStorageHostProtocolRefVO` (
 ) ENGINE = InnoDB DEFAULT CHARSET = utf8;
 
 CALL DROP_COLUMN('ExternalPrimaryStorageHostRefVO', 'protocol');
+
+-- ZCF-4875: persist pending SCIM relation intents for out-of-order role binding materialization.
+CREATE TABLE IF NOT EXISTS `zstack`.`IAM2ScimRelationIntentVO` (
+    `uuid` varchar(32) NOT NULL,
+    `sourceType` varchar(64) NOT NULL,
+    `syncType` varchar(64) NOT NULL,
+    `externalUuid` varchar(32) NOT NULL,
+    `relationType` varchar(64) NOT NULL,
+    `subjectType` varchar(32) NOT NULL,
+    `subjectUuid` varchar(32) NOT NULL,
+    `objectType` varchar(64) NOT NULL,
+    `objectUuid` varchar(32) NOT NULL,
+    `scopeType` varchar(64) DEFAULT NULL,
+    `scopeUuid` varchar(32) DEFAULT NULL,
+    `enabled` tinyint(1) NOT NULL DEFAULT 1,
+    `attributesJson` varchar(2048) DEFAULT NULL,
+    `createDate` timestamp NOT NULL DEFAULT '2000-01-01 00:00:00',
+    `lastOpDate` timestamp NOT NULL DEFAULT '2000-01-01 00:00:00' ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY (`uuid`),
+    UNIQUE KEY `ukIAM2ScimRelationIntentSource` (`sourceType`, `syncType`, `relationType`, `externalUuid`),
+    KEY `idxIAM2ScimRelationIntentSubject` (`relationType`, `subjectType`, `subjectUuid`),
+    KEY `idxIAM2ScimRelationIntentObject` (`relationType`, `objectType`, `objectUuid`),
+    KEY `idxIAM2ScimRelationIntentScope` (`relationType`, `scopeType`, `scopeUuid`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;


### PR DESCRIPTION
Jira: http://jira.zstack.io/browse/ZCF-4875

Root cause:
ZIAM sends project role bindings and project memberships as separate SCIM resources. When a project role binding has no concrete project scope yet, Cloud previously had nowhere to persist that pending relationship, so later project membership sync could create the project membership without creating the project-scoped IAM2VirtualIDRoleRef/IAM2VirtualIDGroupRoleRef. UI/BFF uiPrivileges then could not find a role for the selected project.

Fix summary:
Add IAM2ScimRelationIntentVO schema to store SCIM relation intents for role bindings that need project membership context before materialization.

Verification:
- ./runMavenProfile premium
- mvn -f premium/pom.xml -pl iam2 -Dmaven.test.skip=true install
- mvn -f premium/pom.xml -pl test-premium -Dtest=org.zstack.iam2.scim.IAM2ScimRelationIntentProjectorTest test
- Real env Cloud MN 172.26.21.254 + ZIAM 172.26.52.69: replayed RoleBindings after Roles sync; both project-first and role-first scenarios delivered and uiPrivileges returned systemRoleCount=1.

Companion MR: premium branch fix-4875@@2

DBImpact

Resolves: ZCF-4875

sync from gitlab !10480