### PR TITLE
fix[storage]: reject Legacy-BIOS image on 4096-sector primary storage (ZSTAC-86547)

### DIFF
--- a/compute/src/main/java/org/zstack/compute/vm/VmAllocatePrimaryStorageFlow.java
+++ b/compute/src/main/java/org/zstack/compute/vm/VmAllocatePrimaryStorageFlow.java
@@ -19,6 +19,8 @@ import org.zstack.header.core.workflow.FlowTrigger;
 import org.zstack.header.errorcode.ErrorCode;
 import org.zstack.header.host.HostInventory;
 import org.zstack.header.image.ImageInventory;
+import org.zstack.header.image.ImageBootMode;
+import org.zstack.header.image.ImageVO;
 import org.zstack.header.message.MessageReply;
 import org.zstack.header.storage.backup.BackupStorageVO;
 import org.zstack.header.storage.backup.BackupStorageVO_;
@@ -26,6 +28,7 @@ import org.zstack.header.storage.primary.AllocatePrimaryStorageSpaceMsg;
 import org.zstack.header.storage.primary.AllocatePrimaryStorageSpaceReply;
 import org.zstack.header.storage.primary.PrimaryStorageAllocationPurpose;
 import org.zstack.header.storage.primary.PrimaryStorageConstant;
+import org.zstack.header.storage.primary.PrimaryStorageFeature;
 import org.zstack.header.storage.primary.ReleasePrimaryStorageSpaceMsg;
 import org.zstack.header.vm.VmInstanceConstant;
 import org.zstack.header.vm.VmInstanceSpec;
@@ -37,6 +40,7 @@ import org.zstack.utils.logging.CLogger;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -80,6 +84,9 @@ public class VmAllocatePrimaryStorageFlow implements Flow {
         rmsg.setPurpose(PrimaryStorageAllocationPurpose.CreateNewVm.toString());
         rmsg.setPossiblePrimaryStorageTypes(selectPsTypesFromSpec(spec));
         rmsg.setSystemTags(spec.getRootVolumeSystemTags());
+        if (isLegacyBootImage(rmsg.getImageUuid())) {
+            rmsg.setRequiredFeatures(Collections.singleton(PrimaryStorageFeature.LEGACY_BOOT));
+        }
         bus.makeLocalServiceId(rmsg, PrimaryStorageConstant.SERVICE_ID);
         msgs.add(rmsg);
 
@@ -168,6 +175,14 @@ public class VmAllocatePrimaryStorageFlow implements Flow {
 
         spec.getVolumeSpecs().clear();
         chain.rollback();
+    }
+
+    private boolean isLegacyBootImage(String imageUuid) {
+        if (imageUuid == null) {
+            return false;
+        }
+        String bootMode = VmSystemTags.BOOT_MODE.getTokenByResourceUuid(imageUuid, ImageVO.class, VmSystemTags.BOOT_MODE_TOKEN);
+        return bootMode == null || bootMode.equalsIgnoreCase(ImageBootMode.Legacy.name());
     }
 
     private List<String> selectPsTypesFromSpec(final VmInstanceSpec spec) {

--- a/header/src/main/java/org/zstack/header/storage/addon/primary/StorageCapabilities.java
+++ b/header/src/main/java/org/zstack/header/storage/addon/primary/StorageCapabilities.java
@@ -19,6 +19,15 @@ public class StorageCapabilities {
     public List<String> supportedImageFormats;
     private VolumeProtocol defaultIsoActiveProtocol;
     private VolumeProtocol defaultImageExportProtocol;
+    private int minLogicalSectorSize = 512;
+
+    public int getMinLogicalSectorSize() {
+        return minLogicalSectorSize;
+    }
+
+    public void setMinLogicalSectorSize(int minLogicalSectorSize) {
+        this.minLogicalSectorSize = minLogicalSectorSize;
+    }
 
     public boolean isSupportShareableVolume() {
         return supportShareableVolume;

--- a/header/src/main/java/org/zstack/header/storage/primary/PrimaryStorageAllocationSpec.java
+++ b/header/src/main/java/org/zstack/header/storage/primary/PrimaryStorageAllocationSpec.java
@@ -25,6 +25,15 @@ public class PrimaryStorageAllocationSpec {
     private List<String> excludePrimaryStorageTypes;
     private String backupStorageUuid;
     private Set<PrimaryStorageFeature> requiredFeatures;
+    private String requiredProtocol;
+
+    public String getRequiredProtocol() {
+        return requiredProtocol;
+    }
+
+    public void setRequiredProtocol(String requiredProtocol) {
+        this.requiredProtocol = requiredProtocol;
+    }
 
     public Set<PrimaryStorageFeature> getRequiredFeatures() {
         return requiredFeatures;

--- a/header/src/main/java/org/zstack/header/storage/primary/PrimaryStorageFeature.java
+++ b/header/src/main/java/org/zstack/header/storage/primary/PrimaryStorageFeature.java
@@ -6,4 +6,5 @@ package org.zstack.header.storage.primary;
  */
 public enum PrimaryStorageFeature {
     SHARED_VOLUME,
+    LEGACY_BOOT,
 }

--- a/plugin/zbs/src/main/java/org/zstack/storage/zbs/ZbsStorageController.java
+++ b/plugin/zbs/src/main/java/org/zstack/storage/zbs/ZbsStorageController.java
@@ -142,6 +142,7 @@ public class ZbsStorageController implements PrimaryStorageControllerSvc, Primar
         capabilities.setSupportedImageFormats(Collections.singletonList(ImageConstant.RAW_FORMAT_STRING));
         capabilities.setDefaultIsoActiveProtocol(VolumeProtocol.CBD);
         capabilities.setDefaultImageExportProtocol(VolumeProtocol.NBD);
+        capabilities.setMinLogicalSectorSize(4096);
     }
 
     @Override

--- a/storage/src/main/java/org/zstack/storage/addon/primary/ExternalPrimaryStorageFactory.java
+++ b/storage/src/main/java/org/zstack/storage/addon/primary/ExternalPrimaryStorageFactory.java
@@ -41,6 +41,7 @@ import org.zstack.header.vm.cdrom.VmCdRomVO;
 import org.zstack.header.vm.cdrom.VmCdRomVO_;
 import org.zstack.header.volume.VolumeDeletionPolicyManager;
 import org.zstack.header.volume.VolumeInventory;
+import org.zstack.header.volume.VolumeProtocol;
 import org.zstack.header.volume.VolumeVO;
 import org.zstack.header.volume.VolumeVO_;
 import org.zstack.header.volume.block.BlockVolumeVO;
@@ -1103,7 +1104,7 @@ public class ExternalPrimaryStorageFactory implements PrimaryStorageFactory, Com
     }
 
     @Override
-    public List<PrimaryStorageVO> allocatePrimaryStorage(Set<PrimaryStorageFeature> requiredFeatures, List<PrimaryStorageVO> candidates) {
+    public List<PrimaryStorageVO> allocatePrimaryStorage(Set<PrimaryStorageFeature> requiredFeatures, String requiredProtocol, List<PrimaryStorageVO> candidates) {
         if (requiredFeatures.contains(PrimaryStorageFeature.SHARED_VOLUME)) {
             List<PrimaryStorageVO> excludeCandidates = candidates.stream()
                     .filter(v -> PrimaryStorageConstant.EXTERNAL_PRIMARY_STORAGE_TYPE.equals(v.getType()))
@@ -1113,6 +1114,37 @@ public class ExternalPrimaryStorageFactory implements PrimaryStorageFactory, Com
             logger.info(String.format("exclude external primary storage candidates: %s for shared volume feature", excludeCandidates));
 
             candidates.removeAll(excludeCandidates);
+        }
+
+        if (requiredFeatures.contains(PrimaryStorageFeature.LEGACY_BOOT)) {
+            List<PrimaryStorageVO> externalCandidates = candidates.stream()
+                    .filter(v -> PrimaryStorageConstant.EXTERNAL_PRIMARY_STORAGE_TYPE.equals(v.getType()))
+                    .filter(v -> controllers.containsKey(v.getUuid()))
+                    .collect(Collectors.toList());
+
+            if (!externalCandidates.isEmpty()) {
+                Map<String, String> protocolByUuid = requiredProtocol != null ? Collections.emptyMap() :
+                        Q.New(ExternalPrimaryStorageVO.class)
+                                .select(ExternalPrimaryStorageVO_.uuid, ExternalPrimaryStorageVO_.defaultProtocol)
+                                .in(ExternalPrimaryStorageVO_.uuid, externalCandidates.stream().map(PrimaryStorageVO::getUuid).collect(Collectors.toList()))
+                                .listTuple().stream()
+                                .collect(Collectors.toMap(t -> t.get(0, String.class), t -> t.get(1, String.class)));
+
+                List<PrimaryStorageVO> excludeCandidates = externalCandidates.stream()
+                        .filter(v -> {
+                            String protocol = requiredProtocol != null ? requiredProtocol : protocolByUuid.get(v.getUuid());
+                            // only vhost-user-blk exposes the raw logical sector to the guest; other protocols
+                            // go through the qemu block layer which does 512e emulation
+                            return VolumeProtocol.Vhost.toString().equals(protocol)
+                                    && controllers.get(v.getUuid()).reportCapabilities().getMinLogicalSectorSize() > 512;
+                        })
+                        .collect(Collectors.toList());
+
+                logger.info(String.format("exclude external primary storage candidates: %s for legacy boot feature, " +
+                        "they expose a logical sector size larger than 512 bytes on which a Legacy-BIOS image cannot boot", excludeCandidates));
+
+                candidates.removeAll(excludeCandidates);
+            }
         }
 
         return candidates;

--- a/storage/src/main/java/org/zstack/storage/primary/PrimaryStorageFeatureAllocatorExtensionPoint.java
+++ b/storage/src/main/java/org/zstack/storage/primary/PrimaryStorageFeatureAllocatorExtensionPoint.java
@@ -11,5 +11,5 @@ import java.util.Set;
  * @ Date   : Created in 10:49 2025/7/15
  */
 public interface PrimaryStorageFeatureAllocatorExtensionPoint {
-    List<PrimaryStorageVO> allocatePrimaryStorage(Set<PrimaryStorageFeature> requiredFeatures, List<PrimaryStorageVO> candidates);
+    List<PrimaryStorageVO> allocatePrimaryStorage(Set<PrimaryStorageFeature> requiredFeatures, String requiredProtocol, List<PrimaryStorageVO> candidates);
 }

--- a/storage/src/main/java/org/zstack/storage/primary/PrimaryStorageFeatureAllocatorFlow.java
+++ b/storage/src/main/java/org/zstack/storage/primary/PrimaryStorageFeatureAllocatorFlow.java
@@ -33,7 +33,7 @@ public class PrimaryStorageFeatureAllocatorFlow extends NoRollbackFlow {
         List<PrimaryStorageVO> candidates = (List<PrimaryStorageVO>) data.get(PrimaryStorageConstant.AllocatorParams.CANDIDATES);
         List<PrimaryStorageVO> ret;
         for (PrimaryStorageFeatureAllocatorExtensionPoint extp : pluginRgty.getExtensionList(PrimaryStorageFeatureAllocatorExtensionPoint.class)) {
-            ret = extp.allocatePrimaryStorage(spec.getRequiredFeatures(), candidates);
+            ret = extp.allocatePrimaryStorage(spec.getRequiredFeatures(), spec.getRequiredProtocol(), candidates);
             if (ret == null) {
                 continue;
             }

--- a/storage/src/main/java/org/zstack/storage/primary/PrimaryStorageManagerImpl.java
+++ b/storage/src/main/java/org/zstack/storage/primary/PrimaryStorageManagerImpl.java
@@ -60,6 +60,7 @@ import org.zstack.header.vm.VmInstanceInventory;
 import org.zstack.header.vm.VmInstanceStartExtensionPoint;
 import org.zstack.header.vm.*;
 import org.zstack.resourceconfig.*;
+import org.zstack.storage.volume.VolumeSystemTags;
 import org.zstack.tag.TagManager;
 import org.zstack.utils.*;
 import org.zstack.utils.function.Function;
@@ -830,6 +831,7 @@ public class PrimaryStorageManagerImpl extends AbstractService implements Primar
         PrimaryStorageAllocationSpec spec = new PrimaryStorageAllocationSpec();
         spec.setPossiblePrimaryStorageTypes(msg.getPossiblePrimaryStorageTypes());
         spec.setRequiredFeatures(msg.getRequiredFeatures());
+        spec.setRequiredProtocol(resolveRequiredProtocol(msg));
         spec.setExcludePrimaryStorageTypes(msg.getExcludePrimaryStorageTypes());
         spec.setImageUuid(msg.getImageUuid());
         spec.setDiskOfferingUuid(msg.getDiskOfferingUuid());
@@ -856,6 +858,14 @@ public class PrimaryStorageManagerImpl extends AbstractService implements Primar
             }
         }
         return spec;
+    }
+
+    private String resolveRequiredProtocol(AllocatePrimaryStorageMsg msg) {
+        String protocolTag = msg.getSystemTag(VolumeSystemTags.VOLUME_PROTOCOL::isMatch);
+        if (protocolTag == null) {
+            return null;
+        }
+        return VolumeSystemTags.VOLUME_PROTOCOL.getTokenByTag(protocolTag, VolumeSystemTags.VOLUME_PROTOCOL_TOKEN);
     }
 
     @Override
@@ -1027,7 +1037,7 @@ public class PrimaryStorageManagerImpl extends AbstractService implements Primar
     }
 
     @Override
-    public List<PrimaryStorageVO> allocatePrimaryStorage(Set<PrimaryStorageFeature> requiredFeatures, List<PrimaryStorageVO> candidates) {
+    public List<PrimaryStorageVO> allocatePrimaryStorage(Set<PrimaryStorageFeature> requiredFeatures, String requiredProtocol, List<PrimaryStorageVO> candidates) {
         if (requiredFeatures.contains(PrimaryStorageFeature.SHARED_VOLUME)) {
             candidates = candidates.stream()
                     .filter(v -> PrimaryStorageType.getSupportFeaturesTypes(PrimaryStorageType::isSupportSharedVolume)

--- a/test/src/test/groovy/org/zstack/test/integration/storage/primary/addon/zbs/ZbsVhostLegacyBootAllocateCase.groovy
+++ b/test/src/test/groovy/org/zstack/test/integration/storage/primary/addon/zbs/ZbsVhostLegacyBootAllocateCase.groovy
@@ -1,0 +1,208 @@
+package org.zstack.test.integration.storage.primary.addon.zbs
+
+import org.springframework.http.HttpEntity
+import org.zstack.core.cloudbus.CloudBus
+import org.zstack.header.image.ImageVO
+import org.zstack.header.storage.backup.UploadImageToRemoteTargetMsg
+import org.zstack.header.storage.backup.UploadImageToRemoteTargetReply
+import org.zstack.sdk.ClusterInventory
+import org.zstack.sdk.CreateVmInstanceAction
+import org.zstack.sdk.ImageInventory
+import org.zstack.sdk.InstanceOfferingInventory
+import org.zstack.sdk.L3NetworkInventory
+import org.zstack.sdk.PrimaryStorageInventory
+import org.zstack.sdk.SystemTagInventory
+import org.zstack.storage.zbs.ZbsConstants
+import org.zstack.storage.zbs.ZbsStorageController
+import org.zstack.test.integration.storage.StorageTest
+import org.zstack.testlib.EnvSpec
+import org.zstack.testlib.SubCase
+import org.zstack.utils.data.SizeUnit
+import org.zstack.utils.gson.JSONObjectUtil
+
+import static org.zstack.utils.clouderrorcode.CloudOperationsErrorCode.ORG_ZSTACK_STORAGE_PRIMARY_10035
+
+class ZbsVhostLegacyBootAllocateCase extends SubCase {
+    EnvSpec env
+    CloudBus bus
+    PrimaryStorageInventory ps
+    ClusterInventory cluster
+    InstanceOfferingInventory instanceOffering
+    ImageInventory image
+    L3NetworkInventory l3
+
+    @Override
+    void clean() {
+        env.delete()
+    }
+
+    @Override
+    void setup() {
+        useSpring(StorageTest.springSpec)
+    }
+
+    @Override
+    void environment() {
+        env = makeEnv {
+            instanceOffering {
+                name = "instanceOffering"
+                memory = SizeUnit.GIGABYTE.toByte(8)
+                cpu = 4
+            }
+
+            sftpBackupStorage {
+                name = "sftp"
+                url = "/sftp"
+                username = "root"
+                password = "password"
+                hostname = "127.0.0.2"
+
+                image {
+                    name = "image"
+                    url = "http://zstack.org/download/test.qcow2"
+                    size = SizeUnit.GIGABYTE.toByte(1)
+                    virtio = true
+                }
+            }
+
+            zone {
+                name = "zone"
+
+                cluster {
+                    name = "cluster"
+                    hypervisorType = "KVM"
+
+                    kvm {
+                        name = "kvm-1"
+                        managementIp = "127.0.0.1"
+                        username = "root"
+                        password = "password"
+                    }
+
+                    attachL2Network("l2")
+                }
+
+                l2NoVlanNetwork {
+                    name = "l2"
+                    physicalInterface = "eth0"
+
+                    l3Network {
+                        name = "l3"
+                        ip {
+                            startIp = "192.168.100.10"
+                            endIp = "192.168.100.100"
+                            netmask = "255.255.255.0"
+                            gateway = "192.168.100.1"
+                        }
+                    }
+                }
+
+                externalPrimaryStorage {
+                    name = "zbs-vhost"
+                    identity = "zbs"
+                    defaultOutputProtocol = "Vhost"
+                    config = "{\"mdsUrls\":[\"root:password@127.0.1.1\",\"root:password@127.0.1.2\",\"root:password@127.0.1.3\"],\"logicalPoolName\":\"lpool1\"}"
+                    url = "zbs"
+                }
+
+                attachBackupStorage("sftp")
+            }
+        }
+    }
+
+    @Override
+    void test() {
+        env.create {
+            ps = env.inventoryByName("zbs-vhost") as PrimaryStorageInventory
+            cluster = env.inventoryByName("cluster") as ClusterInventory
+            instanceOffering = env.inventoryByName("instanceOffering") as InstanceOfferingInventory
+            image = env.inventoryByName("image") as ImageInventory
+            l3 = env.inventoryByName("l3") as L3NetworkInventory
+            bus = bean(CloudBus.class)
+
+            registerBaseStubs()
+
+            attachPrimaryStorageToCluster {
+                primaryStorageUuid = ps.uuid
+                clusterUuid = cluster.uuid
+            }
+
+            testLegacyImageRejectedWhenOnlyVhostPsCandidate()
+            testUefiImageNotRejectedByLegacyBootFilter()
+
+            detachPrimaryStorageFromCluster {
+                primaryStorageUuid = ps.uuid
+                clusterUuid = cluster.uuid
+            }
+        }
+    }
+
+    void testLegacyImageRejectedWhenOnlyVhostPsCandidate() {
+        setImageBootMode(image.uuid, "Legacy")
+
+        CreateVmInstanceAction action = new CreateVmInstanceAction()
+        action.name = "legacy-vm"
+        action.instanceOfferingUuid = instanceOffering.uuid
+        action.imageUuid = image.uuid
+        action.l3NetworkUuids = [l3.uuid]
+        action.primaryStorageUuidForRootVolume = ps.uuid
+        action.sessionId = adminSession()
+
+        CreateVmInstanceAction.Result result = action.call()
+        assert result.error != null : "Legacy image with only a ZBS-vhost candidate PS must fail at allocate stage"
+        assert JSONObjectUtil.toJsonString(result.error).contains(ORG_ZSTACK_STORAGE_PRIMARY_10035) :
+                "Legacy vm should be rejected by the primary storage feature allocator, actual: ${JSONObjectUtil.toJsonString(result.error)}"
+    }
+
+    void testUefiImageNotRejectedByLegacyBootFilter() {
+        setImageBootMode(image.uuid, "UEFI")
+
+        CreateVmInstanceAction action = new CreateVmInstanceAction()
+        action.name = "uefi-vm"
+        action.instanceOfferingUuid = instanceOffering.uuid
+        action.imageUuid = image.uuid
+        action.l3NetworkUuids = [l3.uuid]
+        action.primaryStorageUuidForRootVolume = ps.uuid
+        action.sessionId = adminSession()
+
+        CreateVmInstanceAction.Result result = action.call()
+        assert result.error == null ||
+                !JSONObjectUtil.toJsonString(result.error).contains("returns zero primary storage candidate") :
+                "UEFI image must not be rejected by the legacy boot allocator filter"
+    }
+
+    void setImageBootMode(String imageUuid, String bootMode) {
+        def existing = querySystemTag {
+            conditions = ["resourceUuid=${imageUuid}".toString(), "tag~=bootMode::%"]
+        } as List<SystemTagInventory>
+
+        if (existing.isEmpty()) {
+            createSystemTag {
+                resourceUuid = imageUuid
+                resourceType = ImageVO.getSimpleName()
+                tag = "bootMode::${bootMode}".toString()
+            }
+        } else {
+            updateSystemTag {
+                uuid = existing.get(0).uuid
+                tag = "bootMode::${bootMode}".toString()
+            }
+        }
+    }
+
+    void registerBaseStubs() {
+        env.message(UploadImageToRemoteTargetMsg.class) { UploadImageToRemoteTargetMsg msg, CloudBus b ->
+            b.reply(msg, new UploadImageToRemoteTargetReply())
+        }
+
+        env.afterSimulator(ZbsStorageController.CREATE_VOLUME_PATH) { rsp, HttpEntity<String> e ->
+            def cmd = JSONObjectUtil.toObject(e.body, ZbsStorageController.CreateVolumeCmd)
+            if (cmd.volume == ZbsConstants.ZBS_HEARTBEAT_VOLUME_NAME) {
+                def vrsp = new ZbsStorageController.CreateVolumeRsp()
+                vrsp.installPath = "zbs://${cmd.logicalPool}/${cmd.volume}".toString()
+                return vrsp
+            }
+            return rsp
+        }
+    }
+}

--- a/test/src/test/groovy/org/zstack/test/integration/storage/primary/addon/zbs/ZbsVhostVolumeCase.groovy
+++ b/test/src/test/groovy/org/zstack/test/integration/storage/primary/addon/zbs/ZbsVhostVolumeCase.groovy
@@ -422,6 +422,12 @@ class ZbsVhostVolumeCase extends SubCase {
             return rsp
         }
 
+        createSystemTag {
+            resourceUuid = image.uuid
+            resourceType = org.zstack.header.image.ImageVO.getSimpleName()
+            tag = "bootMode::UEFI"
+        }
+
         VmInstanceInventory vm = createVmInstance {
             name = "vhost-vm"
             instanceOfferingUuid = instanceOffering.uuid

--- a/testlib/src/main/java/org/zstack/testlib/ExternalPrimaryStorageSpec.groovy
+++ b/testlib/src/main/java/org/zstack/testlib/ExternalPrimaryStorageSpec.groovy
@@ -91,6 +91,28 @@ class ExternalPrimaryStorageSpec extends PrimaryStorageSpec {
                 return rsp
             }
 
+            simulator(ZbsStorageController.PREPARE_VHOST_TARGET_ENV_PATH) { HttpEntity<String> e, EnvSpec spec ->
+                def rsp = new ZbsStorageController.AgentResponse()
+                rsp.success = true
+
+                return rsp
+            }
+
+            simulator(ZbsStorageController.DEPLOY_VHOST_PATH) { HttpEntity<String> e, EnvSpec spec ->
+                def rsp = new ZbsStorageController.AgentResponse()
+                rsp.success = true
+
+                return rsp
+            }
+
+            simulator(ZbsStorageController.VHOST_TARGET_HEALTH_PATH) { HttpEntity<String> e, EnvSpec spec ->
+                def rsp = new ZbsStorageController.VhostTargetHealthRsp()
+                rsp.success = true
+                rsp.targetRunning = true
+
+                return rsp
+            }
+
             simulator(ZbsStorageController.GET_FACTS_PATH) { HttpEntity<String> e, EnvSpec spec ->
                 ZbsStorageController.GetFactsCmd cmd = JSONObjectUtil.toObject(e.body, ZbsStorageController.GetFactsCmd.class)
                 ExternalPrimaryStorageSpec zspec = spec.specByUuid(cmd.uuid)


### PR DESCRIPTION
## 问题（ZSTAC-86547）

用 ZBS-vhost 根盘创建的 VM 状态 Running，但 SeaBIOS 报 `No bootable device`。根因：ZBS-vhost 的 bdev 暴露 **4096 字节 logical block size**（vhost-user-blk 绕过 qemu block layer，guest 直接看到 4096 扇区；CBD 走 block layer 有 512e 转换故不受影响）。传统 512-sector BIOS/MBR（Legacy，非 UEFI）镜像在 logical=4096 下无法引导。

## 修复方案（分层架构）

复用已有 `requiredFeatures` 分配管线（与 `SHARED_VOLUME` 同构）：

1. **storage capability**：`StorageCapabilities.minLogicalSectorSize` 单一定值（默认 512）；ZBS controller 静态上报 4096（存储固有属性，与协议无关）。
2. **feature 声明**：新增 `PrimaryStorageFeature.LEGACY_BOOT`。allocate ps 的 handle（`PrimaryStorageManagerImpl.buildAllocateSpecFromMsg`）从 msg 的 `volumeProtocol::` systemtag 解析 required protocol 存入 spec。
3. **allocator 过滤**：`ExternalPrimaryStorageFactory` 在 `LEGACY_BOOT` required 时，过滤掉「协议为 Vhost（透传裸扇区）且 minLogicalSectorSize > 512」的候选。required protocol 为 null 时兜底用候选 PS 的 defaultProtocol（一次批量查建 map，无 N+1）。Legacy 镜像由 `VmAllocatePrimaryStorageFlow` 检测 bootMode 后置 feature。

## 测试

- 新增 `ZbsVhostLegacyBootAllocateCase`：Legacy 镜像被拒（10035）、UEFI 放行。声明式 attach PS 到 cluster 让 teardown 自动 detach。
- 回归 `ZbsVhostVolumeCase`：vhost 根盘 VM 改用 UEFI 镜像。

## 关联

- premium MR: zstackio/premium !14677（`fix/ZSTAC-86547@@2`，修 `ZbsPrimaryStorageVhostHaCase` 同类回归）
- `@@2` 跨仓关联构建

Resolves: ZSTAC-86547

sync from gitlab !10487