### PR TITLE
<fix>[virtualRouterProvider]: ZSTAC-86737 exclude owner-empty SLB VIP

### DIFF
--- a/plugin/virtualRouterProvider/src/main/java/org/zstack/network/service/virtualrouter/VirtualRouterManagerImpl.java
+++ b/plugin/virtualRouterProvider/src/main/java/org/zstack/network/service/virtualrouter/VirtualRouterManagerImpl.java
@@ -2643,11 +2643,18 @@ public class VirtualRouterManagerImpl extends AbstractService implements Virtual
     public List<String> getVirtualRouterVips(String vrUuid, List<String> vipUuids) {
         List<String> ret = new ArrayList<>();
         String peerUuid = haBackend.getVirtualRouterPeerUuid(vrUuid);
+        Set<String> slbVipUuids = vipUuids.isEmpty() ? Collections.emptySet() : new HashSet<>(Q.New(VipVO.class)
+                .in(VipVO_.uuid, vipUuids)
+                .eq(VipVO_.serviceProvider, APPLIANCE_VM_TYPE_SLB)
+                .select(VipVO_.uuid)
+                .listValues());
 
         for (String uuid : vipUuids) {
             List<String> vrUuids = vipProxy.getVrUuidsByNetworkService(VipVO.class.getSimpleName(), uuid);
             if (vrUuids == null || vrUuids.isEmpty()) {
-                ret.add(uuid);
+                if (!slbVipUuids.contains(uuid)) {
+                    ret.add(uuid);
+                }
                 continue;
             }
 


### PR DESCRIPTION
## Summary
Prevent serviceProvider=SLB VIPs with no SLB instance owner from falling back to the current VPC Router.

## Changes
- Batch identify SLB VIP candidates in getVirtualRouterVips().
- Exclude owner-empty SLB VIPs from the generic current-router fallback.
- Preserve non-SLB fallback and valid SLB owner matching.

## Testing
- zstack full build: 56/56 BUILD SUCCESS
- premium full build: 86/86 BUILD SUCCESS
- SlbVipWithoutInstanceCase: RED -> GREEN
- SlbVipAfterInstanceDestroyedCase: RED -> GREEN
- SlbVipWithoutInstanceVpcHaCase: RED -> GREEN
- TestVfVmMigratationCase guest VF path: RED -> GREEN

Related premium test MR: http://dev.zstack.io:9080/zstackio/premium/-/merge_requests/14715

Resolves: ZSTAC-86737

sync from gitlab !10525