### PR TITLE
<fix>[ha]: ZSTAC-84992 direct-pick HA pre-fence core to 5.4.12 (@@3)

### DIFF
--- a/compute/src/main/java/org/zstack/compute/vm/VmInstanceBase.java
+++ b/compute/src/main/java/org/zstack/compute/vm/VmInstanceBase.java
@@ -8985,4 +8985,3 @@ public class VmInstanceBase extends AbstractVmInstance {
         });
     }
 }
-

--- a/compute/src/main/java/org/zstack/compute/vm/VmInstanceBase.java
+++ b/compute/src/main/java/org/zstack/compute/vm/VmInstanceBase.java
@@ -1005,18 +1005,38 @@ public class VmInstanceBase extends AbstractVmInstance {
 
                         logger.debug(String.format("HaStartVmJudger[%s] says the VM[uuid:%s, name:%s] is qualified for HA start, now we are starting it",
                                 judger.getClass(), self.getUuid(), self.getName()));
+                        String hostUuid = self.getHostUuid();
+                        String suspectHostUuid = StringUtils.trimToNull(hostUuid);
+                        String peerHostUuid = StringUtils.trimToNull(msg.getAccessiblePeerHostUuid());
                         UpdateQuery sql = SQL.New(VmInstanceVO.class)
                                 .eq(VmInstanceVO_.uuid, self.getUuid())
                                 .set(VmInstanceVO_.state, VmInstanceState.Stopped)
                                 .set(VmInstanceVO_.hostUuid, null);
 
-                        if (self.getHostUuid() != null) {
-                            sql.set(VmInstanceVO_.lastHostUuid, self.getHostUuid());
+                        if (hostUuid != null) {
+                            sql.set(VmInstanceVO_.lastHostUuid, hostUuid);
                         }
 
                         sql.update();
                         refreshVO();
-                        createPreFencePendingTag(msg);
+                        if (suspectHostUuid == null) {
+                            logger.debug(String.format("HA-start vm[%s]: skip creating pre-fence tag because suspect host is absent",
+                                    self.getUuid()));
+                        } else if (peerHostUuid == null) {
+                            logger.debug(String.format("HA-start vm[%s]: skip creating pre-fence tag because peer host is absent",
+                                    self.getUuid()));
+                        } else {
+                            Map<String, String> tokens = new HashMap<>();
+                            tokens.put(VmSystemTags.HA_PRE_FENCE_SUSPECT_HOST_UUID_TOKEN, suspectHostUuid);
+                            tokens.put(VmSystemTags.HA_PRE_FENCE_ACCESSIBLE_PEER_HOST_UUID_TOKEN, peerHostUuid);
+
+                            SystemTagCreator creator = VmSystemTags.HA_PRE_FENCE_PENDING.newSystemTagCreator(self.getUuid());
+                            creator.inherent = true;
+                            creator.recreate = true;
+                            creator.ignoreIfExisting = true;
+                            creator.setTagByTokens(tokens);
+                            creator.create();
+                        }
 
                         startVm(msg, new Completion(msg, chain) {
                             @Override
@@ -1045,28 +1065,6 @@ public class VmInstanceBase extends AbstractVmInstance {
                 return "ha-start-vm";
             }
         });
-    }
-
-    private void createPreFencePendingTag(HaStartVmInstanceMsg msg) {
-        String suspectHostUuid = StringUtils.trimToNull(CollectionUtils.isEmpty(msg.getSoftAvoidHostUuids()) ?
-                self.getLastHostUuid() : msg.getSoftAvoidHostUuids().get(0));
-        String peerHostUuid = StringUtils.trimToNull(msg.getAccessiblePeerHostUuid());
-        if (suspectHostUuid == null || peerHostUuid == null) {
-            logger.debug(String.format("HA-start vm[%s]: skip creating pre-fence tag because suspect host[%s] or peer host[%s] is absent",
-                    self.getUuid(), suspectHostUuid, peerHostUuid));
-            return;
-        }
-
-        Map<String, String> tokens = new HashMap<>();
-        tokens.put(VmSystemTags.HA_PRE_FENCE_SUSPECT_HOST_UUID_TOKEN, suspectHostUuid);
-        tokens.put(VmSystemTags.HA_PRE_FENCE_ACCESSIBLE_PEER_HOST_UUID_TOKEN, peerHostUuid);
-
-        SystemTagCreator creator = VmSystemTags.HA_PRE_FENCE_PENDING.newSystemTagCreator(self.getUuid());
-        creator.inherent = true;
-        creator.recreate = true;
-        creator.ignoreIfExisting = true;
-        creator.setTagByTokens(tokens);
-        creator.create();
     }
 
     private void changeVmIp(final String l3Uuid, final Map<Integer, String> staticIpMap, final Completion completion) {

--- a/compute/src/main/java/org/zstack/compute/vm/VmInstanceBase.java
+++ b/compute/src/main/java/org/zstack/compute/vm/VmInstanceBase.java
@@ -1015,6 +1015,8 @@ public class VmInstanceBase extends AbstractVmInstance {
                         }
 
                         sql.update();
+                        refreshVO();
+                        createPreFencePendingTag(msg);
 
                         startVm(msg, new Completion(msg, chain) {
                             @Override
@@ -1043,6 +1045,28 @@ public class VmInstanceBase extends AbstractVmInstance {
                 return "ha-start-vm";
             }
         });
+    }
+
+    private void createPreFencePendingTag(HaStartVmInstanceMsg msg) {
+        String suspectHostUuid = StringUtils.trimToNull(CollectionUtils.isEmpty(msg.getSoftAvoidHostUuids()) ?
+                self.getLastHostUuid() : msg.getSoftAvoidHostUuids().get(0));
+        String peerHostUuid = StringUtils.trimToNull(msg.getAccessiblePeerHostUuid());
+        if (suspectHostUuid == null || peerHostUuid == null) {
+            logger.debug(String.format("HA-start vm[%s]: skip creating pre-fence tag because suspect host[%s] or peer host[%s] is absent",
+                    self.getUuid(), suspectHostUuid, peerHostUuid));
+            return;
+        }
+
+        Map<String, String> tokens = new HashMap<>();
+        tokens.put(VmSystemTags.HA_PRE_FENCE_SUSPECT_HOST_UUID_TOKEN, suspectHostUuid);
+        tokens.put(VmSystemTags.HA_PRE_FENCE_ACCESSIBLE_PEER_HOST_UUID_TOKEN, peerHostUuid);
+
+        SystemTagCreator creator = VmSystemTags.HA_PRE_FENCE_PENDING.newSystemTagCreator(self.getUuid());
+        creator.inherent = true;
+        creator.recreate = true;
+        creator.ignoreIfExisting = true;
+        creator.setTagByTokens(tokens);
+        creator.create();
     }
 
     private void changeVmIp(final String l3Uuid, final Map<Integer, String> staticIpMap, final Completion completion) {

--- a/compute/src/main/java/org/zstack/compute/vm/VmStartOnHypervisorFlow.java
+++ b/compute/src/main/java/org/zstack/compute/vm/VmStartOnHypervisorFlow.java
@@ -5,17 +5,26 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Configurable;
 import org.zstack.core.cloudbus.CloudBus;
 import org.zstack.core.cloudbus.CloudBusCallBack;
+import org.zstack.core.asyncbatch.While;
 import org.zstack.core.componentloader.PluginRegistry;
+import org.zstack.core.workflow.FlowChainBuilder;
+import org.zstack.header.core.Completion;
+import org.zstack.header.core.WhileDoneCompletion;
 import org.zstack.header.core.workflow.Flow;
+import org.zstack.header.core.workflow.FlowChain;
+import org.zstack.header.core.workflow.FlowDoneHandler;
+import org.zstack.header.core.workflow.FlowErrorHandler;
 import org.zstack.header.core.workflow.FlowRollback;
 import org.zstack.header.core.workflow.FlowTrigger;
+import org.zstack.header.core.workflow.NoRollbackFlow;
+import org.zstack.header.errorcode.ErrorCode;
+import org.zstack.header.errorcode.ErrorCodeList;
 import org.zstack.header.host.HostConstant;
 import org.zstack.header.message.MessageReply;
 import org.zstack.header.vm.*;
 import org.zstack.utils.Utils;
 import org.zstack.utils.logging.CLogger;
 
-import java.util.List;
 import java.util.Map;
 @Configurable(preConstruction = true, autowire = Autowire.BY_TYPE)
 public class VmStartOnHypervisorFlow implements Flow {
@@ -26,34 +35,68 @@ public class VmStartOnHypervisorFlow implements Flow {
     @Autowired
     private PluginRegistry pluginRgty;
 
-    private final List<VmBeforeStartOnHypervisorExtensionPoint> exts = pluginRgty.getExtensionList(VmBeforeStartOnHypervisorExtensionPoint.class);;
-
-    private void fireExtensions(VmInstanceSpec spec) {
-        for (VmBeforeStartOnHypervisorExtensionPoint ext : exts) {
-            ext.beforeStartVmOnHypervisor(spec);
-        }
-    }
-
     @Override
     public void run(final FlowTrigger chain, final Map data) {
         final VmInstanceSpec spec = (VmInstanceSpec) data.get(VmInstanceConstant.Params.VmInstanceSpec.toString());
-
-        fireExtensions(spec);
-
-        StartVmOnHypervisorMsg msg = new StartVmOnHypervisorMsg();
-        msg.setVmSpec(spec);
-        bus.makeTargetServiceIdByResourceUuid(msg, HostConstant.SERVICE_ID, spec.getDestHost().getUuid());
-        bus.send(msg, new CloudBusCallBack(chain) {
+        FlowChain fchain = FlowChainBuilder.newSimpleFlowChain();
+        fchain.setName(String.format("vm-start-on-hypervisor-vm-%s", spec.getVmInventory().getUuid()));
+        fchain.then(new NoRollbackFlow() {
             @Override
-            public void run(MessageReply reply) {
-                if (reply.isSuccess()) {
-                    data.put(VmStartOnHypervisorFlow.class.getName(), true);
-                    chain.next();
-                } else {
-                    chain.fail(reply.getError());
-                }
+            public void run(FlowTrigger trigger, Map d) {
+                new While<>(pluginRgty.getExtensionList(VmBeforeStartOnHypervisorExtensionPoint.class))
+                        .each((ext, comp) -> ext.beforeStartVmOnHypervisor(spec, new Completion(comp) {
+                            @Override
+                            public void success() {
+                                comp.done();
+                            }
+
+                            @Override
+                            public void fail(ErrorCode errorCode) {
+                                comp.addError(errorCode);
+                                comp.done();
+                            }
+                        })).run(new WhileDoneCompletion(trigger) {
+                            @Override
+                            public void done(ErrorCodeList errorCodeList) {
+                                if (errorCodeList.getCauses().size() > 0) {
+                                    trigger.fail(errorCodeList.getCauses().get(0));
+                                } else {
+                                    trigger.next();
+                                }
+                            }
+                        });
             }
         });
+        fchain.then(new NoRollbackFlow() {
+            @Override
+            public void run(FlowTrigger trigger, Map d) {
+                StartVmOnHypervisorMsg msg = new StartVmOnHypervisorMsg();
+                msg.setVmSpec(spec);
+                bus.makeTargetServiceIdByResourceUuid(msg, HostConstant.SERVICE_ID, spec.getDestHost().getUuid());
+                bus.send(msg, new CloudBusCallBack(trigger) {
+                    @Override
+                    public void run(MessageReply reply) {
+                        if (reply.isSuccess()) {
+                            data.put(VmStartOnHypervisorFlow.class.getName(), true);
+                            trigger.next();
+                        } else {
+                            trigger.fail(reply.getError());
+                        }
+                    }
+                });
+            }
+        });
+        fchain.done(new FlowDoneHandler(chain) {
+            @Override
+            public void handle(Map d) {
+                chain.next();
+            }
+        }).error(new FlowErrorHandler(chain) {
+            @Override
+            public void handle(ErrorCode errCode, Map d) {
+                chain.fail(errCode);
+            }
+        }).start();
     }
 
     @Override

--- a/compute/src/main/java/org/zstack/compute/vm/VmSystemTags.java
+++ b/compute/src/main/java/org/zstack/compute/vm/VmSystemTags.java
@@ -309,12 +309,12 @@ public class VmSystemTags {
 
     public static PatternedSystemTag VM_STATE_PAUSED_AFTER_MIGRATE = new PatternedSystemTag(("vmPausedAfterMigrate"), VmInstanceVO.class);
 
+    public static PatternedSystemTag VM_MEMORY_ACCESS_MODE_SHARED = new PatternedSystemTag(("vmMemoryAccessModeShared"), VmInstanceVO.class);
+
     public static String HA_PRE_FENCE_SUSPECT_HOST_UUID_TOKEN = "suspectHostUuid";
     public static String HA_PRE_FENCE_ACCESSIBLE_PEER_HOST_UUID_TOKEN = "accessiblePeerHostUuid";
     public static PatternedSystemTag HA_PRE_FENCE_PENDING =
             new PatternedSystemTag(String.format("haPreFencePending::{%s}::{%s}",
                     HA_PRE_FENCE_SUSPECT_HOST_UUID_TOKEN,
                     HA_PRE_FENCE_ACCESSIBLE_PEER_HOST_UUID_TOKEN), VmInstanceVO.class);
-
-    public static PatternedSystemTag VM_MEMORY_ACCESS_MODE_SHARED = new PatternedSystemTag(("vmMemoryAccessModeShared"), VmInstanceVO.class);
 }

--- a/compute/src/main/java/org/zstack/compute/vm/VmSystemTags.java
+++ b/compute/src/main/java/org/zstack/compute/vm/VmSystemTags.java
@@ -309,5 +309,12 @@ public class VmSystemTags {
 
     public static PatternedSystemTag VM_STATE_PAUSED_AFTER_MIGRATE = new PatternedSystemTag(("vmPausedAfterMigrate"), VmInstanceVO.class);
 
+    public static String HA_PRE_FENCE_SUSPECT_HOST_UUID_TOKEN = "suspectHostUuid";
+    public static String HA_PRE_FENCE_ACCESSIBLE_PEER_HOST_UUID_TOKEN = "accessiblePeerHostUuid";
+    public static PatternedSystemTag HA_PRE_FENCE_PENDING =
+            new PatternedSystemTag(String.format("haPreFencePending::{%s}::{%s}",
+                    HA_PRE_FENCE_SUSPECT_HOST_UUID_TOKEN,
+                    HA_PRE_FENCE_ACCESSIBLE_PEER_HOST_UUID_TOKEN), VmInstanceVO.class);
+
     public static PatternedSystemTag VM_MEMORY_ACCESS_MODE_SHARED = new PatternedSystemTag(("vmMemoryAccessModeShared"), VmInstanceVO.class);
 }

--- a/header/src/main/java/org/zstack/header/vm/HaStartVmInstanceMsg.java
+++ b/header/src/main/java/org/zstack/header/vm/HaStartVmInstanceMsg.java
@@ -12,6 +12,7 @@ public class HaStartVmInstanceMsg extends NeedReplyMessage implements VmInstance
     private String vmInstanceUuid;
     private String judgerClassName;
     private List<String> softAvoidHostUuids;
+    private String accessiblePeerHostUuid;
     private String haReason;
 
     public String getJudgerClassName() {
@@ -28,6 +29,14 @@ public class HaStartVmInstanceMsg extends NeedReplyMessage implements VmInstance
 
     public void setSoftAvoidHostUuids(List<String> softAvoidHostUuids) {
         this.softAvoidHostUuids = softAvoidHostUuids;
+    }
+
+    public String getAccessiblePeerHostUuid() {
+        return accessiblePeerHostUuid;
+    }
+
+    public void setAccessiblePeerHostUuid(String accessiblePeerHostUuid) {
+        this.accessiblePeerHostUuid = accessiblePeerHostUuid;
     }
 
     @Override

--- a/header/src/main/java/org/zstack/header/vm/VmBeforeStartOnHypervisorExtensionPoint.java
+++ b/header/src/main/java/org/zstack/header/vm/VmBeforeStartOnHypervisorExtensionPoint.java
@@ -1,7 +1,14 @@
 package org.zstack.header.vm;
 
+import org.zstack.header.core.Completion;
+
 /**
  */
 public interface VmBeforeStartOnHypervisorExtensionPoint {
-    void beforeStartVmOnHypervisor(VmInstanceSpec spec);
+    default void beforeStartVmOnHypervisor(VmInstanceSpec spec) {}
+
+    default void beforeStartVmOnHypervisor(VmInstanceSpec spec, Completion completion) {
+        beforeStartVmOnHypervisor(spec);
+        completion.success();
+    }
 }


### PR DESCRIPTION
## Summary
Backport the ZSTAC-84992/ZSTAC-83890 HA pre-fence core changes to 5.4.12 by direct cherry-pick.

## Changes
- Adds core pre-fence system tag handling and peer requirement for suspect-host HA start.
- Updates VM start-on-hypervisor flow and HA start message/extension contract.

## Cherry-picked commits
- e6d9f59760 `<fix>[ha]: stabilize suspect host pre-fence flow`
- 3845ee6cfb `<fix>[ha]: create pre-fence tag in core`
- b894009119 `<fix>[ha]: require peer for pre-fence tag`

## Testing
- [x] `git diff --check upstream/5.4.12..HEAD`

Resolves: ZSTAC-84992

sync from gitlab !10528