### PR TITLE
<fix>[sugonSdn]: sync tf ports after ping

### DIFF
--- a/conf/springConfigXml/sugonSdnController.xml
+++ b/conf/springConfigXml/sugonSdnController.xml
@@ -67,11 +67,7 @@
         </zstack:plugin>
     </bean>
 
-    <bean id="TfZstackPortSync" class="org.zstack.sugonSdnController.network.TfZstackPortSync">
-        <zstack:plugin>
-            <zstack:extension interface="org.zstack.header.managementnode.ManagementNodeReadyExtensionPoint" />
-        </zstack:plugin>
-    </bean>
+    <bean id="TfZstackPortSync" class="org.zstack.sugonSdnController.network.TfZstackPortSync" />
 
     <bean id="SugonApiInterceptor" class="org.zstack.sugonSdnController.header.SugonApiInterceptor">
         <zstack:plugin>

--- a/plugin/sugonSdnController/src/main/java/org/zstack/sugonSdnController/controller/SugonSdnController.java
+++ b/plugin/sugonSdnController/src/main/java/org/zstack/sugonSdnController/controller/SugonSdnController.java
@@ -3,6 +3,7 @@ package org.zstack.sugonSdnController.controller;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.net.util.SubnetUtils;
 import org.springframework.beans.factory.annotation.Autowire;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Configurable;
 import org.zstack.core.db.Q;
 import org.zstack.header.core.Completion;
@@ -19,6 +20,7 @@ import org.zstack.sdnController.header.*;
 import org.zstack.sugonSdnController.controller.api.*;
 import org.zstack.sugonSdnController.controller.api.types.*;
 import org.zstack.sugonSdnController.header.APICreateL2TfNetworkMsg;
+import org.zstack.sugonSdnController.network.TfZstackPortSync;
 import org.zstack.utils.StringDSL;
 import org.zstack.utils.Utils;
 import org.zstack.utils.logging.CLogger;
@@ -32,6 +34,9 @@ import static org.zstack.utils.network.NetworkUtils.getSubnetInfo;
 @Configurable(preConstruction = true, autowire = Autowire.BY_TYPE)
 public class SugonSdnController implements TfSdnController, SdnController {
     private static final CLogger logger = Utils.getLogger(SugonSdnController.class);
+
+    @Autowired
+    TfZstackPortSync tfZstackPortSync;
 
     private SdnControllerVO sdnControllerVO;
 
@@ -94,6 +99,7 @@ public class SugonSdnController implements TfSdnController, SdnController {
 
     @Override
     public void postInitSdnController(APIAddSdnControllerMsg msg, Completion completion){
+        tfZstackPortSync.triggerSyncIfDue(sdnControllerVO.getUuid());
         completion.success();
     }
 

--- a/plugin/sugonSdnController/src/main/java/org/zstack/sugonSdnController/controller/neutronClient/TfPortClient.java
+++ b/plugin/sugonSdnController/src/main/java/org/zstack/sugonSdnController/controller/neutronClient/TfPortClient.java
@@ -33,6 +33,22 @@ public class TfPortClient {
         if (sdn == null){
             throw new RuntimeException("Can not find a tf sdn controller.");
         }
+        init(sdn);
+    }
+
+    public TfPortClient(String sdnControllerUuid) {
+        SdnControllerVO sdn = Q.New(SdnControllerVO.class).eq(
+                SdnControllerVO_.uuid, sdnControllerUuid).find();
+        if (sdn == null) {
+            throw new RuntimeException(String.format("Can not find a tf sdn controller[uuid:%s].", sdnControllerUuid));
+        }
+        if (!Objects.equals(sdn.getVendorType(), SdnControllerConstant.TF_CONTROLLER)) {
+            throw new RuntimeException(String.format("Sdn controller[uuid:%s] is not a tf sdn controller.", sdnControllerUuid));
+        }
+        init(sdn);
+    }
+
+    private void init(SdnControllerVO sdn) {
         client = new TfHttpClient(sdn.getIp());
         tenantId = StringDSL.transToTfUuid(sdn.getAccountUuid());
     }
@@ -510,5 +526,4 @@ public class TfPortClient {
         }
     }
 }
-
 

--- a/plugin/sugonSdnController/src/main/java/org/zstack/sugonSdnController/network/TfPortService.java
+++ b/plugin/sugonSdnController/src/main/java/org/zstack/sugonSdnController/network/TfPortService.java
@@ -32,6 +32,11 @@ public class TfPortService {
         return tfPortClient.getVirtualMachineInterfaceDetail();
     }
 
+    public List<VirtualMachineInterface> getTfPortsDetail(String sdnControllerUuid) {
+        TfPortClient tfPortClient = new TfPortClient(sdnControllerUuid);
+        return tfPortClient.getVirtualMachineInterfaceDetail();
+    }
+
     public TfPortResponse createTfPort(String tfPortUUid, String l2NetworkUuid, String l3NetworkUuid, String mac, String ip) {
         //invoke tf rest interface to retrieve real ip and mac and portId
         TfPortClient tfPortClient = new TfPortClient();
@@ -111,6 +116,12 @@ public class TfPortService {
     public TfPortResponse deleteTfPort(String portUUid) {
         String tfPortUUid = StringDSL.transToTfUuid(portUUid);
         TfPortClient tfPortClient = new TfPortClient();
+        return tfPortClient.deletePort(tfPortUUid);
+    }
+
+    public TfPortResponse deleteTfPort(String sdnControllerUuid, String portUUid) {
+        String tfPortUUid = StringDSL.transToTfUuid(portUUid);
+        TfPortClient tfPortClient = new TfPortClient(sdnControllerUuid);
         return tfPortClient.deletePort(tfPortUUid);
     }
 

--- a/plugin/sugonSdnController/src/main/java/org/zstack/sugonSdnController/network/TfZstackPortSync.java
+++ b/plugin/sugonSdnController/src/main/java/org/zstack/sugonSdnController/network/TfZstackPortSync.java
@@ -2,9 +2,8 @@ package org.zstack.sugonSdnController.network;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.zstack.core.db.Q;
-import org.zstack.core.thread.PeriodicTask;
+import org.zstack.core.thread.Task;
 import org.zstack.core.thread.ThreadFacade;
-import org.zstack.header.managementnode.ManagementNodeReadyExtensionPoint;
 import org.zstack.header.network.l2.L2NetworkVO;
 import org.zstack.header.network.l2.L2NetworkVO_;
 import org.zstack.header.vm.VmNicVO;
@@ -19,39 +18,57 @@ import org.zstack.utils.logging.CLogger;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
-import java.util.concurrent.Future;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 
-public class TfZstackPortSync implements ManagementNodeReadyExtensionPoint {
+public class TfZstackPortSync {
+    private static final long SYNC_INTERVAL_MILLIS = TimeUnit.DAYS.toMillis(1);
+    private static final int MAX_DELETE_COUNT = 10;
 
     @Autowired
     protected ThreadFacade thdf;
-    private Future<Void> trackerThread = null;
     @Autowired
     private TfPortService tfPortService;
     private final static CLogger logger = Utils.getLogger(TfZstackPortSync.class);
     private final List<String> excludeTypes = new ArrayList<String>(Arrays.asList("neutron:LOADBALANCER", "VIP", "BMS"));
+    private final Map<String, Long> lastSyncTime = new ConcurrentHashMap<>();
+    private final Set<String> runningSyncs = Collections.newSetFromMap(new ConcurrentHashMap<String, Boolean>());
 
-    @Override
-    public void managementNodeReady() {
-        if (trackerThread != null) {
-            trackerThread.cancel(true);
+    public void triggerSyncIfDue(String sdnControllerUuid) {
+        if (sdnControllerUuid == null) {
+            logger.warn("Port_Sync_Task: skip sync because sdn controller uuid is null.");
+            return;
         }
-        trackerThread = thdf.submitPeriodicTask(new SyncPort());
+
+        long now = System.currentTimeMillis();
+        Long lastSync = lastSyncTime.get(sdnControllerUuid);
+        if (lastSync != null && now - lastSync < SYNC_INTERVAL_MILLIS) {
+            return;
+        }
+        if (!runningSyncs.add(sdnControllerUuid)) {
+            return;
+        }
+
+        lastSyncTime.put(sdnControllerUuid, now);
+        try {
+            thdf.submit(new SyncPort(sdnControllerUuid));
+        } catch (RuntimeException e) {
+            lastSyncTime.remove(sdnControllerUuid);
+            runningSyncs.remove(sdnControllerUuid);
+            throw e;
+        }
     }
 
-    private class SyncPort implements PeriodicTask {
+    private class SyncPort implements Task<Void> {
+        private final String sdnControllerUuid;
 
-        @Override
-        public TimeUnit getTimeUnit() {
-            return TimeUnit.DAYS;
-        }
-
-        @Override
-        public long getInterval() {
-            return 1;
+        private SyncPort(String sdnControllerUuid) {
+            this.sdnControllerUuid = sdnControllerUuid;
         }
 
         @Override
@@ -64,7 +81,10 @@ public class TfZstackPortSync implements ManagementNodeReadyExtensionPoint {
             List<String> zstackL2NetworksUuid = Q.New(L2NetworkVO.class).select(L2NetworkVO_.uuid).listValues();
             List<String> tfPortsUuid = new ArrayList<>();
             try{
-                List<VirtualMachineInterface> tfPorts = tfPortService.getTfPortsDetail();
+                List<VirtualMachineInterface> tfPorts = tfPortService.getTfPortsDetail(sdnControllerUuid);
+                if (tfPorts == null) {
+                    return new HashSet<>();
+                }
                 for (VirtualMachineInterface vmi : tfPorts) {
                     // skip port if it's network not in zstack
                     List<ObjectReference<ApiPropertyBase>>  tfNetworks = vmi.getVirtualNetwork();
@@ -83,7 +103,7 @@ public class TfZstackPortSync implements ManagementNodeReadyExtensionPoint {
                 }
             } catch (Exception e) {
                 logger.error(String.format("Port_Sync_Task: Fetch tf VirtualMachineInterface failed: %s.", e));
-                return null;
+                return new HashSet<>();
             }
             HashSet<String> result = new HashSet<>(tfPortsUuid);
             result.removeAll(zstackPortsUuid);
@@ -92,13 +112,13 @@ public class TfZstackPortSync implements ManagementNodeReadyExtensionPoint {
         }
 
         @Override
-        public void run() {
+        public Void call() {
             logger.info("Port_Sync_Task: begin.");
             try {
                 HashSet<String> portsToDelete = getPortToDelete();
-                int maxDeleteCount = 10;
+                int maxDeleteCount = MAX_DELETE_COUNT;
                 for (String portUuid: portsToDelete) {
-                    TfPortResponse response = tfPortService.deleteTfPort(portUuid);
+                    TfPortResponse response = tfPortService.deleteTfPort(sdnControllerUuid, portUuid);
                     if (response.getCode() == 200) {
                         logger.info(String.format("Port_Sync_Task: VirtualMachineInterface: %s delete success.",
                                 portUuid));
@@ -113,7 +133,10 @@ public class TfZstackPortSync implements ManagementNodeReadyExtensionPoint {
                 }
             } catch (Exception e) {
                 logger.error(String.format("Port_Sync_Task failed: %s.", e));
+            } finally {
+                runningSyncs.remove(sdnControllerUuid);
             }
+            return null;
         }
     }
 }

--- a/test/src/test/groovy/org/zstack/test/integration/network/sdnController/SugonSdnControllerCase.groovy
+++ b/test/src/test/groovy/org/zstack/test/integration/network/sdnController/SugonSdnControllerCase.groovy
@@ -1,5 +1,6 @@
 package org.zstack.test.integration.network.sdnController
 
+import org.springframework.http.HttpEntity
 import org.zstack.core.db.DatabaseFacade
 import org.zstack.sdk.*
 import org.zstack.sugonSdnController.controller.SugonSdnControllerConstant
@@ -8,6 +9,7 @@ import org.zstack.sugonSdnController.controller.api.types.Project
 import org.zstack.sugonSdnController.controller.api.types.VirtualMachineInterface
 import org.zstack.sugonSdnController.controller.api.ApiSerializer
 import org.zstack.sugonSdnController.controller.api.TfCommands
+import org.zstack.sugonSdnController.network.TfZstackPortSync
 import org.zstack.sdnController.header.SdnControllerVO
 import org.zstack.header.network.l3.L3NetworkVO;
 import org.zstack.testlib.EnvSpec
@@ -15,6 +17,9 @@ import org.zstack.testlib.SubCase
 import javax.persistence.TypedQuery;
 import org.springframework.http.ResponseEntity
 import org.springframework.http.HttpStatus
+
+import javax.servlet.http.HttpServletRequest
+import java.util.concurrent.atomic.AtomicInteger
 
 
 class SugonSdnControllerCase extends SubCase {
@@ -37,6 +42,7 @@ class SugonSdnControllerCase extends SubCase {
     void test() {
         env.create {
             dbf = bean(DatabaseFacade.class)
+            testTfPortSyncTriggeredForController()
             testTfApi()
         }
     }
@@ -44,6 +50,44 @@ class SugonSdnControllerCase extends SubCase {
     @Override
     void clean() {
         env.delete()
+    }
+
+    void testTfPortSyncTriggeredForController() {
+        String sql = "select sdn" +
+                " from SdnControllerVO sdn" +
+                " where sdn.vendorType = :vendorType";
+        TypedQuery<SdnControllerVO> q = dbf.getEntityManager().createQuery(sql, SdnControllerVO.class);
+        q.setParameter("vendorType", SugonSdnControllerConstant.TF_CONTROLLER);
+        SdnControllerVO sdn = q.getResultList().get(0);
+        AtomicInteger syncCount = new AtomicInteger(0)
+
+        env.simulator(TfCommands.TF_CREATE_VMI) { HttpServletRequest req, HttpEntity<String> e, EnvSpec spec ->
+            if (req.method == "GET") {
+                syncCount.incrementAndGet()
+                return '{"virtual-machine-interfaces":[]}'
+            }
+
+            VirtualMachineInterface rsp = new VirtualMachineInterface();
+            rsp.name = TfCommands.TEST_VMI_UUID
+            rsp.uuid = TfCommands.TEST_VMI_UUID
+            Project project = new Project();
+            project.name = TfCommands.TEST_PROJECT_UUID
+            project.uuid = TfCommands.TEST_PROJECT_UUID
+            project.displayName = "admin";
+            rsp.setParent(project)
+            String json = ApiSerializer.serializeObject("virtual-machine-interface", rsp);
+            ResponseEntity<String> response = new ResponseEntity<String>(json, HttpStatus.OK);
+            return response.getBody()
+        }
+
+        bean(TfZstackPortSync.class).triggerSyncIfDue(sdn.uuid)
+        retryInSecs {
+            assert syncCount.get() == 1
+        }
+
+        bean(TfZstackPortSync.class).triggerSyncIfDue(sdn.uuid)
+        sleep(500)
+        assert syncCount.get() == 1
     }
 
     void testTfApi() {


### PR DESCRIPTION
Trigger TF port sync from TF controller ping success instead of MN startup. Keep the original one day interval and port cleanup algorithm, while scoping sync to the current controller.

Resolves: ZSTAC-85281

Change-Id: I84a88a34135cd47fc79b3019d2f0fc2953f06ac9

sync from gitlab !10534