### PR TITLE
ZSTAC-86507: enlarge DRS migration result column

### DIFF
--- a/conf/db/upgrade/V5.4.12__schema.sql
+++ b/conf/db/upgrade/V5.4.12__schema.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `zstack`.`DRSVmMigrationActivityVO` MODIFY COLUMN `result` TEXT DEFAULT NULL;


### PR DESCRIPTION
Backport of ZSTAC-63316 to 5.4.12.

Source: zstack!10316 (5.5.28).

Expands the DRS VM migration activity result column to TEXT.

Validation: static diff and commit checks only; no case was run per backport requirement.

sync from gitlab !10549