### PR TITLE
ZSTAC-86249: publish HA start state change

### DIFF
--- a/compute/src/main/java/org/zstack/compute/vm/VmInstanceBase.java
+++ b/compute/src/main/java/org/zstack/compute/vm/VmInstanceBase.java
@@ -326,6 +326,10 @@ public class VmInstanceBase extends AbstractVmInstance {
     }
 
     protected VmInstanceVO changeVmStateInDb(VmInstanceStateEvent stateEvent, Runnable runnable) {
+        return changeVmStateInDb(stateEvent, runnable, null);
+    }
+
+    protected VmInstanceVO changeVmStateInDb(VmInstanceStateEvent stateEvent, Runnable runnable, String stateChangeSource) {
         VmInstanceState bs = self.getState();
         final VmInstanceState state = self.getState().nextState(stateEvent);
 
@@ -374,6 +378,7 @@ public class VmInstanceBase extends AbstractVmInstance {
             data.setVmUuid(self.getUuid());
             data.setOldState(bs.toString());
             data.setNewState(state.toString());
+            data.setStateChangeSource(stateChangeSource);
             data.setInventory(getSelfInventory());
             evtf.fire(VmCanonicalEvents.VM_FULL_STATE_CHANGED_PATH, data);
 
@@ -1008,17 +1013,7 @@ public class VmInstanceBase extends AbstractVmInstance {
                         String hostUuid = self.getHostUuid();
                         String suspectHostUuid = StringUtils.trimToNull(hostUuid);
                         String peerHostUuid = StringUtils.trimToNull(msg.getAccessiblePeerHostUuid());
-                        UpdateQuery sql = SQL.New(VmInstanceVO.class)
-                                .eq(VmInstanceVO_.uuid, self.getUuid())
-                                .set(VmInstanceVO_.state, VmInstanceState.Stopped)
-                                .set(VmInstanceVO_.hostUuid, null);
-
-                        if (hostUuid != null) {
-                            sql.set(VmInstanceVO_.lastHostUuid, hostUuid);
-                        }
-
-                        sql.update();
-                        refreshVO();
+                        changeVmStateInDb(VmInstanceStateEvent.stopped, null, HaStartVmInstanceMsg.class.getName());
                         if (suspectHostUuid == null) {
                             logger.debug(String.format("HA-start vm[%s]: skip creating pre-fence tag because suspect host is absent",
                                     self.getUuid()));

--- a/header/src/main/java/org/zstack/header/vm/VmCanonicalEvents.java
+++ b/header/src/main/java/org/zstack/header/vm/VmCanonicalEvents.java
@@ -155,6 +155,7 @@ public class VmCanonicalEvents {
         private String vmUuid;
         private String oldState;
         private String newState;
+        private String stateChangeSource;
         private VmInstanceInventory inventory;
         private Date date = new Date();
 
@@ -196,6 +197,14 @@ public class VmCanonicalEvents {
 
         public void setNewState(String newState) {
             this.newState = newState;
+        }
+
+        public String getStateChangeSource() {
+            return stateChangeSource;
+        }
+
+        public void setStateChangeSource(String stateChangeSource) {
+            this.stateChangeSource = stateChangeSource;
         }
     }
 


### PR DESCRIPTION
Backport of ZSTAC-84266 to 5.4.12.

Source: zstack!9795 (5.4.8).

Publishes the VM HA start state change event used by the HA flow.

Validation: static diff and commit checks only; no case was run per backport requirement.

sync from gitlab !10552