### PR TITLE
<fix>[platformservice]: persist service VM static network

### DIFF
--- a/compute/src/main/java/org/zstack/compute/vm/VmAllocateNicFlow.java
+++ b/compute/src/main/java/org/zstack/compute/vm/VmAllocateNicFlow.java
@@ -165,8 +165,7 @@ public class VmAllocateNicFlow implements Flow {
                 protected String scripts() {
                     VmNicVO nicVO = vnicFactory.createVmNic(nic, spec);
                     if (!nw.enableIpAllocation() && nicNetworkInfoMap != null
-                            && nicNetworkInfoMap.containsKey(nw.getUuid())
-                            && spec.getVmInventory().getType().equals(VmInstanceConstant.USER_VM_TYPE)) {
+                            && nicNetworkInfoMap.containsKey(nw.getUuid())) {
                         NicIpAddressInfo nicIpAddressInfo = nicNetworkInfoMap.get(nic.getL3NetworkUuid());
                         if (!StringUtils.isEmpty(nicIpAddressInfo.ipv6Address)) {
                             UsedIpVO vo = new UsedIpVO();

--- a/sdk/src/main/java/org/zstack/sdk/platformservice/DeployPlatformServiceAction.java
+++ b/sdk/src/main/java/org/zstack/sdk/platformservice/DeployPlatformServiceAction.java
@@ -64,6 +64,9 @@ public class DeployPlatformServiceAction extends AbstractAction {
     @Param(required = false, maxLength = 255, nonempty = false, nullElements = false, emptyString = true, noTrim = false)
     public java.lang.String allocatorStrategy;
 
+    @Param(required = false, validValues = {"zh_CN","en_US"}, maxLength = 5, nonempty = false, nullElements = false, emptyString = true, noTrim = false)
+    public java.lang.String language;
+
     @Param(required = false)
     public java.util.List systemTags;
 

--- a/sdk/src/main/java/org/zstack/sdk/platformservice/DeployPlatformServiceAction.java
+++ b/sdk/src/main/java/org/zstack/sdk/platformservice/DeployPlatformServiceAction.java
@@ -47,6 +47,12 @@ public class DeployPlatformServiceAction extends AbstractAction {
     public java.lang.String staticIp;
 
     @Param(required = false, nonempty = false, nullElements = false, emptyString = true, noTrim = false)
+    public java.lang.String netmask;
+
+    @Param(required = false, nonempty = false, nullElements = false, emptyString = true, noTrim = false)
+    public java.lang.String gateway;
+
+    @Param(required = false, nonempty = false, nullElements = false, emptyString = true, noTrim = false)
     public java.lang.String clusterUuid;
 
     @Param(required = false, nonempty = false, nullElements = false, emptyString = true, noTrim = false)


### PR DESCRIPTION
Persist static network metadata for service VMs on no-IPAM L3.

Expose optional netmask and gateway fields in the generated SDK action.

Related: ZSV-12702

Change-Id: I3648fa08104fdd7b47abc934027683bf1fb0a5df

sync from gitlab !10556