### PR TITLE
<fix>[kvm]: ZSTAC-86649 reconcile missing detach target

### DIFF
--- a/plugin/kvm/src/main/java/org/zstack/kvm/KVMAgentCommands.java
+++ b/plugin/kvm/src/main/java/org/zstack/kvm/KVMAgentCommands.java
@@ -1637,6 +1637,8 @@ public class KVMAgentCommands {
         private VolumeTO volume;
         @GrayVersion(value = "5.0.0")
         private String vmInstanceUuid;
+        @GrayVersion(value = "5.5.28")
+        private List<VolumeTO> expectedVolumes;
 
         public VolumeTO getVolume() {
             return volume;
@@ -1652,6 +1654,14 @@ public class KVMAgentCommands {
 
         public void setVmUuid(String vmInstanceUuid) {
             this.vmInstanceUuid = vmInstanceUuid;
+        }
+
+        public List<VolumeTO> getExpectedVolumes() {
+            return expectedVolumes;
+        }
+
+        public void setExpectedVolumes(List<VolumeTO> expectedVolumes) {
+            this.expectedVolumes = expectedVolumes;
         }
     }
 

--- a/plugin/kvm/src/main/java/org/zstack/kvm/KVMHost.java
+++ b/plugin/kvm/src/main/java/org/zstack/kvm/KVMHost.java
@@ -3798,13 +3798,17 @@ public class KVMHost extends HostBase implements Host {
 
         final VolumeInventory vol = msg.getInventory();
         final VmInstanceInventory vm = msg.getVmInventory();
-        VolumeTO to = VolumeTO.valueOfWithOutExtension(vol, (KVMHostInventory) getSelfInventory(), vm.getPlatform());
+        KVMHostInventory host = (KVMHostInventory) getSelfInventory();
+        VolumeTO to = VolumeTO.valueOfWithOutExtension(vol, host, vm.getPlatform());
 
         final DetachVolumeFromVmOnHypervisorReply reply = new DetachVolumeFromVmOnHypervisorReply();
         final DetachDataVolumeCmd cmd = new DetachDataVolumeCmd();
         cmd.setVolume(to);
         cmd.setVmUuid(vm.getUuid());
-        extEmitter.beforeDetachVolume((KVMHostInventory) getSelfInventory(), vm, vol, cmd);
+        cmd.setExpectedVolumes(vm.getAllDiskVolumes().stream()
+                .map(volume -> VolumeTO.valueOf(volume, host, vm.getPlatform(), true))
+                .collect(Collectors.toList()));
+        extEmitter.beforeDetachVolume(host, vm, vol, cmd);
 
         new Http<>(detachDataVolumePath, cmd, DetachDataVolumeResponse.class).call(new ReturnValueCompletion<DetachDataVolumeResponse>(msg, completion) {
             @Override

--- a/test/src/test/groovy/org/zstack/test/integration/storage/volume/DetachDataVolumeCmdWithAllVmVolumesCase.groovy
+++ b/test/src/test/groovy/org/zstack/test/integration/storage/volume/DetachDataVolumeCmdWithAllVmVolumesCase.groovy
@@ -1,0 +1,97 @@
+package org.zstack.test.integration.storage.volume
+
+import org.springframework.http.HttpEntity
+import org.zstack.header.image.ImagePlatform
+import org.zstack.kvm.KVMConstant
+import org.zstack.sdk.DiskOfferingInventory
+import org.zstack.sdk.VmInstanceInventory
+import org.zstack.sdk.VolumeInventory
+import org.zstack.test.integration.storage.Env
+import org.zstack.test.integration.storage.StorageTest
+import org.zstack.testlib.EnvSpec
+import org.zstack.testlib.SubCase
+
+class DetachDataVolumeCmdWithAllVmVolumesCase extends SubCase {
+    EnvSpec env
+
+    @Override
+    void setup() {
+        useSpring(StorageTest.springSpec)
+    }
+
+    @Override
+    void environment() {
+        env = Env.localStorageOneVmWithOneDataVolumeEnv()
+    }
+
+    @Override
+    void test() {
+        env.create {
+            testDetachCommandContainsAllVmVolumes()
+        }
+    }
+
+    void testDetachCommandContainsAllVmVolumes() {
+        VmInstanceInventory vm = env.inventoryByName("vm") as VmInstanceInventory
+        vm = queryVmInstance {
+            conditions = ["uuid=${vm.uuid}"]
+        }[0] as VmInstanceInventory
+
+        VolumeInventory target = vm.allVolumes.find {
+            it.uuid != vm.rootVolumeUuid
+        } as VolumeInventory
+        assert target != null
+
+        DiskOfferingInventory diskOffering =
+                env.inventoryByName("diskOffering") as DiskOfferingInventory
+        VolumeInventory otherData = createDataVolume {
+            name = "other-data-volume"
+            diskOfferingUuid = diskOffering.uuid
+        } as VolumeInventory
+
+        attachDataVolumeToVm {
+            volumeUuid = otherData.uuid
+            vmInstanceUuid = vm.uuid
+        }
+
+        updateVmInstance {
+            uuid = vm.uuid
+            platform = ImagePlatform.Other.toString()
+        }
+
+        VmInstanceInventory vmBeforeDetach = queryVmInstance {
+            conditions = ["uuid=${vm.uuid}"]
+        }[0] as VmInstanceInventory
+
+        List<String> expectedVolumeUuids =
+                vmBeforeDetach.allVolumes.collect { it.uuid as String }.sort()
+        List<String> requiredVolumeUuids =
+                [vmBeforeDetach.rootVolumeUuid, target.uuid, otherData.uuid].sort()
+        assert expectedVolumeUuids == requiredVolumeUuids
+
+        Map detachCmd
+        env.afterSimulator(KVMConstant.KVM_DETACH_VOLUME) { rsp, HttpEntity<String> e ->
+            detachCmd = json(e.body, LinkedHashMap.class)
+            return rsp
+        }
+
+        detachDataVolumeFromVm {
+            uuid = target.uuid
+        }
+
+        assert detachCmd != null
+        assert detachCmd.volume?.volumeUuid == target.uuid
+
+        List expectedVolumes = (detachCmd.expectedVolumes ?: []) as List
+        List<String> actualExpectedVolumeUuids = expectedVolumes
+                        .collect { it.volumeUuid as String }
+                        .sort()
+        assert actualExpectedVolumeUuids == expectedVolumeUuids
+        assert expectedVolumes.every { it.useVirtio == false }
+    }
+
+    @Override
+    void clean() {
+        env.delete()
+    }
+}


### PR DESCRIPTION
## Summary
Make explicit data-volume detach carry the VM's complete expected disk snapshot so the KVM Agent can safely converge a stale MN relationship when the target disk is already absent.

## Changes
- add version-gated `expectedVolumes` to `DetachDataVolumeCmd`
- serialize root, target and other data volumes with VM platform/storage extensions
- add Groovy regression coverage for the full UUID set and `ImagePlatform.Other`

## Testing
- [x] `plugin/kvm` package
- [x] `DetachDataVolumeCmdWithAllVmVolumesCase` — 1 passed, 0 skipped
- [x] Real 5.5.28.430 E2E: missing-target reconciliation, negative missing-peer guard, Stop/Start, normal detach
- [ ] CI pipeline

## Companion MR
- zstack-utility branch: `fix/ZSTAC-86649-5.5.28@@2`

Resolves: ZSTAC-86649

sync from gitlab !10564