### PR TITLE
<fix>[portal]: ZSTAC-86502 release phantom inventory lock

### DIFF
--- a/portal/src/main/java/org/zstack/portal/managementnode/ManagementNodeManagerImpl.java
+++ b/portal/src/main/java/org/zstack/portal/managementnode/ManagementNodeManagerImpl.java
@@ -627,7 +627,13 @@ public class ManagementNodeManagerImpl extends AbstractService implements Manage
                 }
             }).start();
         } finally {
-            lock.unlock();
+            try {
+                lock.unlock();
+            } catch (Exception e) {
+                ErrorCode errCode = Platform.inerr(e.getMessage());
+                new BootErrorLog().write(errCode.toString());
+                ret.success = false;
+            }
         }
 
         if (!ret.success || !Platform.IS_RUNNING) {


### PR DESCRIPTION
## Summary
Backport zstack-side ZSTAC-80498 fix for ZSTAC-86502 to 5.4.12: handle phantom inventory lock cleanup in management node logic.

## Original Fix
- Jira: ZSTAC-80498
- MR: http://dev.zstack.io:9080/zstackio/zstack/-/merge_requests/8983
- Commit: 69cb6717b291906caf71559966623b0d3e3573c4

## Testing
- [x] `mvn compile -pl portal -am -Dmaven.test.skip=true`

Resolves: ZSTAC-86502

sync from gitlab !10576