### PR TITLE
<backport>[4.8.39][cloudbus]: support send confirm (@@2)

### DIFF
--- a/core/src/main/java/org/zstack/core/Platform.java
+++ b/core/src/main/java/org/zstack/core/Platform.java
@@ -50,6 +50,7 @@ import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
+import java.net.Inet4Address;
 import java.net.InetAddress;
 import java.net.NetworkInterface;
 import java.net.SocketException;
@@ -826,9 +827,14 @@ public class Platform {
             for (NetworkInterface iface : Collections.list(nets)) {
                 String name = iface.getName();
                 if (defaultLine.contains(name)) {
-                    InetAddress ia = iface.getInetAddresses().nextElement();
-                    ip = ia.getHostAddress();
-                    break;
+                    for (InetAddress ia : Collections.list(iface.getInetAddresses())) {
+                        ip = ia.getHostAddress();
+                        if (ia instanceof Inet4Address) {
+                            // we prefer IPv4 address
+                            ip = ia.getHostAddress();
+                            break;
+                        }
+                    }
                 }
             }
         } catch (SocketException e) {

--- a/core/src/main/java/org/zstack/core/cloudbus/CloudBus.java
+++ b/core/src/main/java/org/zstack/core/cloudbus/CloudBus.java
@@ -3,6 +3,7 @@ package org.zstack.core.cloudbus;
 import org.springframework.http.HttpEntity;
 import org.zstack.header.Component;
 import org.zstack.header.Service;
+import org.zstack.header.core.FutureCompletion;
 import org.zstack.header.errorcode.ErrorCode;
 import org.zstack.header.exception.CloudConfigureFailException;
 import org.zstack.header.message.*;
@@ -12,14 +13,19 @@ import java.util.List;
 import java.util.function.Consumer;
 
 public interface CloudBus extends Component {
-    void send(Message msg);
+    /**
+     * submit a message sending task into the queue.
+     * @return  {@link FutureCompletion} which can be used to check whether the message was successfully sent or not.
+     */
+
+    FutureCompletion send(Message msg);
     
     <T extends Message> void send(List<T> msgs);
 
     @Deprecated
     void send(APIMessage msg, Consumer<APIEvent> consumer);
 
-    void send(NeedReplyMessage msg, CloudBusCallBack callback);
+    FutureCompletion send(NeedReplyMessage msg, CloudBusCallBack callback);
 
     @Deprecated
     void send(List<? extends NeedReplyMessage> msgs, CloudBusListCallBack callBack);

--- a/core/src/main/java/org/zstack/core/cloudbus/CloudBusImpl2.java
+++ b/core/src/main/java/org/zstack/core/cloudbus/CloudBusImpl2.java
@@ -19,6 +19,7 @@ import org.zstack.core.thread.ThreadFacadeImpl.TimeoutTaskReceipt;
 import org.zstack.core.timeout.ApiTimeoutManager;
 import org.zstack.header.Constants;
 import org.zstack.header.Service;
+import org.zstack.header.core.FutureCompletion;
 import org.zstack.header.log.NoLogging;
 import org.zstack.header.apimediator.APIIsReadyToGoMsg;
 import org.zstack.header.apimediator.APIIsReadyToGoReply;
@@ -105,6 +106,11 @@ public class CloudBusImpl2 implements CloudBus, CloudBusIN, ManagementNodeChange
     private final String AMQP_PROPERTY_HEADER__COMPRESSED = "compressed";
 
     private String SERVICE_ID = makeLocalServiceId("cloudbus");
+    public static final FutureCompletion SEND_CONFIRMED = new FutureCompletion(null);
+
+    static {
+        SEND_CONFIRMED.success();
+    }
 
     public void setDEFAULT_MESSAGE_TIMEOUT(long timeout) {
         this.DEFAULT_MESSAGE_TIMEOUT = timeout;
@@ -1327,8 +1333,9 @@ public class CloudBusImpl2 implements CloudBus, CloudBusIN, ManagementNodeChange
     }
 
     @Override
-    public void send(Message msg) {
+    public FutureCompletion send(Message msg) {
         send(msg, true);
+        return SEND_CONFIRMED;
     }
 
     @Override
@@ -1358,7 +1365,7 @@ public class CloudBusImpl2 implements CloudBus, CloudBusIN, ManagementNodeChange
     }
 
     @Override
-    public void send(final NeedReplyMessage msg, final CloudBusCallBack callback) {
+    public FutureCompletion send(final NeedReplyMessage msg, final CloudBusCallBack callback) {
         evaluateMessageTimeout(msg);
 
         Envelope e = new Envelope() {
@@ -1409,6 +1416,7 @@ public class CloudBusImpl2 implements CloudBus, CloudBusIN, ManagementNodeChange
         envelopes.put(msg.getId(), e);
 
         send(msg, false);
+        return SEND_CONFIRMED;
     }
 
     private MessageReply createTimeoutReply(NeedReplyMessage m) {

--- a/core/src/main/java/org/zstack/core/cloudbus/CloudBusImpl3.java
+++ b/core/src/main/java/org/zstack/core/cloudbus/CloudBusImpl3.java
@@ -101,6 +101,7 @@ public class CloudBusImpl3 implements CloudBus, CloudBusIN {
     private final static TimeoutRestTemplate http = RESTFacade.createRestTemplate(CoreGlobalProperty.REST_FACADE_READ_TIMEOUT, CoreGlobalProperty.REST_FACADE_CONNECT_TIMEOUT);
 
     public static final String HTTP_BASE_URL = "/cloudbus";
+    public static final FutureCompletion SEND_CONFIRMED = new FutureCompletion(null);
 
     {
         if (CloudBusGlobalProperty.MESSAGE_LOG != null) {
@@ -114,6 +115,8 @@ public class CloudBusImpl3 implements CloudBus, CloudBusIN {
             CloudBusGlobalProperty.HTTP_CONTEXT_PATH = "";
             CloudBusGlobalProperty.HTTP_PORT = 8989;
         }
+
+        SEND_CONFIRMED.success();
     }
 
     public static String getManagementNodeUUIDFromServiceID(String serviceID) {
@@ -123,6 +126,12 @@ public class CloudBusImpl3 implements CloudBus, CloudBusIN {
         }
 
         return ss[0];
+    }
+
+    private FutureCompletion sendFail(ErrorCode errorCode) {
+        FutureCompletion c = new FutureCompletion(null);
+        c.fail(errorCode);
+        return c;
     }
 
     private abstract class Envelope {
@@ -250,8 +259,8 @@ public class CloudBusImpl3 implements CloudBus, CloudBusIN {
     }
 
     @Override
-    public void send(Message msg) {
-        send(msg, true);
+    public FutureCompletion send(Message msg) {
+        return send(msg, true);
     }
 
     @Override
@@ -291,11 +300,11 @@ public class CloudBusImpl3 implements CloudBus, CloudBusIN {
     }
 
     @Override
-    public void send(NeedReplyMessage msg, CloudBusCallBack callback) {
+    public FutureCompletion send(NeedReplyMessage msg, CloudBusCallBack callback) {
         evaluateMessageTimeout(msg);
         if (msg.getTimeout() <= 1) {
             callback.run(createTimeoutReply(msg));
-            return;
+            return SEND_CONFIRMED;
         }
 
         Envelope e = new Envelope() {
@@ -346,7 +355,7 @@ public class CloudBusImpl3 implements CloudBus, CloudBusIN {
 
         envelopes.put(msg.getId(), e);
         msgExts.forEach(m -> m.afterAddEnvelopes(msg.getId()));
-        send(msg, false);
+        return send(msg, false);
     }
 
     @Override
@@ -526,29 +535,36 @@ public class CloudBusImpl3 implements CloudBus, CloudBusIN {
             localSend = !CloudBusGlobalProperty.HTTP_ALWAYS && managementNodeId.equals(Platform.getManagementServerId());
         }
 
-        void send() {
+        FutureCompletion send() {
             try {
-                doSend();
+                return doSend();
             } catch (Throwable th) {
-                replyErrorIfNeeded(operr(th.getMessage()));
+                ErrorCode err = operr(th.getMessage());
+                replyErrorIfNeeded(err);
+
+                FutureCompletion c = new FutureCompletion(null);
+                c.fail(err);
+                return c;
             }
         }
 
-        private void doSend() {
+        private FutureCompletion doSend() {
             if (msg instanceof Event) {
                 eventSend();
-                return;
+                return SEND_CONFIRMED;
             }
 
             if (localSend) {
                 localSend();
+                return SEND_CONFIRMED;
             } else {
-                httpSend();
+                return httpSend();
             }
         }
 
-        private void httpSendInQueue(String ip) {
-            thdf.chainSubmit(new ChainTask(null) {
+        private FutureCompletion httpSendInQueue(String ip) {
+            FutureCompletion sendCompletion = new FutureCompletion(null);
+            thdf.chainSubmit(new ChainTask(sendCompletion) {
                 @Override
                 public String getSyncSignature() {
                     return "http-send-in-queue";
@@ -557,6 +573,7 @@ public class CloudBusImpl3 implements CloudBus, CloudBusIN {
                 @Override
                 public void run(SyncTaskChain chain) {
                     httpSend(ip);
+                    sendCompletion.success();
                     chain.next();
                 }
 
@@ -570,25 +587,29 @@ public class CloudBusImpl3 implements CloudBus, CloudBusIN {
                     return getSyncSignature();
                 }
             });
+            return sendCompletion;
         }
 
-        private void httpSend() {
+        private FutureCompletion httpSend() {
             buildSchema(msg);
+            String ip;
             try {
-                String ip = destMaker.getNodeInfo(managementNodeId).getNodeIP();
-                httpSendInQueue(ip);
+                ip = destMaker.getNodeInfo(managementNodeId).getNodeIP();
             } catch (ManagementNodeNotFoundException e) {
-                if (msg instanceof MessageReply) {
-                    if (!deadMessageManager.handleManagementNodeNotFoundError(managementNodeId, msg, () -> {
-                        String ip = destMaker.getNodeInfo(managementNodeId).getNodeIP();
-                        httpSendInQueue(ip);
-                    })) {
-                        throw e;
-                    }
+                boolean errorHandled = msg instanceof MessageReply &&
+                        deadMessageManager.handleManagementNodeNotFoundError(managementNodeId, msg, () -> {
+                            String otherIp = destMaker.getNodeInfo(managementNodeId).getNodeIP();
+                            logger.warn(String.format("resend the message[id:%s] to node[ip:%s]", msg.getId(), otherIp));
+                            httpSendInQueue(otherIp);
+                        });
+                if (errorHandled) {
+                    return SEND_CONFIRMED;
                 } else {
                     throw e;
                 }
             }
+
+            return httpSendInQueue(ip);
         }
 
         private void httpSend(String ip) {
@@ -1208,7 +1229,7 @@ public class CloudBusImpl3 implements CloudBus, CloudBusIN {
         }
     }
 
-    private void doSendAndCallExtensions(Message msg) {
+    private FutureCompletion doSendAndCallExtensions(Message msg) {
         // for unit test finding invocation chain
         MessageCommandRecorder.record(msg.getClass());
 
@@ -1223,20 +1244,20 @@ public class CloudBusImpl3 implements CloudBus, CloudBusIN {
             interceptor.beforeSendMessage(msg);
         }
 
-        doSend(msg);
+        return doSend(msg);
     }
 
-    private void doSend(Message msg) {
+    private FutureCompletion doSend(Message msg) {
         evalThreadContextToMessage(msg);
 
         if (logger.isTraceEnabled() && islogMessage(msg)) {
             logger.trace(String.format("[msg send]: %s", dumpMessage(msg)));
         }
 
-        new MessageSender(msg).send();
+        return new MessageSender(msg).send();
     }
 
-    private void send(Message msg, Boolean noNeedReply) {
+    private FutureCompletion send(Message msg, Boolean noNeedReply) {
         if (msg.getServiceId() == null) {
             throw new IllegalArgumentException(String.format("service id cannot be null: %s", msg.getClass().getName()));
         }
@@ -1252,7 +1273,7 @@ public class CloudBusImpl3 implements CloudBus, CloudBusIN {
             msg.putHeaderEntry(NO_NEED_REPLY_MSG, noNeedReply.toString());
         }
 
-        doSendAndCallExtensions(msg);
+        return doSendAndCallExtensions(msg);
     }
 
     private void restoreFromSchema(Message msg, Map raw) throws ClassNotFoundException {

--- a/core/src/main/java/org/zstack/core/thread/DispatchQueueImpl.java
+++ b/core/src/main/java/org/zstack/core/thread/DispatchQueueImpl.java
@@ -8,7 +8,6 @@ import org.zstack.core.CoreGlobalProperty;
 import org.zstack.core.debug.DebugManager;
 import org.zstack.core.debug.DebugSignalHandler;
 import org.zstack.header.Constants;
-import org.zstack.header.core.Completion;
 import org.zstack.header.core.ExceptionSafe;
 import org.zstack.header.core.ReturnValueCompletion;
 import org.zstack.header.core.progress.ChainInfo;
@@ -107,47 +106,33 @@ class DispatchQueueImpl implements DispatchQueue, DebugSignalHandler {
 
     public void beforeCleanQueuedumpThread(String signatureName) {
         String title = "\n================= Before Clean Task Queue Dump ================";
-        dumpsignatureNameThread(signatureName,title);
+        dumpSignatureNameThread(signatureName,title);
     }
 
     public void afterCleanQueuedumpThread(String signatureName) {
         String title = "\n================= After Clean Task Queue Dump ================";
-        dumpsignatureNameThread(signatureName,title);
+        dumpSignatureNameThread(signatureName,title);
     }
 
-    public void dumpsignatureNameThread(String signatureName,String title) {
+    public void dumpSignatureNameThread(String signatureName, String title) {
         StringBuilder sb = new StringBuilder();
         sb.append(title);
         sb.append("\nASYNC TASK QUEUE DUMP:");
         sb.append(String.format("\nTASK QUEUE NUMBER: %s\n", chainTasks.size()));
         List<String> asyncTasks = new ArrayList<>();
-        long now = System.currentTimeMillis();
-        synchronized (chainTasks) {
-            ChainTaskQueueWrapper w = chainTasks.get(signatureName);
-            if (w == null) {
-                sb.append(String.format("\n===== NO QUEUE SYNC SIGNATURE: %s =====", signatureName));
-                sb.append(StringUtils.join(asyncTasks, "\n"));
-                sb.append("\n================= END TASK QUEUE DUMP ==================\n");
-                _threadFacade.printThreadsAndTasks();
-                logger.debug(sb.toString());
-                return;
-            }
-            StringBuilder tb = new StringBuilder(String.format("\nQUEUE SYNC SIGNATURE: %s", signatureName));
-            tb.append(String.format("\nRUNNING TASK NUMBER: %s", w.runningQueue.size()));
-            tb.append(String.format("\nPENDING TASK NUMBER: %s", w.pendingQueue.size()));
-            tb.append(String.format("\nASYNC LEVEL: %s", w.maxThreadNum));
-            int index = 0;
-            for (Object obj : w.runningQueue) {
-                ChainFuture cf = (ChainFuture) obj;
-                tb.append(TaskInfoBuilder.buildRunningTaskInfo(cf, now, index++));
-            }
 
-            for (Object obj : w.pendingQueue) {
-                ChainFuture cf = (ChainFuture) obj;
-                tb.append(TaskInfoBuilder.buildPendingTaskInfo(cf, now, index++));
-            }
-            asyncTasks.add(tb.toString());
+        ChainTaskQueueWrapper w = chainTasks.get(signatureName);
+        if (w == null) {
+            sb.append(String.format("\n===== NO QUEUE SYNC SIGNATURE: %s =====", signatureName));
+            sb.append(StringUtils.join(asyncTasks, "\n"));
+            sb.append("\n================= END TASK QUEUE DUMP ==================\n");
+            _threadFacade.printThreadsAndTasks();
+            logger.debug(sb.toString());
+            return;
         }
+        StringBuilder tb = new StringBuilder(String.format("\nQUEUE SYNC SIGNATURE: %s", signatureName));
+        tb.append(w.getTaskQueueInfo());
+        asyncTasks.add(tb.toString());
 
         sb.append(StringUtils.join(asyncTasks, "\n"));
         sb.append("\n================= END TASK QUEUE DUMP ==================\n");
@@ -157,26 +142,12 @@ class DispatchQueueImpl implements DispatchQueue, DebugSignalHandler {
 
     @Override
     public ChainInfo getChainTaskInfo(String signature) {
-        long now = System.currentTimeMillis();
-        synchronized (chainTasks) {
-            ChainInfo info = new ChainInfo();
-            ChainTaskQueueWrapper w = chainTasks.get(signature);
-            if (w == null) {
-                return info;
-            }
-
-            int index = 0;
-            for (Object obj : w.runningQueue) {
-                ChainFuture cf = (ChainFuture) obj;
-                info.addRunningTask(TaskInfoBuilder.buildRunningTaskInfo(cf, now, index++));
-            }
-
-            for (Object obj : w.pendingQueue) {
-                ChainFuture cf = (ChainFuture) obj;
-                info.addPendingTask(TaskInfoBuilder.buildPendingTaskInfo(cf, now, index++));
-            }
-            return info;
+        ChainTaskQueueWrapper w = chainTasks.get(signature);
+        if (w == null) {
+            return new ChainInfo();
         }
+
+        return w.getChainInfo();
     }
 
     @Override
@@ -782,7 +753,7 @@ class DispatchQueueImpl implements DispatchQueue, DebugSignalHandler {
     }
 
     private class ChainTaskQueueWrapper extends AbstractTaskQueueWrapper {
-        LinkedList pendingQueue = new LinkedList();
+        final LinkedList pendingQueue = new LinkedList();
         final Map<String, AtomicInteger> subPendingMap = new ConcurrentHashMap<>();
         final LinkedList runningQueue = new LinkedList();
         AtomicInteger counter = new AtomicInteger(0);
@@ -958,28 +929,31 @@ class DispatchQueueImpl implements DispatchQueue, DebugSignalHandler {
 
         @Override
         protected String getTaskQueueInfo() {
+            return getChainInfo().toString();
+        }
+
+        protected ChainInfo getChainInfo() {
             long now = zTimer.getCurrentTimeMillis();
-            StringBuilder tb = new StringBuilder();
-            tb.append(String.format("\nRUNNING TASK NUMBER: %s", runningQueue.size()));
-            tb.append(String.format("\nPENDING TASK NUMBER: %s", pendingQueue.size()));
-            tb.append(String.format("\nASYNC LEVEL: %s", maxThreadNum));
+
+            ChainInfo info = new ChainInfo();
+            info.setMaxThreadNum(maxThreadNum);
 
             int index = 0;
             synchronized (runningQueue) {
                 for (Object obj : runningQueue) {
                     ChainFuture cf = (ChainFuture) obj;
-                    tb.append(TaskInfoBuilder.buildRunningTaskInfo(cf, now, index++));
+                    info.addRunningTask(TaskInfoBuilder.buildRunningTaskInfo(cf, now, index++));
                 }
             }
 
-            synchronized (pendingQueue) {
+            // pendingQueue is synchronized with chainTasks, do not synchronize itself
+            synchronized (chainTasks) {
                 for (Object obj : pendingQueue) {
                     ChainFuture cf = (ChainFuture) obj;
-                    tb.append(TaskInfoBuilder.buildPendingTaskInfo(cf, now, index++));
+                    info.addPendingTask(TaskInfoBuilder.buildPendingTaskInfo(cf, now, index++));
                 }
             }
-
-            return tb.toString();
+            return info;
         }
     }
 

--- a/core/src/main/java/org/zstack/core/thread/TaskInfoBuilder.java
+++ b/core/src/main/java/org/zstack/core/thread/TaskInfoBuilder.java
@@ -21,7 +21,7 @@ import java.util.concurrent.TimeUnit;
 public class TaskInfoBuilder {
     static RunningTaskInfo buildRunningTaskInfo(AbstractTimeStatisticFuture abstractTimeStatisticFuture, long now, int index) {
         RunningTaskInfo info = new RunningTaskInfo();
-        loadTaskInfo(info, abstractTimeStatisticFuture, index);
+        loadTaskInfo(info, abstractTimeStatisticFuture.getTask(), index);
         info.setExecutionTime(TimeUnit.MILLISECONDS.toSeconds(now - abstractTimeStatisticFuture.getStartExecutionTimeInMills()));
         info.setPendingTime(TimeUnit.MILLISECONDS.toSeconds(now - abstractTimeStatisticFuture.getStartPendingTimeInMills()) - info.getExecutionTime());
         return info;
@@ -29,23 +29,23 @@ public class TaskInfoBuilder {
 
     static PendingTaskInfo buildPendingTaskInfo(AbstractTimeStatisticFuture abstractTimeStatisticFuture, long now, int index) {
         PendingTaskInfo info = new PendingTaskInfo();
-        loadTaskInfo(info, abstractTimeStatisticFuture, index);
+        loadTaskInfo(info, abstractTimeStatisticFuture.getTask(), index);
         info.setPendingTime(TimeUnit.MILLISECONDS.toSeconds(now - abstractTimeStatisticFuture.getStartPendingTimeInMills()));
         return info;
     }
 
-    static private void loadTaskInfo(TaskInfo info, AbstractTimeStatisticFuture cf, int index) {
-        info.setName(cf.getTask().getName());
-        info.setClassName(cf.getTask().getClass().getSimpleName());
+    static private void loadTaskInfo(TaskInfo info, AbstractChainTask task, int index) {
+        info.setName(task.getName());
+        info.setClassName(task.getClass().getSimpleName());
         info.setIndex(index);
-        Map<String, String> tc = cf.getTask().getThreadContext();
+        Map<String, String> tc = task.getThreadContext();
         if (tc != null) {
             info.setApiName(tc.get(Constants.THREAD_CONTEXT_TASK_NAME));
             info.setApiId(tc.get(Constants.THREAD_CONTEXT_API));
         }
 
         info.setContextList(new ArrayList<>());
-        for (AsyncBackup backup : cf.getTask().getBackups()) {
+        for (AsyncBackup backup : task.getBackups()) {
             if (backup instanceof Message) {
                 info.getContextList().add(JSONObjectUtil.toJsonString(backup));
             }

--- a/core/src/main/java/org/zstack/core/thread/ThreadFacadeImpl.java
+++ b/core/src/main/java/org/zstack/core/thread/ThreadFacadeImpl.java
@@ -163,6 +163,7 @@ public class ThreadFacadeImpl implements ThreadFacade, ThreadFactory, RejectedEx
 
     @Override
     public <T> Future<T> submit(Task<T> task) {
+        _logger.trace(String.format("submit task: %s", task.getName()));
         return _pool.submit(new Worker<T>(task));
     }
 

--- a/header/src/main/java/org/zstack/header/core/progress/ChainInfo.java
+++ b/header/src/main/java/org/zstack/header/core/progress/ChainInfo.java
@@ -1,5 +1,8 @@
 package org.zstack.header.core.progress;
 
+import org.zstack.header.message.NoJsonSchema;
+import org.zstack.header.rest.APINoSee;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -9,6 +12,8 @@ import java.util.List;
 public class ChainInfo {
     private List<RunningTaskInfo> runningTask = new ArrayList<>();
     private List<PendingTaskInfo> pendingTask = new ArrayList<>();
+    @APINoSee
+    private long maxThreadNum;
 
     public void setPendingTask(List<PendingTaskInfo> pendingTask) {
         this.pendingTask = pendingTask;
@@ -32,5 +37,26 @@ public class ChainInfo {
 
     public void addPendingTask(PendingTaskInfo pendingTask) {
         this.pendingTask.add(pendingTask);
+    }
+
+    public void setMaxThreadNum(long maxThreadNum) {
+        this.maxThreadNum = maxThreadNum;
+    }
+
+    public long getMaxThreadNum() {
+        return maxThreadNum;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder tb = new StringBuilder();
+        tb.append(String.format("\nRUNNING TASK NUMBER: %s", runningTask.size()));
+        tb.append(String.format("\nPENDING TASK NUMBER: %s", pendingTask.size()));
+        tb.append(String.format("\nASYNC LEVEL: %s", maxThreadNum));
+
+        runningTask.forEach(tb::append);
+        pendingTask.forEach(tb::append);
+
+        return tb.toString();
     }
 }

--- a/portal/src/main/java/org/zstack/portal/managementnode/ManagementNodeManagerImpl.java
+++ b/portal/src/main/java/org/zstack/portal/managementnode/ManagementNodeManagerImpl.java
@@ -904,7 +904,17 @@ public class ManagementNodeManagerImpl extends AbstractService implements Manage
 
             @Override
             public Void call() {
+                logger.debug(String.format("heartbeat thread[%s] for management node[uuid:%s] started",
+                        Thread.currentThread().getName(), node().getUuid()));
                 while (true) {
+                    if (Thread.currentThread().isInterrupted()) {
+                        // the heartbeat task may be cancelled by the heartbeat interval change,
+                        // just return, don't break, otherwise it stops the management node
+                        logger.debug(String.format("heartbeat thread[%s] for management node[uuid:%s] is interrupted, exit heartbeat loop",
+                                Thread.currentThread().getName(), node().getUuid()));
+                        return null;
+                    }
+
                     try {
                         if (!amIalive()) {
                             logger.warn(String.format("cannot find my[uuid:%s] heartbeat in database, quit process", node().getUuid()));
@@ -927,23 +937,19 @@ public class ManagementNodeManagerImpl extends AbstractService implements Manage
                     }
 
                     sleepAHeartbeatInterval();
-
-                    if (heartBeatTask.isCancelled()) {
-                        // the heartbeat task may be cancelled by the heartbeat interval change,
-                        // just return, don't break, otherwise it stops the management node
-                        return null;
-                    }
                 }
 
                 stop();
                 return null;
             }
 
-            private void sleepAHeartbeatInterval() {
+            private boolean sleepAHeartbeatInterval() {
                 try {
                     TimeUnit.SECONDS.sleep(ManagementNodeGlobalConfig.NODE_HEARTBEAT_INTERVAL.value(Long.class));
+                    return true;
                 } catch (InterruptedException ignored) {
                     Thread.currentThread().interrupt();
+                    return false;
                 }
             }
 
@@ -962,6 +968,10 @@ public class ManagementNodeManagerImpl extends AbstractService implements Manage
                 int heartbeatFailureTimes = 0;
 
                 while (true) {
+                    if (Thread.currentThread().isInterrupted()) {
+                        return false;
+                    }
+
                     if (heartbeatFailureTimes > PortalGlobalProperty.MAX_HEARTBEAT_FAILURE) {
                         logger.warn(String.format("the heartbeat has failed %s times that is greater than the max allowed value[%s]," +
                                 " quit process", heartbeatFailureTimes, PortalGlobalProperty.MAX_HEARTBEAT_FAILURE), t);

--- a/test/src/test/groovy/org/zstack/test/integration/core/cloudbus/CloudBus3Case.groovy
+++ b/test/src/test/groovy/org/zstack/test/integration/core/cloudbus/CloudBus3Case.groovy
@@ -1,9 +1,14 @@
 package org.zstack.test.integration.core.cloudbus
 
+import org.zstack.core.CoreGlobalProperty
 import org.zstack.core.Platform
 import org.zstack.core.cloudbus.*
 import org.zstack.core.db.DatabaseFacade
+import org.zstack.core.thread.SyncThread
+import org.zstack.core.thread.ThreadFacade
 import org.zstack.header.AbstractService
+import org.zstack.header.core.FutureCompletion
+import org.zstack.header.core.progress.ChainInfo
 import org.zstack.header.errorcode.OperationFailureException
 import org.zstack.header.errorcode.SysErrors
 import org.zstack.header.managementnode.ManagementNodeInventory
@@ -22,6 +27,9 @@ import java.util.concurrent.TimeUnit
 import java.util.function.Consumer
 
 class CloudBus3Case extends SubCase {
+    AbstractService service
+    CloudBus bus
+
     @Override
     void clean() {
     }
@@ -222,16 +230,13 @@ class CloudBus3Case extends SubCase {
 
         def qmsg = new APIQueryVmInstanceMsg()
         qmsg.setTimeout(1L)
-        bus.makeLocalServiceId(qmsg, SERVICE_ID)
         bus.makeServiceIdByManagementNodeId(qmsg, SERVICE_ID, "some-fake-uuid")
 
         MessageReply r = bus.call(qmsg)
         assert r.error.isError(SysErrors.TIMEOUT)
 
         qmsg = new APIQueryVmInstanceMsg()
-        qmsg.setTimeout(2L)
-        bus.makeLocalServiceId(qmsg, SERVICE_ID)
-        bus.makeServiceIdByManagementNodeId(qmsg, SERVICE_ID, "some-fake-uuid")
+        bus.makeServiceIdByManagementNodeId(qmsg, SERVICE_ID, "some-fake-uuid2")
 
         expect(OperationFailureException.class) {
             bus.call(qmsg)
@@ -240,10 +245,224 @@ class CloudBus3Case extends SubCase {
         bus.unregisterService(service)
     }
 
+    void testFutureCompletionSend() {
+        CloudBus bus = bean(CloudBus.class)
+        String SERVICE_ID = "testFutureCompletionSend"
+
+        if (service == null) {
+            service = new AbstractService() {
+                @Override
+                void handleMessage(Message msg) {
+                    bus.reply(msg, new MessageReply())
+                }
+
+                @Override
+                String getId() {
+                    return bus.makeLocalServiceId(SERVICE_ID)
+                }
+
+                @Override
+                boolean start() {
+                    return true
+                }
+
+                @Override
+                boolean stop() {
+                    return true
+                }
+            }
+
+            bus.registerService(service)
+        }
+
+        StartVmInstanceMsg msg = new StartVmInstanceMsg(vmInstanceUuid: Platform.uuid)
+        bus.makeLocalServiceId(msg, SERVICE_ID)
+        FutureCompletion completion = bus.send(msg)
+        completion.await(5000L)
+        assert completion.isSuccess()
+        assert !completion.isTimeout()
+
+        MessageReply[] replyHolder = new MessageReply[1]
+        NeedReplyMessage nrMsg = new StartVmInstanceMsg(vmInstanceUuid: Platform.uuid)
+        bus.makeLocalServiceId(nrMsg, SERVICE_ID)
+        FutureCompletion completion2 = bus.send(nrMsg, new CloudBusCallBack(null) {
+            @Override
+            void run(MessageReply reply) {
+                replyHolder[0] = reply
+            }
+        })
+        completion2.await(5000L)
+        assert completion2.isSuccess()
+        assert !completion2.isTimeout()
+        retryInSecs {
+            assert replyHolder[0] != null
+            assert replyHolder[0].isSuccess()
+        }
+    }
+
+    void testFutureCompletionSendToNonExistService() {
+        CloudBus bus = bean(CloudBus.class)
+        String NON_EXIST_SERVICE_ID = "NonExistService" + Platform.uuid
+
+        StartVmInstanceMsg msg = new StartVmInstanceMsg(vmInstanceUuid: Platform.uuid)
+        bus.makeLocalServiceId(msg, NON_EXIST_SERVICE_ID)
+        FutureCompletion completion = bus.send(msg)
+        completion.await(5000L)
+        assert completion.isSuccess()
+
+
+        MessageReply[] replyHolder = new MessageReply[1]
+        NeedReplyMessage nrMsg = new StartVmInstanceMsg(vmInstanceUuid: Platform.uuid)
+        bus.makeLocalServiceId(nrMsg, NON_EXIST_SERVICE_ID)
+        FutureCompletion completion2 = bus.send(nrMsg, new CloudBusCallBack(null) {
+            @Override
+            void run(MessageReply reply) {
+                replyHolder[0] = reply
+            }
+        })
+        completion2.await(5000L)
+        assert completion2.isSuccess()
+        retryInSecs {
+            assert replyHolder[0] != null
+            assert !replyHolder[0].isSuccess()
+        }
+    }
+
+    void testFutureCompletionSendTimeout() {
+        CloudBus bus = bean(CloudBus.class)
+        String SERVICE_ID = "testFutureCompletionSendTimeout"
+
+        def service = new AbstractService() {
+            @Override
+            void handleMessage(Message msg) {
+                // Do not reply to simulate timeout
+                try {
+                    Thread.sleep(3000)
+                } catch (InterruptedException e) {
+                    e.printStackTrace()
+                }
+            }
+
+            @Override
+            String getId() {
+                return bus.makeLocalServiceId(SERVICE_ID)
+            }
+
+            @Override
+            boolean start() {
+                return true
+            }
+
+            @Override
+            boolean stop() {
+                return true
+            }
+        }
+
+        bus.registerService(service)
+
+        // test timeout (Message msg)
+        StartVmInstanceMsg msg = new StartVmInstanceMsg(vmInstanceUuid: Platform.uuid)
+        msg.setTimeout(1)
+        bus.makeLocalServiceId(msg, SERVICE_ID)
+        FutureCompletion completion = bus.send(msg)
+        completion.await(5000L)
+        assert completion.isSuccess()
+
+        MessageReply[] replyHolder = new MessageReply[1]
+        NeedReplyMessage nrMsg = new StartVmInstanceMsg(vmInstanceUuid: Platform.uuid)
+        nrMsg.setTimeout(1)
+        bus.makeLocalServiceId(nrMsg, SERVICE_ID)
+        FutureCompletion completion2 = bus.send(nrMsg, new CloudBusCallBack(null) {
+            @Override
+            void run(MessageReply reply) {
+                replyHolder[0] = reply
+            }
+        })
+        completion2.await(5000L)
+        assert completion2.isSuccess()
+        retryInSecs {
+            assert replyHolder[0] != null
+            assert !replyHolder[0].isSuccess()
+            assert replyHolder[0].error.isError(SysErrors.TIMEOUT)
+        }
+
+        bus.unregisterService(service)
+    }
+
+    void testFutureCompletionSendToMissingNode() {
+        CloudBus bus = bean(CloudBus.class)
+        String SERVICE_ID = "testFutureCompletionSendToMissingNode"
+
+        StartVmInstanceMsg msg = new StartVmInstanceMsg(vmInstanceUuid: Platform.uuid)
+        msg.setTimeout(2)
+        bus.makeServiceIdByManagementNodeId(msg, SERVICE_ID, "fake-management-node-uuid")
+        FutureCompletion completion = bus.send(msg)
+        completion.await(5000L)
+        assert !completion.isSuccess()
+
+        MessageReply[] replyHolder = new MessageReply[1]
+        NeedReplyMessage nrMsg = new StartVmInstanceMsg(vmInstanceUuid: Platform.uuid)
+        nrMsg.setTimeout(2)
+        bus.makeServiceIdByManagementNodeId(nrMsg, SERVICE_ID, "fake-management-node-uuid")
+        FutureCompletion completion2 = bus.send(nrMsg, new CloudBusCallBack(null) {
+            @Override
+            void run(MessageReply reply) {
+                replyHolder[0] = reply
+            }
+        })
+        completion2.await(5000L)
+        assert !completion2.isSuccess()
+        assert completion2.getErrorCode() != null
+
+        retryInSecs {
+            assert replyHolder[0] != null
+            assert !replyHolder[0].isSuccess()
+            // TODO
+            // assert replyHolder[0].error.isError(SysErrors.MANAGEMENT_NODE_UNAVAILABLE_ERROR)
+        }
+    }
+
+    void testSendQueue() {
+        def threads = []
+        1.upto(50) { i ->
+            Thread t = Thread.start {
+                new MessageSender().sendMsg()
+            }
+            threads << t
+        }
+
+        ThreadFacade thdf = bean(ThreadFacade.class)
+
+        ChainInfo info = thdf.getChainTaskInfo("http-send-in-queue")
+        assert info.runningTask.size() <= 1
+        sleep(100)
+        info = thdf.getChainTaskInfo("http-send-in-queue")
+        assert info.runningTask.size() <= 1
+
+        threads.each { it.join() }
+    }
+
     @Override
     void test() {
+        bus = bean(CloudBus.class)
+
         testStepSend()
         testManagementNodeGone()
         testSendToMissingNode()
+        testFutureCompletionSend()
+        testFutureCompletionSendToNonExistService()
+        testFutureCompletionSendTimeout()
+        testFutureCompletionSendToMissingNode()
+        CloudBusGlobalProperty.HTTP_ALWAYS = true
+
+        testFutureCompletionSend()
+        testFutureCompletionSendToNonExistService()
+        testFutureCompletionSendTimeout()
+        testFutureCompletionSendToMissingNode()
+
+        testSendQueue()
+        bus.unregisterService(service)
+        CloudBusGlobalProperty.HTTP_ALWAYS = false
     }
 }

--- a/test/src/test/groovy/org/zstack/test/integration/core/cloudbus/ManagementNodeNotFoundHandlerCase.groovy
+++ b/test/src/test/groovy/org/zstack/test/integration/core/cloudbus/ManagementNodeNotFoundHandlerCase.groovy
@@ -3,10 +3,12 @@ package org.zstack.test.integration.core.cloudbus
 import org.zstack.core.Platform
 import org.zstack.core.cloudbus.CloudBus
 import org.zstack.core.cloudbus.CloudBusGlobalConfig
+import org.zstack.core.cloudbus.DeadMessageManager
 import org.zstack.core.cloudbus.DeadMessageManagerImpl
 import org.zstack.core.cloudbus.EventFacade
 import org.zstack.core.db.DatabaseFacade
 import org.zstack.header.AbstractService
+import org.zstack.header.core.FutureCompletion
 import org.zstack.header.managementnode.ManagementNodeCanonicalEvent
 import org.zstack.header.managementnode.ManagementNodeInventory
 import org.zstack.header.managementnode.ManagementNodeState
@@ -22,6 +24,8 @@ import org.zstack.testlib.SubCase
 import java.util.concurrent.TimeUnit
 
 class ManagementNodeNotFoundHandlerCase extends SubCase {
+    DeadMessageManagerImpl mgr
+
     @Override
     void clean() {
     }
@@ -33,7 +37,7 @@ class ManagementNodeNotFoundHandlerCase extends SubCase {
 
     @Override
     void environment() {
-        DeadMessageManagerImpl mgr = bean(DeadMessageManagerImpl.class)
+        mgr = bean(DeadMessageManagerImpl.class)
         mgr.managementNodeNotFoundHandlers.invalidateAll()
         mgr.managementNodeNotFoundHandlers.cleanUp()
 
@@ -46,7 +50,7 @@ class ManagementNodeNotFoundHandlerCase extends SubCase {
         ManagementNodeVO vo = new ManagementNodeVO(
                 hostName: "127.0.0.10",
                 // mock a future heartbeat
-                heartBeat: new Date(System.currentTimeMillis() + TimeUnit.HOURS.toMillis(1)).toTimestamp(),
+                heartBeat: new Date(System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(5)).toTimestamp(),
                 uuid: mgmtUuid,
                 port: 8989,
                 state: ManagementNodeState.RUNNING
@@ -74,6 +78,7 @@ class ManagementNodeNotFoundHandlerCase extends SubCase {
         def secondNodeService = new AbstractService() {
             @Override
             void handleMessage(Message msg) {
+                logger.debug("received message[${msg.id}] on service[${getId()}]")
                 message = msg
             }
 
@@ -95,17 +100,18 @@ class ManagementNodeNotFoundHandlerCase extends SubCase {
 
         StartVmInstanceReply reply = new StartVmInstanceReply()
         bus.makeServiceIdByManagementNodeId(reply, secondServiceName, secondNodeUuid)
-        bus.send(reply)
+        FutureCompletion c = bus.send(reply)
 
         assert message == null
 
         bus.registerService(secondNodeService)
 
+        c.await()
+        assert !mgr.managementNodeNotFoundHandlers.asMap().values().message.contains(reply)
         Closure cleanup = mockAManagementNode(secondNodeUuid)
 
-        retryInSecs {
-            assert message == null
-        }
+        sleep(1000)
+        assert message == null
 
         cleanup()
         bus.unregisterService(secondNodeService)
@@ -120,6 +126,7 @@ class ManagementNodeNotFoundHandlerCase extends SubCase {
         def secondNodeService = new AbstractService() {
             @Override
             void handleMessage(Message msg) {
+                logger.debug("received message[${msg.id}] on service[${getId()}]")
                 message = msg
             }
 
@@ -141,17 +148,17 @@ class ManagementNodeNotFoundHandlerCase extends SubCase {
 
         StartVmInstanceMsg msg = new StartVmInstanceMsg()
         bus.makeServiceIdByManagementNodeId(msg, secondServiceName, secondNodeUuid)
-        bus.send(msg)
+        FutureCompletion c = bus.send(msg)
 
         assert message == null
 
         bus.registerService(secondNodeService)
-
+        c.await()
+        assert !mgr.managementNodeNotFoundHandlers.asMap().values().message.contains(msg)
         Closure cleanup = mockAManagementNode(secondNodeUuid)
 
-        retryInSecs {
-            assert message == null
-        }
+        sleep(1000)
+        assert message == null
 
         cleanup()
         bus.unregisterService(secondNodeService)
@@ -166,6 +173,7 @@ class ManagementNodeNotFoundHandlerCase extends SubCase {
         def secondNodeService = new AbstractService() {
             @Override
             void handleMessage(Message msg) {
+                logger.debug("received message[${msg.id}] on service[${getId()}]")
                 message = msg
             }
 
@@ -190,12 +198,15 @@ class ManagementNodeNotFoundHandlerCase extends SubCase {
 
         StartVmInstanceReply reply = new StartVmInstanceReply()
         bus.makeServiceIdByManagementNodeId(reply, secondServiceName, secondNodeUuid)
-        bus.send(reply)
+        FutureCompletion c = bus.send(reply)
 
         assert message == null
 
         bus.registerService(secondNodeService)
 
+        // send is a async operation, so we need to wait a bit
+        c.await()
+        assert mgr.managementNodeNotFoundHandlers.asMap().values().message.contains(reply)
         Closure cleanup = mockAManagementNode(secondNodeUuid)
 
         retryInSecs {

--- a/test/src/test/groovy/org/zstack/test/integration/core/cloudbus/MessageSender.java
+++ b/test/src/test/groovy/org/zstack/test/integration/core/cloudbus/MessageSender.java
@@ -1,0 +1,43 @@
+package org.zstack.test.integration.core.cloudbus;
+
+import org.zstack.core.Platform;
+import org.zstack.core.cloudbus.CloudBus;
+import org.zstack.core.thread.SyncTask;
+import org.zstack.core.thread.SyncThread;
+import org.zstack.core.thread.ThreadFacade;
+import org.zstack.header.core.FutureCompletion;
+import org.zstack.header.vm.StartVmInstanceMsg;
+
+public class MessageSender {
+
+    void sendMsg() {
+        CloudBus bus = Platform.getComponentLoader().getComponent(CloudBus.class);
+        ThreadFacade thread = Platform.getComponentLoader().getComponent(ThreadFacade.class);
+
+        thread.syncSubmit(new SyncTask<Void>() {
+            @Override
+            public Void call() throws Exception {
+                StartVmInstanceMsg msg = new StartVmInstanceMsg();
+                bus.makeLocalServiceId(msg, "testFutureCompletionSend");
+                FutureCompletion completion = bus.send(msg);
+                completion.await(5000L);
+                return null;
+            }
+
+            @Override
+            public String getName() {
+                return "MessageSender.sendMsg";
+            }
+
+            @Override
+            public int getSyncLevel() {
+                return 1;
+            }
+
+            @Override
+            public String getSyncSignature() {
+                return getName();
+            }
+        });
+    }
+}

--- a/test/src/test/groovy/org/zstack/test/integration/portal/ManagementNodeHeartbeatCase.groovy
+++ b/test/src/test/groovy/org/zstack/test/integration/portal/ManagementNodeHeartbeatCase.groovy
@@ -58,10 +58,10 @@ class ManagementNodeHeartbeatCase extends SubCase {
     }
 
     void testUnexpectedManagementNodeRecord() {
+        prepareInvalidRecords()
         ManagementNodeGlobalConfig.NODE_HEARTBEAT_INTERVAL.updateValue(1)
         PortalGlobalProperty.MAX_HEARTBEAT_FAILURE = 2
 
-        prepareInvalidRecords()
         int heartbeatFailureTimeout = ManagementNodeGlobalConfig.NODE_HEARTBEAT_INTERVAL.value(Integer.class) * PortalGlobalProperty.MAX_HEARTBEAT_FAILURE
         int heartbeatUpdateDelay = 1 * ManagementNodeGlobalConfig.NODE_HEARTBEAT_INTERVAL.value(Integer.class)
 
@@ -80,7 +80,12 @@ class ManagementNodeHeartbeatCase extends SubCase {
         assert count == 2
 
         // wait one more interval to wait 127.0.0.111 cleaned
-        sleep(TimeUnit.SECONDS.toMillis(failureInterval * 3))
+        // exceed 3s will be added in suspects
+        // next heartbeat will be clean
+        // but hb timestamp is second precision, so it will not be added until 4s.
+        // and cleaned after 5s
+        // so we need to wait more than 5s
+        sleep(TimeUnit.SECONDS.toMillis(failureInterval * 3) + 500)
         count = dbf.count(ManagementNodeVO.class)
         assert count == 1
 


### PR DESCRIPTION
## 变更说明

将 ZSTAC-86875（ZSTAC-86600 / ZSTAC-71213 的 4.8.39 回移单）回移到 4.8.39。本 MR 与 premium 同名 `@@2` 分支组成统一产品 CI。

CloudBus send 返回发送完成确认，使监控消息按实际发送过程限流；同时包含源提交中的 MN heartbeat interrupt 修复及任务链信息整理。

## Cherry-pick 来源

- 最初源提交：`af58834cb816224677b5bc2d7badd0a7a446befa`
- 4.8.38 已合入：zstack !10423
- 当前提交：`111a730521041625f0f8353f4d57189a4c662065`
- commit message、author、author date、Change-Id 与最初源提交完全一致
- stable patch-id：`124f56fb5cb15dbdcb9e825e06e861ad8510f135`（三者一致）
- 未添加 `-x`，未做版本适配或额外改动

## 验证

- 4.8.39 目标历史中无相同 Change-Id / patch-id
- `mvn -pl core,portal -am -DskipTests compile`：BUILD SUCCESS
- 隔离 Maven 仓库执行 zstack 依赖 install：BUILD SUCCESS
- premium 本地组合编译在源码编译前被 Nexus `eip-4.8.0.pom` 下载超时阻塞，将由本组 CI 验证
- 原 4.8.38 环境已有高频告警场景验证通过记录；本 MR 仍重新跑 4.8.39 CI

Resolves: ZSTAC-86875

sync from gitlab !10597