### PR TITLE
<fix>[pci-device]: ZSTAC-86456 clean duplicate mdev refs

### DIFF
--- a/conf/db/upgrade/V5.4.12__schema.sql
+++ b/conf/db/upgrade/V5.4.12__schema.sql
@@ -37,3 +37,69 @@ ALTER TABLE `GuestVmScriptExecutedRecordDetailVO`
 
 ALTER TABLE `GuestVmScriptExecutedRecordDetailVO`
     MODIFY `stderr` MEDIUMTEXT CHARACTER SET `utf8mb4` COLLATE `utf8mb4_unicode_ci`;
+
+UPDATE `zstack`.`PciDeviceMdevSpecRefVO` keepRef
+JOIN (
+    SELECT `pciDeviceUuid`, `mdevSpecUuid`, MAX(`id`) AS `keepId`, MAX(`effective`) AS `effective`
+    FROM `zstack`.`PciDeviceMdevSpecRefVO`
+    GROUP BY `pciDeviceUuid`, `mdevSpecUuid`
+) groupedRef ON keepRef.`id` = groupedRef.`keepId`
+SET keepRef.`effective` = groupedRef.`effective`;
+
+DELETE duplicateRef FROM `zstack`.`PciDeviceMdevSpecRefVO` duplicateRef
+JOIN `zstack`.`PciDeviceMdevSpecRefVO` keepRef
+  ON duplicateRef.`pciDeviceUuid` = keepRef.`pciDeviceUuid`
+ AND duplicateRef.`mdevSpecUuid` = keepRef.`mdevSpecUuid`
+ AND duplicateRef.`id` < keepRef.`id`;
+
+UPDATE `zstack`.`PciDeviceMdevSpecRefVO` ref
+JOIN (
+    SELECT activeRef.`id`
+    FROM `zstack`.`PciDeviceMdevSpecRefVO` activeRef
+    JOIN (
+        SELECT `pciDeviceUuid`
+        FROM `zstack`.`PciDeviceMdevSpecRefVO`
+        WHERE `effective` = 1
+        GROUP BY `pciDeviceUuid`
+        HAVING COUNT(*) > 1
+    ) duplicatedPci ON activeRef.`pciDeviceUuid` = duplicatedPci.`pciDeviceUuid`
+    WHERE activeRef.`effective` = 1
+      AND NOT EXISTS (
+          SELECT 1
+          FROM `zstack`.`MdevDeviceVO` mdev
+          WHERE mdev.`parentUuid` = activeRef.`pciDeviceUuid`
+            AND mdev.`mdevSpecUuid` = activeRef.`mdevSpecUuid`
+      )
+) staleRef ON ref.`id` = staleRef.`id`
+SET ref.`effective` = 0;
+
+UPDATE `zstack`.`PciDeviceMdevSpecRefVO` oldRef
+JOIN `zstack`.`PciDeviceMdevSpecRefVO` newRef
+  ON oldRef.`pciDeviceUuid` = newRef.`pciDeviceUuid`
+ AND oldRef.`effective` = 1
+ AND newRef.`effective` = 1
+ AND oldRef.`id` < newRef.`id`
+SET oldRef.`effective` = 0;
+
+DROP PROCEDURE IF EXISTS addPciDeviceMdevSpecRefUniqueKey;
+DELIMITER $$
+CREATE PROCEDURE addPciDeviceMdevSpecRefUniqueKey()
+BEGIN
+    DECLARE index_count INT DEFAULT 0;
+
+    SELECT COUNT(*) INTO index_count
+    FROM information_schema.statistics
+    WHERE table_schema = 'zstack'
+      AND table_name = 'PciDeviceMdevSpecRefVO'
+      AND index_name = 'ukPciDeviceMdevSpecRefVOPciUuidMdevSpecUuid';
+
+    IF index_count < 1 THEN
+        ALTER TABLE `zstack`.`PciDeviceMdevSpecRefVO`
+            ADD UNIQUE KEY `ukPciDeviceMdevSpecRefVOPciUuidMdevSpecUuid` (`pciDeviceUuid`, `mdevSpecUuid`);
+    END IF;
+
+    SELECT CURTIME();
+END $$
+DELIMITER ;
+CALL addPciDeviceMdevSpecRefUniqueKey();
+DROP PROCEDURE IF EXISTS addPciDeviceMdevSpecRefUniqueKey;


### PR DESCRIPTION
Jira: http://jira.zstack.io/browse/ZSTAC-86456

Backport the idempotent mdev-reference cleanup into V5.4.12__schema.sql. It removes duplicate references, resolves conflicting effective references, and adds the composite unique key.

The cleanup SQL is identical to the existing V5.5.28 migration segment, so executing V5.5.28 after a 5.4.12 upgrade remains safe.

Tested by executing the 5.4.12 cleanup followed by the V5.5.28 cleanup on MariaDB and verifying data normalization, index uniqueness, and duplicate rejection.

Paired premium MR: http://dev.zstack.io:9080/zstackio/premium/-/merge_requests/14837

Cross-repository branch: fix/5.4.12/ZSTAC-86456@@2

sync from gitlab !10600