### PR TITLE
<fix>[management-network]: fix callback endpoint selection

### DIFF
--- a/core/src/main/java/org/zstack/core/Platform.java
+++ b/core/src/main/java/org/zstack/core/Platform.java
@@ -76,6 +76,9 @@ import java.util.stream.Collectors;
 import static org.zstack.utils.CollectionDSL.e;
 import static org.zstack.utils.CollectionDSL.map;
 import static org.zstack.utils.StringDSL.ln;
+import static org.zstack.utils.clouderrorcode.CloudOperationsErrorCode.ORG_ZSTACK_CORE_PLATFORM_10003;
+import static org.zstack.utils.clouderrorcode.CloudOperationsErrorCode.ORG_ZSTACK_CORE_PLATFORM_10004;
+import static org.zstack.utils.clouderrorcode.CloudOperationsErrorCode.ORG_ZSTACK_CORE_PLATFORM_10005;
 
 public class Platform {
     private static final CLogger logger = CLoggerImpl.getLogger(Platform.class);
@@ -1056,6 +1059,78 @@ public class Platform {
             return ErrorableValue.of(getManagementServerIp());
         }
         return getManagementNodeEndpointData().selectForTarget(ManagementEndpointData.EndpointType.NODE, targetIp);
+    }
+
+    public static ErrorableValue<List<RemoteEndpoint>> resolveRemoteEndpoints(String endpoint) {
+        String normalizedEndpoint = IPv6NetworkUtils.stripHostUrlBrackets(endpoint == null ? null : endpoint.trim());
+        if (StringUtils.isBlank(normalizedEndpoint)) {
+            return ErrorableValue.ofErrorCode(argerr(ORG_ZSTACK_CORE_PLATFORM_10003,
+                    "cannot resolve an empty remote endpoint"));
+        }
+
+        if (NetworkUtils.isIpAddress(normalizedEndpoint)) {
+            return resolveRemoteEndpoints(normalizedEndpoint, Collections.singletonList(normalizedEndpoint));
+        }
+
+        try {
+            List<String> addresses = Arrays.stream(InetAddress.getAllByName(normalizedEndpoint))
+                    .map(InetAddress::getHostAddress)
+                    .collect(Collectors.toList());
+            return resolveRemoteEndpoints(normalizedEndpoint, addresses);
+        } catch (UnknownHostException e) {
+            return ErrorableValue.ofErrorCode(operr(ORG_ZSTACK_CORE_PLATFORM_10004,
+                    "cannot resolve remote endpoint[%s]: %s", normalizedEndpoint, e.getMessage()));
+        }
+    }
+
+    public static ErrorableValue<List<RemoteEndpoint>> resolveRemoteEndpoints(String endpoint, Collection<String> addresses) {
+        List<RemoteEndpoint> endpoints = new ArrayList<>();
+        ErrorCode lastError = null;
+        Set<String> uniqueAddresses = new LinkedHashSet<>();
+        if (addresses != null) {
+            for (String address : addresses) {
+                String connectIp = normalizeManagementIp(IPv6NetworkUtils.stripHostUrlBrackets(address));
+                if (!NetworkUtils.isIpAddress(connectIp) || !uniqueAddresses.add(connectIp)) {
+                    continue;
+                }
+
+                ErrorableValue<String> callbackIp = getManagementServerIp(connectIp);
+                if (callbackIp.isSuccess()) {
+                    endpoints.add(new RemoteEndpoint(connectIp, callbackIp.result));
+                } else {
+                    lastError = callbackIp.error;
+                }
+            }
+        }
+
+        if (!endpoints.isEmpty()) {
+            return ErrorableValue.of(endpoints);
+        }
+
+        if (lastError != null) {
+            return ErrorableValue.ofErrorCode(lastError);
+        }
+
+        return ErrorableValue.ofErrorCode(argerr(ORG_ZSTACK_CORE_PLATFORM_10005,
+                "remote endpoint[%s] has no valid IPv4 or IPv6 address", endpoint));
+    }
+
+    public static class RemoteEndpoint {
+        private final String connectIp;
+        private final String callbackIp;
+
+        public RemoteEndpoint(String connectIp, String callbackIp) {
+            this.connectIp = connectIp;
+            this.callbackIp = callbackIp;
+        }
+
+        public String getConnectIp() {
+            return connectIp;
+        }
+
+        public String getCallbackIp() {
+            return callbackIp;
+        }
     }
 
     public static int getManagementNodeServicePort() {

--- a/core/src/main/java/org/zstack/core/ansible/AnsibleRunner.java
+++ b/core/src/main/java/org/zstack/core/ansible/AnsibleRunner.java
@@ -390,22 +390,19 @@ public class AnsibleRunner {
 
     public void run(ReturnValueCompletion<Boolean> completion) {
         try {
+            ErrorableValue<List<Platform.RemoteEndpoint>> resolvedEndpoints = Platform.resolveRemoteEndpoints(targetIp);
+            if (!resolvedEndpoints.isSuccess()) {
+                completion.fail(resolvedEndpoints.error);
+                return;
+            }
+            Platform.RemoteEndpoint resolvedEndpoint = resolvedEndpoints.result.get(0);
+            targetIp = resolvedEndpoint.getConnectIp();
+
             String selectedManagementNodeIp = managementNodeIp;
             if (selectedManagementNodeIp == null) {
-                if (NetworkUtils.isIpAddress(targetIp)) {
-                    ErrorableValue<String> managementNodeEndpoint = Platform.getManagementServerIp(targetIp);
-                    if (!managementNodeEndpoint.isSuccess()) {
-                        completion.fail(managementNodeEndpoint.error);
-                        return;
-                    }
-                    selectedManagementNodeIp = managementNodeEndpoint.result;
-                } else {
-                    selectedManagementNodeIp = restf.getHostName();
-                }
+                selectedManagementNodeIp = resolvedEndpoint.getCallbackIp();
             }
-            if (NetworkUtils.isIpAddress(targetIp)) {
-                updateCheckersManagementNodeIp(selectedManagementNodeIp);
-            }
+            updateCheckersManagementNodeIp(selectedManagementNodeIp);
 
             if (!forceRun && !isNeedRun()) {
                 completion.success(false);

--- a/core/src/main/java/org/zstack/core/rest/RESTFacadeImpl.java
+++ b/core/src/main/java/org/zstack/core/rest/RESTFacadeImpl.java
@@ -243,11 +243,7 @@ public class RESTFacadeImpl implements RESTFacade {
     }
 
     public static ErrorableValue<String> selectCallbackUrl(String requestUrl, Map<String, String> headers, String defaultCallbackUrl, int port, String path) {
-        if (headers != null && headers.keySet().stream().anyMatch(RESTConstant.CALLBACK_URL::equalsIgnoreCase)) {
-            return ErrorableValue.of(defaultCallbackUrl);
-        }
-
-        if (CoreGlobalProperty.UNIT_TEST_ON) {
+        if (hasCallbackUrlHeader(headers) || CoreGlobalProperty.UNIT_TEST_ON) {
             return ErrorableValue.of(defaultCallbackUrl);
         }
 
@@ -256,15 +252,41 @@ public class RESTFacadeImpl implements RESTFacade {
             return ErrorableValue.of(defaultCallbackUrl);
         }
 
-        if (!NetworkUtils.isIpv4Address(host) && !IPv6NetworkUtils.isIpv6Address(host)) {
-            return ErrorableValue.of(defaultCallbackUrl);
+        ErrorableValue<Platform.RemoteEndpoint> endpoint = resolveRequestEndpoint(host);
+        if (!endpoint.isSuccess()) {
+            return ErrorableValue.ofErrorCode(endpoint.error);
         }
+        return ErrorableValue.of(buildCallbackUrl(endpoint.result.getCallbackIp(), port, path));
+    }
 
-        ErrorableValue<String> callbackIp = Platform.getManagementServerIp(host);
-        if (!callbackIp.isSuccess()) {
-            return ErrorableValue.ofErrorCode(callbackIp.error);
+    private static boolean hasCallbackUrlHeader(Map<String, String> headers) {
+        return headers != null && headers.keySet().stream().anyMatch(RESTConstant.CALLBACK_URL::equalsIgnoreCase);
+    }
+
+    private static ErrorableValue<Platform.RemoteEndpoint> resolveRequestEndpoint(String host) {
+        ErrorableValue<List<Platform.RemoteEndpoint>> endpoints = Platform.resolveRemoteEndpoints(host);
+        if (!endpoints.isSuccess()) {
+            return ErrorableValue.ofErrorCode(endpoints.error);
         }
-        return ErrorableValue.of(buildCallbackUrl(callbackIp.result, port, path));
+        return ErrorableValue.of(endpoints.result.get(0));
+    }
+
+    private static boolean isHttpsHostname(String requestUrl, String host) {
+        try {
+            return "https".equalsIgnoreCase(new URI(requestUrl).getScheme()) && !NetworkUtils.isIpAddress(host);
+        } catch (URISyntaxException e) {
+            return false;
+        }
+    }
+
+    private static String replaceRequestHost(String requestUrl, String connectIp) {
+        try {
+            URI uri = new URI(requestUrl);
+            return new URI(uri.getScheme(), uri.getUserInfo(), connectIp, uri.getPort(),
+                    uri.getPath(), uri.getQuery(), uri.getFragment()).toString();
+        } catch (URISyntaxException e) {
+            throw new CloudRuntimeException(String.format("cannot replace request host in url[%s]", requestUrl), e);
+        }
     }
 
     private static String extractRequestHost(String requestUrl) {
@@ -434,11 +456,27 @@ public class RESTFacadeImpl implements RESTFacade {
 
     @Override
     public void asyncJson(final String url, final String body, Map<String, String> headers, HttpMethod method, final AsyncRESTCallback callback, final TimeUnit unit, final long timeout) {
-        ErrorableValue<String> selectedCallbackUrl = selectCallbackUrl(url, headers, callbackUrl, port, path);
-        if (!selectedCallbackUrl.isSuccess()) {
-            callback.fail(selectedCallbackUrl.error);
-            return;
+        String selectedCallbackUrl = callbackUrl;
+        String targetUrl = url;
+        if (!hasCallbackUrlHeader(headers) && !CoreGlobalProperty.UNIT_TEST_ON) {
+            String host = extractRequestHost(url);
+            if (host != null) {
+                if (isHttpsHostname(url, host)) {
+                    callback.fail(operr(ORG_ZSTACK_CORE_REST_10016,
+                            "cannot use hostname[%s] for asynchronous HTTPS request[%s] because its resolved address cannot be pinned without changing TLS server identity",
+                            host, url));
+                    return;
+                }
+                ErrorableValue<Platform.RemoteEndpoint> endpoint = resolveRequestEndpoint(host);
+                if (!endpoint.isSuccess()) {
+                    callback.fail(endpoint.error);
+                    return;
+                }
+                selectedCallbackUrl = buildCallbackUrl(endpoint.result.getCallbackIp(), port, path);
+                targetUrl = replaceRequestHost(url, endpoint.result.getConnectIp());
+            }
         }
+        final String actualTargetUrl = targetUrl;
 
         synchronized (interceptors) {
             for (BeforeAsyncJsonPostInterceptor ic : interceptors) {
@@ -469,7 +507,7 @@ public class RESTFacadeImpl implements RESTFacade {
         HttpHeaders requestHeaders = new HttpHeaders();
         requestHeaders.setContentLength(body.length());
         requestHeaders.set(RESTConstant.TASK_UUID, taskUuid);
-        requestHeaders.set(RESTConstant.CALLBACK_URL, selectedCallbackUrl.result);
+        requestHeaders.set(RESTConstant.CALLBACK_URL, selectedCallbackUrl);
         MediaType JSON = MediaType.parseMediaType("application/json; charset=utf-8");
         requestHeaders.setContentType(JSON);
         if (headers != null) {
@@ -667,7 +705,7 @@ public class RESTFacadeImpl implements RESTFacade {
                 logger.trace(String.format("json %s [%s], %s", method.toString(), url, req));
             }
 
-            ListenableFuture<ResponseEntity<String>> f = asyncRestTemplate.exchange(url, method, req, String.class);
+            ListenableFuture<ResponseEntity<String>> f = asyncRestTemplate.exchange(actualTargetUrl, method, req, String.class);
             f.addCallback(rsp -> {}, e -> wrapper.fail(err(ORG_ZSTACK_CORE_REST_10003, SysErrors.HTTP_ERROR, e.getLocalizedMessage())));
         } catch (RestClientException e) {
             logger.warn(String.format("Unable to %s to %s: %s", method.toString(), url, e.getMessage()));

--- a/plugin/kvm/src/main/java/org/zstack/kvm/KVMHost.java
+++ b/plugin/kvm/src/main/java/org/zstack/kvm/KVMHost.java
@@ -2904,11 +2904,11 @@ public class KVMHost extends HostBase implements Host {
     }
 
     public static ErrorableValue<String> buildManagementNodeCallbackCheckCommand(String hostManagementIp, RESTFacade restf) {
-        ErrorableValue<String> callbackHost = Platform.getManagementServerIp(hostManagementIp);
-        if (!callbackHost.isSuccess()) {
-            return ErrorableValue.ofErrorCode(callbackHost.error);
+        ErrorableValue<List<Platform.RemoteEndpoint>> endpoints = Platform.resolveRemoteEndpoints(hostManagementIp);
+        if (!endpoints.isSuccess()) {
+            return ErrorableValue.ofErrorCode(endpoints.error);
         }
-        return ErrorableValue.of(buildManagementNodeCallbackCheckCommand(restf.buildCallbackUrl(callbackHost.result)));
+        return ErrorableValue.of(buildManagementNodeCallbackCheckCommand(restf.buildCallbackUrl(endpoints.result.get(0).getCallbackIp())));
     }
 
     private static String joinAgentPath(String rootPath, String path) {
@@ -5804,18 +5804,19 @@ public class KVMHost extends HostBase implements Host {
 
             @Override
             public void run(FlowTrigger trigger, Map data) {
-                ShellUtils.run(String.format("arp -d %s || true", getSelf().getManagementIp()));
+                ErrorableValue<List<Platform.RemoteEndpoint>> endpoints = Platform.resolveRemoteEndpoints(getSelf().getManagementIp());
+                if (!endpoints.isSuccess()) {
+                    throw new OperationFailureException(endpoints.error);
+                }
+                Platform.RemoteEndpoint endpoint = endpoints.result.get(0);
+                ShellUtils.run(String.format("arp -d %s || true", endpoint.getConnectIp()));
                 SshShell sshShell = new SshShell();
-                sshShell.setHostname(getSelf().getManagementIp());
+                sshShell.setHostname(endpoint.getConnectIp());
                 sshShell.setUsername(getSelf().getUsername());
                 sshShell.setPassword(getSelf().getPassword());
                 sshShell.setPort(getSelf().getPort());
                 sshShell.setWithSudo(false);
-                ErrorableValue<String> callbackHost = Platform.getManagementServerIp(getSelf().getManagementIp());
-                if (!callbackHost.isSuccess()) {
-                    throw new OperationFailureException(callbackHost.error);
-                }
-                final String cmd = buildManagementNodeCallbackCheckCommand(restf.buildCallbackUrl(callbackHost.result));
+                final String cmd = buildManagementNodeCallbackCheckCommand(restf.buildCallbackUrl(endpoint.getCallbackIp()));
                 SshResult ret = sshShell.runCommand(cmd);
                 if (ret.getStderr() != null && ret.getStderr().contains("No route to host")) {
                     // c.f. https://access.redhat.com/solutions/1120533
@@ -5833,7 +5834,7 @@ public class KVMHost extends HostBase implements Host {
                                     "please check if username/password is wrong; %s", self.getManagementIp(), getSelf().getUsername(), getSelf().getPort(), ret.getExitErrorMessage()));
                 } else if (ret.getReturnCode() != 0) {
                     throw new OperationFailureException(operr(ORG_ZSTACK_KVM_10106, "the KVM host[ip:%s] cannot access the management node's callback url. It seems" +
-                                    " that the KVM host cannot reach the management IP[%s]. %s %s", self.getManagementIp(), callbackHost.result,
+                                    " that the KVM host cannot reach the management IP[%s]. %s %s", self.getManagementIp(), endpoint.getCallbackIp(),
                             ret.getStderr(), ret.getExitErrorMessage()));
                 }
 
@@ -6069,11 +6070,14 @@ public class KVMHost extends HostBase implements Host {
 
                     @Override
                     public void run(final FlowTrigger trigger, Map data) {
-                        ErrorableValue<String> callbackIp = Platform.getManagementServerIp(getSelf().getManagementIp());
-                        if (!callbackIp.isSuccess()) {
-                            trigger.fail(callbackIp.error);
+                        ErrorableValue<List<Platform.RemoteEndpoint>> endpoints = Platform.resolveRemoteEndpoints(getSelf().getManagementIp());
+                        if (!endpoints.isSuccess()) {
+                            trigger.fail(endpoints.error);
                             return;
                         }
+                        Platform.RemoteEndpoint endpoint = endpoints.result.get(0);
+                        String hostManagementIp = endpoint.getConnectIp();
+                        String callbackIp = endpoint.getCallbackIp();
 
                         String srcPath = PathUtil.findFileOnClassPath(String.format("ansible/kvm/%s", agentPackageName), true).getAbsolutePath();
                         String destPath = String.format("/var/lib/zstack/kvm/package/%s", agentPackageName);
@@ -6081,7 +6085,7 @@ public class KVMHost extends HostBase implements Host {
                         checker.setUsername(getSelf().getUsername());
                         checker.setPassword(getSelf().getPassword());
                         checker.setSshPort(getSelf().getPort());
-                        checker.setTargetIp(getSelf().getManagementIp());
+                        checker.setTargetIp(hostManagementIp);
                         checker.addSrcDestPair(SshFileMd5Checker.ZSTACKLIB_SRC_PATH, String.format("/var/lib/zstack/kvm/package/%s", AnsibleGlobalProperty.ZSTACKLIB_PACKAGE_NAME));
                         checker.addSrcDestPair(srcPath, destPath);
 
@@ -6089,31 +6093,31 @@ public class KVMHost extends HostBase implements Host {
                         dhcpChecker.setUsername(getSelf().getUsername());
                         dhcpChecker.setPassword(getSelf().getPassword());
                         dhcpChecker.setSshPort(getSelf().getPort());
-                        dhcpChecker.setTargetIp(getSelf().getManagementIp());
+                        dhcpChecker.setTargetIp(hostManagementIp);
                         dhcpChecker.setFilePath(KVMConstant.DHCP_BIN_FILE_PATH);
 
                         SshChronyConfigChecker chronyChecker = new SshChronyConfigChecker();
-                        chronyChecker.setTargetIp(getSelf().getManagementIp());
+                        chronyChecker.setTargetIp(hostManagementIp);
                         chronyChecker.setUsername(getSelf().getUsername());
                         chronyChecker.setPassword(getSelf().getPassword());
                         chronyChecker.setSshPort(getSelf().getPort());
 
                         SshYumRepoChecker repoChecker = new SshYumRepoChecker();
-                        repoChecker.setTargetIp(getSelf().getManagementIp());
+                        repoChecker.setTargetIp(hostManagementIp);
                         repoChecker.setUsername(getSelf().getUsername());
                         repoChecker.setPassword(getSelf().getPassword());
                         repoChecker.setSshPort(getSelf().getPort());
 
                         CallBackNetworkChecker callbackChecker = new CallBackNetworkChecker();
-                        callbackChecker.setTargetIp(getSelf().getManagementIp());
+                        callbackChecker.setTargetIp(hostManagementIp);
                         callbackChecker.setUsername(getSelf().getUsername());
                         callbackChecker.setPassword(getSelf().getPassword());
                         callbackChecker.setPort(getSelf().getPort());
-                        callbackChecker.setCallbackIp(callbackIp.result);
+                        callbackChecker.setCallbackIp(callbackIp);
                         callbackChecker.setCallBackPort(CloudBusGlobalProperty.HTTP_PORT);
 
                         KvmHostConfigChecker kvmHostConfigChecker = new KvmHostConfigChecker();
-                        kvmHostConfigChecker.setTargetIp(getSelf().getManagementIp());
+                        kvmHostConfigChecker.setTargetIp(hostManagementIp);
                         kvmHostConfigChecker.setUsername(getSelf().getUsername());
                         kvmHostConfigChecker.setPassword(getSelf().getPassword());
                         kvmHostConfigChecker.setSshPort(getSelf().getPort());
@@ -6129,11 +6133,11 @@ public class KVMHost extends HostBase implements Host {
 
                         if (KVMGlobalConfig.ENABLE_HOST_TCP_CONNECTION_CHECK.value(Boolean.class)) {
                             CallBackNetworkChecker hostTcpConnectionCallbackChecker = new CallBackNetworkChecker();
-                            hostTcpConnectionCallbackChecker.setTargetIp(getSelf().getManagementIp());
+                            hostTcpConnectionCallbackChecker.setTargetIp(hostManagementIp);
                             hostTcpConnectionCallbackChecker.setUsername(getSelf().getUsername());
                             hostTcpConnectionCallbackChecker.setPassword(getSelf().getPassword());
                             hostTcpConnectionCallbackChecker.setPort(getSelf().getPort());
-                            hostTcpConnectionCallbackChecker.setCallbackIp(callbackIp.result);
+                            hostTcpConnectionCallbackChecker.setCallbackIp(callbackIp);
                             hostTcpConnectionCallbackChecker.setCallBackPort(KVMGlobalProperty.TCP_SERVER_PORT);
                             runner.installChecker(hostTcpConnectionCallbackChecker);
                         }
@@ -6145,8 +6149,8 @@ public class KVMHost extends HostBase implements Host {
                             }
                         }
                         runner.setAgentPort(KVMGlobalProperty.AGENT_PORT);
-                        runner.setTargetIp(getSelf().getManagementIp());
-                        runner.setManagementNodeIp(callbackIp.result);
+                        runner.setTargetIp(hostManagementIp);
+                        runner.setManagementNodeIp(callbackIp);
                         runner.setTargetUuid(getSelf().getUuid());
                         runner.setPlayBookName(KVMConstant.ANSIBLE_PLAYBOOK_NAME);
                         runner.setUsername(getSelf().getUsername());

--- a/test/src/test/groovy/org/zstack/test/integration/core/PlatformManagementEndpointSelectionTest.groovy
+++ b/test/src/test/groovy/org/zstack/test/integration/core/PlatformManagementEndpointSelectionTest.groovy
@@ -116,6 +116,41 @@ class PlatformManagementEndpointSelectionTest {
     }
 
     @Test
+    void testResolvedRemoteEndpointsKeepConnectionAndCallbackInTheSameAddressFamily() {
+        withUnitTestOn(false) {
+            withErrorFacade {
+                withManagementServerIpProperties([
+                        "management.server.ip" : IPV4,
+                        "management.server.ip6": IPV6,
+                ]) {
+                    def endpoints = Platform.resolveRemoteEndpoints("controller.example.com", ["2001:db8::20", "192.168.1.20"])
+
+                    assert endpoints.success
+                    assert endpoints.result*.connectIp == ["2001:db8::20", "192.168.1.20"]
+                    assert endpoints.result*.callbackIp == [IPV6, IPV4]
+                }
+            }
+        }
+    }
+
+    @Test
+    void testResolvedRemoteEndpointsSkipAddressFamiliesWithoutManagementEndpoint() {
+        withUnitTestOn(false) {
+            withErrorFacade {
+                withManagementServerIpProperties([
+                        "management.server.ip": IPV4,
+                ]) {
+                    def endpoints = Platform.resolveRemoteEndpoints("controller.example.com", ["2001:db8::20", "192.168.1.20"])
+
+                    assert endpoints.success
+                    assert endpoints.result*.connectIp == ["192.168.1.20"]
+                    assert endpoints.result*.callbackIp == [IPV4]
+                }
+            }
+        }
+    }
+
+    @Test
     void testTargetAwareGetterFailsWithoutConfiguredEndpointOutsideUnitTest() {
         withUnitTestOn(false) {
             withErrorFacade {
@@ -159,6 +194,23 @@ class PlatformManagementEndpointSelectionTest {
     }
 
     @Test
+    void testAsyncRestCallbackSelectionResolvesHostnameToMatchingManagementEndpoint() {
+        withUnitTestOn(false) {
+            withErrorFacade {
+                withManagementServerIpProperties([
+                        "management.server.ip": IPV4,
+                ]) {
+                    def callback = RESTFacadeImpl.selectCallbackUrl(
+                            "http://localhost:7070/host/ping", [:], "http://127.0.0.1:8080/zstack/asyncrest/callback", 8080, "zstack")
+
+                    assert callback.success
+                    assert callback.result == "http://${IPV4}:8080/zstack/asyncrest/callback"
+                }
+            }
+        }
+    }
+
+    @Test
     void testAsyncRestCallbackSelectionFailsBeforeInterceptors() {
         withUnitTestOn(false) {
             withErrorFacade {
@@ -187,6 +239,35 @@ class PlatformManagementEndpointSelectionTest {
                     assert interceptorCalls.get() == 0
                     assert error.get().globalErrorCode == "ORG_ZSTACK_CORE_PLATFORM_10001"
                 }
+            }
+        }
+    }
+
+    @Test
+    void testAsyncRestRejectsHttpsHostnameBeforeInterceptors() {
+        withUnitTestOn(false) {
+            withErrorFacade {
+                AtomicInteger interceptorCalls = new AtomicInteger()
+                AtomicReference error = new AtomicReference()
+                RESTFacadeImpl restf = new RESTFacadeImpl()
+                restf.installBeforeAsyncJsonPostInterceptor([
+                        beforeAsyncJsonPost: { Object... ignored -> interceptorCalls.incrementAndGet() },
+                ] as org.zstack.header.rest.BeforeAsyncJsonPostInterceptor)
+
+                restf.asyncJson("https://controller.example.com:7070/host/ping", "{}", [:], HttpMethod.POST,
+                        new AsyncRESTCallback(null) {
+                            @Override
+                            void fail(org.zstack.header.errorcode.ErrorCode errorCode) {
+                                error.set(errorCode)
+                            }
+
+                            @Override
+                            void success(HttpEntity<String> responseEntity) {
+                            }
+                        }, TimeUnit.SECONDS, 10)
+
+                assert interceptorCalls.get() == 0
+                assert error.get().globalErrorCode == "ORG_ZSTACK_CORE_REST_10016"
             }
         }
     }

--- a/test/src/test/groovy/org/zstack/test/integration/core/ansible/AnsibleRunnerTargetAwareArgumentsTest.groovy
+++ b/test/src/test/groovy/org/zstack/test/integration/core/ansible/AnsibleRunnerTargetAwareArgumentsTest.groovy
@@ -38,7 +38,7 @@ class AnsibleRunnerTargetAwareArgumentsTest {
         testTargetAwareEndpointArgumentsUseTheSelectedIpv4Node()
         testMissingFamilyFailsBeforeRunAnsibleDispatch()
         testMissingFamilyFailsBeforeChecker()
-        testHostnameKeepsConfiguredCallbackIp()
+        testHostnameUsesResolvedTargetAndMatchingCallbackIp()
     }
 
     void testTargetAwareEndpointArgumentsUseTheSelectedIpv6Node() {
@@ -149,13 +149,12 @@ class AnsibleRunnerTargetAwareArgumentsTest {
         }
     }
 
-    void testHostnameKeepsConfiguredCallbackIp() {
+    void testHostnameUsesResolvedTargetAndMatchingCallbackIp() {
         withManagementServerIpProperties([
                 "management.server.ip": IPV4,
         ]) {
             AtomicReference<Boolean> result = new AtomicReference<>()
             CallBackNetworkChecker checker = new CallBackNetworkChecker()
-            checker.callbackIp = "configured-callback-ip"
             AnsibleRunner runner = new AnsibleRunner()
             setField(runner, "restf", [
                     getBaseUrl : { String.format("http://127.0.0.1:%d", REST_PORT) },
@@ -172,7 +171,7 @@ class AnsibleRunnerTargetAwareArgumentsTest {
             try {
                 CoreGlobalProperty.UNIT_TEST_ON = true
                 runner.forceRun = true
-                runner.targetIp = "host.example.com"
+                runner.targetIp = "localhost"
                 runner.targetUuid = Platform.uuid
                 runner.playBookName = "kvm.yml"
                 runner.username = "root"
@@ -194,7 +193,7 @@ class AnsibleRunnerTargetAwareArgumentsTest {
             }
 
             assert result.get() == true
-            assert checker.callbackIp == "configured-callback-ip"
+            assert checker.callbackIp == IPV4
         }
     }
 

--- a/utils/src/main/java/org/zstack/utils/clouderrorcode/CloudOperationsErrorCode.java
+++ b/utils/src/main/java/org/zstack/utils/clouderrorcode/CloudOperationsErrorCode.java
@@ -2956,6 +2956,12 @@ public class CloudOperationsErrorCode {
 
     public static final String ORG_ZSTACK_CORE_PLATFORM_10002 = "ORG_ZSTACK_CORE_PLATFORM_10002";
 
+    public static final String ORG_ZSTACK_CORE_PLATFORM_10003 = "ORG_ZSTACK_CORE_PLATFORM_10003";
+
+    public static final String ORG_ZSTACK_CORE_PLATFORM_10004 = "ORG_ZSTACK_CORE_PLATFORM_10004";
+
+    public static final String ORG_ZSTACK_CORE_PLATFORM_10005 = "ORG_ZSTACK_CORE_PLATFORM_10005";
+
     public static final String ORG_ZSTACK_SCHEDULER_10000 = "ORG_ZSTACK_SCHEDULER_10000";
 
     public static final String ORG_ZSTACK_SCHEDULER_10001 = "ORG_ZSTACK_SCHEDULER_10001";
@@ -10707,6 +10713,8 @@ public class CloudOperationsErrorCode {
 
     public static final String ORG_ZSTACK_CORE_REST_10015 = "ORG_ZSTACK_CORE_REST_10015";
 
+    public static final String ORG_ZSTACK_CORE_REST_10016 = "ORG_ZSTACK_CORE_REST_10016";
+
     public static final String ORG_ZSTACK_LICENSE_10000 = "ORG_ZSTACK_LICENSE_10000";
 
     public static final String ORG_ZSTACK_LICENSE_10001 = "ORG_ZSTACK_LICENSE_10001";
@@ -12252,6 +12260,7 @@ public class CloudOperationsErrorCode {
     // 10052 ZNS internal change-controller endpoint is not a literal IP address
     // 10053 ZNS change-controller has no computer manager UUID
     // 10054 ZNS change-controller cluster has no same-family endpoint
+    // 10055 ZNS endpoint cannot be resolved for an asynchronous request
     public static final String ORG_ZSTACK_NETWORK_ZNS_10035 = "ORG_ZSTACK_NETWORK_ZNS_10035";
     public static final String ORG_ZSTACK_NETWORK_ZNS_10036 = "ORG_ZSTACK_NETWORK_ZNS_10036";
     public static final String ORG_ZSTACK_NETWORK_ZNS_10037 = "ORG_ZSTACK_NETWORK_ZNS_10037";
@@ -12272,6 +12281,7 @@ public class CloudOperationsErrorCode {
     public static final String ORG_ZSTACK_NETWORK_ZNS_10052 = "ORG_ZSTACK_NETWORK_ZNS_10052";
     public static final String ORG_ZSTACK_NETWORK_ZNS_10053 = "ORG_ZSTACK_NETWORK_ZNS_10053";
     public static final String ORG_ZSTACK_NETWORK_ZNS_10054 = "ORG_ZSTACK_NETWORK_ZNS_10054";
+    public static final String ORG_ZSTACK_NETWORK_ZNS_10055 = "ORG_ZSTACK_NETWORK_ZNS_10055";
 
     public static final String ORG_ZSTACK_PREMIUM_EXTERNALSERVICE_MARKETPLACE_10000 = "ORG_ZSTACK_PREMIUM_EXTERNALSERVICE_MARKETPLACE_10000";
 


### PR DESCRIPTION
Jira: ZSTAC-86635

## Changes
- Resolve a remote hostname once, then use the selected numeric address for connection and the initiating MN endpoint of the same address family for callback.
- Apply this to generic async REST, KVM callback/deployment, and Ansible.
- Reject hostname-based asynchronous HTTPS requests because replacing the hostname would change TLS SNI and certificate identity.

## Validation
- mvn install -DskipTests in utils and core
- PlatformManagementEndpointSelectionTest: 13 passed
- AnsibleRunnerTargetAwareArgumentsTest: 1 passed
- git diff --check: passed

DualStackAddKvmHostCase is blocked before the changed path by an existing StaticIpOperator startup NPE.

sync from gitlab !10628